### PR TITLE
Fix invalid types in generator

### DIFF
--- a/apps/demo/app/[...puckPath]/client.tsx
+++ b/apps/demo/app/[...puckPath]/client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Data } from "@measured/puck/types/Config";
+import { Data } from "@measured/puck";
 import { Puck } from "@measured/puck/components/Puck";
 import { Render } from "@measured/puck/components/Render";
 import { Framework } from "../Framework";

--- a/apps/demo/app/configs/antd/blocks/CardDeck.tsx
+++ b/apps/demo/app/configs/antd/blocks/CardDeck.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Card, Col, Row } from "antd";
-import { ComponentConfig } from "@measured/puck/types/Config";
+import { ComponentConfig } from "@measured/puck";
 
 export type CardDeckProps = {
   cards: { title: string; content: string }[];

--- a/apps/demo/app/configs/antd/blocks/Carousel.tsx
+++ b/apps/demo/app/configs/antd/blocks/Carousel.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Carousel as AntdCarousel } from "antd/dist/antd";
 import { Image } from "antd";
-import { ComponentConfig } from "@measured/puck/types/Config";
+import { ComponentConfig } from "@measured/puck";
 
 export type CarouselProps = {
   slides: { imageUrl: string; alt: string }[];

--- a/apps/demo/app/configs/antd/blocks/Hero.tsx
+++ b/apps/demo/app/configs/antd/blocks/Hero.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Button, Image, Space, Typography } from "antd";
-import { ComponentConfig } from "@measured/puck/types/Config";
+import { ComponentConfig } from "@measured/puck";
 
 export type HeroProps = {
   title: string;

--- a/apps/demo/app/configs/antd/blocks/Video.tsx
+++ b/apps/demo/app/configs/antd/blocks/Video.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ComponentConfig } from "@measured/puck/types/Config";
+import { ComponentConfig } from "@measured/puck";
 
 export type VideoProps = {
   autoplay: "on" | "off";

--- a/apps/demo/app/configs/antd/index.tsx
+++ b/apps/demo/app/configs/antd/index.tsx
@@ -1,4 +1,4 @@
-import { Config, Data } from "@measured/puck/types/Config";
+import { Config, Data } from "@measured/puck";
 import { CardDeck, CardDeckProps } from "./blocks/CardDeck";
 import { Carousel, CarouselProps } from "./blocks/Carousel";
 import { Hero, HeroProps } from "./blocks/Hero";

--- a/apps/demo/app/configs/custom/blocks/Blank/index.tsx
+++ b/apps/demo/app/configs/custom/blocks/Blank/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ComponentConfig } from "@measured/puck/types/Config";
+import { ComponentConfig } from "@measured/puck";
 import styles from "./styles.module.css";
 import { getClassNameFactory } from "@measured/puck/lib";
 

--- a/apps/demo/app/configs/custom/blocks/ButtonGroup/index.tsx
+++ b/apps/demo/app/configs/custom/blocks/ButtonGroup/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @next/next/no-img-element */
 import React from "react";
-import { ComponentConfig } from "@measured/puck/types/Config";
+import { ComponentConfig } from "@measured/puck";
 import styles from "./styles.module.css";
 import { getClassNameFactory } from "@measured/puck/lib";
 import { Button } from "@measured/puck/components/Button";

--- a/apps/demo/app/configs/custom/blocks/FeatureList/index.tsx
+++ b/apps/demo/app/configs/custom/blocks/FeatureList/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @next/next/no-img-element */
 import React from "react";
-import { ComponentConfig } from "@measured/puck/types/Config";
+import { ComponentConfig } from "@measured/puck";
 import styles from "./styles.module.css";
 import { getClassNameFactory } from "@measured/puck/lib";
 import { Section } from "../../components/Section";

--- a/apps/demo/app/configs/custom/blocks/Heading/index.tsx
+++ b/apps/demo/app/configs/custom/blocks/Heading/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ComponentConfig } from "@measured/puck/types/Config";
+import { ComponentConfig } from "@measured/puck";
 import { Heading as _Heading } from "@measured/puck/components/Heading";
 import type { HeadingProps as _HeadingProps } from "@measured/puck/components/Heading";
 import { Section } from "../../components/Section";

--- a/apps/demo/app/configs/custom/blocks/Hero/index.tsx
+++ b/apps/demo/app/configs/custom/blocks/Hero/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @next/next/no-img-element */
 import React from "react";
-import { ComponentConfig } from "@measured/puck/types/Config";
+import { ComponentConfig } from "@measured/puck";
 import styles from "./styles.module.css";
 import { getClassNameFactory } from "@measured/puck/lib";
 import { Button } from "@measured/puck/components/Button";

--- a/apps/demo/app/configs/custom/blocks/Logos/index.tsx
+++ b/apps/demo/app/configs/custom/blocks/Logos/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @next/next/no-img-element */
 import React from "react";
-import { ComponentConfig } from "@measured/puck/types/Config";
+import { ComponentConfig } from "@measured/puck";
 import styles from "./styles.module.css";
 import { getClassNameFactory } from "@measured/puck/lib";
 import { Section } from "../../components/Section";

--- a/apps/demo/app/configs/custom/blocks/Stats/index.tsx
+++ b/apps/demo/app/configs/custom/blocks/Stats/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @next/next/no-img-element */
 import React from "react";
-import { ComponentConfig } from "@measured/puck/types/Config";
+import { ComponentConfig } from "@measured/puck";
 import styles from "./styles.module.css";
 import { getClassNameFactory } from "@measured/puck/lib";
 import { Section } from "../../components/Section";

--- a/apps/demo/app/configs/custom/blocks/Text/index.tsx
+++ b/apps/demo/app/configs/custom/blocks/Text/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ComponentConfig } from "@measured/puck/types/Config";
+import { ComponentConfig } from "@measured/puck";
 import { Section } from "../../components/Section";
 
 export type TextProps = {

--- a/apps/demo/app/configs/custom/blocks/VerticalSpace/index.tsx
+++ b/apps/demo/app/configs/custom/blocks/VerticalSpace/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ComponentConfig } from "@measured/puck/types/Config";
+import { ComponentConfig } from "@measured/puck";
 import { spacingOptions } from "../../options";
 
 export type VerticalSpaceProps = {

--- a/apps/demo/app/configs/custom/index.tsx
+++ b/apps/demo/app/configs/custom/index.tsx
@@ -1,4 +1,4 @@
-import { Config, Data } from "@measured/puck/types/Config";
+import { Config, Data } from "@measured/puck";
 import { ButtonGroup, ButtonGroupProps } from "./blocks/ButtonGroup";
 import { Hero, HeroProps } from "./blocks/Hero";
 import { Heading, HeadingProps } from "./blocks/Heading";

--- a/apps/demo/app/configs/custom/root.tsx
+++ b/apps/demo/app/configs/custom/root.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from "react";
 
-import { DefaultRootProps } from "@measured/puck/types/Config";
+import { DefaultRootProps } from "@measured/puck";
 import { Footer } from "./components/Footer";
 
 export type RootProps = {

--- a/apps/demo/app/configs/material-ui/Container.tsx
+++ b/apps/demo/app/configs/material-ui/Container.tsx
@@ -3,7 +3,7 @@ import React, { ReactNode } from "react";
 import { Breakpoint, Container as _Container } from "@mui/material";
 import { breakpointOptions, spacingOptions } from "./options";
 
-import { Fields } from "@measured/puck/types/Config";
+import { Fields } from "@measured/puck";
 
 export type ContainerProps = {
   paddingBottom?: string;

--- a/apps/demo/app/configs/material-ui/blocks/ButtonGroup.tsx
+++ b/apps/demo/app/configs/material-ui/blocks/ButtonGroup.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ComponentConfig } from "@measured/puck/types/Config";
+import { ComponentConfig } from "@measured/puck";
 import { Button, Stack } from "@mui/material";
 import { Container, ContainerProps, containerFields } from "../Container";
 

--- a/apps/demo/app/configs/material-ui/blocks/CardDeck.tsx
+++ b/apps/demo/app/configs/material-ui/blocks/CardDeck.tsx
@@ -7,7 +7,7 @@ import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
 import Grid from "@mui/material/Unstable_Grid2"; // Grid version 2
 
-import { ComponentConfig } from "@measured/puck/types/Config";
+import { ComponentConfig } from "@measured/puck";
 import { Container, ContainerProps, containerFields } from "../Container";
 
 export type CardDeckProps = {

--- a/apps/demo/app/configs/material-ui/blocks/ImageList.tsx
+++ b/apps/demo/app/configs/material-ui/blocks/ImageList.tsx
@@ -7,7 +7,7 @@ import {
 } from "@mui/material";
 import { Container, ContainerProps, containerFields } from "../Container";
 
-import { ComponentConfig } from "@measured/puck/types/Config";
+import { ComponentConfig } from "@measured/puck";
 
 export type ImageListProps = {
   variant: "masonry" | "quilted" | "standard" | "woven";

--- a/apps/demo/app/configs/material-ui/blocks/TypographyBlock.tsx
+++ b/apps/demo/app/configs/material-ui/blocks/TypographyBlock.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ComponentConfig } from "@measured/puck/types/Config";
+import { ComponentConfig } from "@measured/puck";
 import { Typography, TypographyVariant } from "@mui/material";
 import { ContainerProps, Container, containerFields } from "../Container";
 

--- a/apps/demo/app/configs/material-ui/blocks/VerticalSpace.tsx
+++ b/apps/demo/app/configs/material-ui/blocks/VerticalSpace.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ComponentConfig } from "@measured/puck/types/Config";
+import { ComponentConfig } from "@measured/puck";
 import { Box } from "@mui/material";
 import { spacingOptions } from "../options";
 

--- a/apps/demo/app/configs/material-ui/index.tsx
+++ b/apps/demo/app/configs/material-ui/index.tsx
@@ -1,4 +1,4 @@
-import { Config, Data } from "@measured/puck/types/Config";
+import { Config, Data } from "@measured/puck";
 import { ButtonGroup, ButtonGroupProps } from "./blocks/ButtonGroup";
 import { CardDeck, CardDeckProps } from "./blocks/CardDeck";
 import {

--- a/apps/demo/puck.config.tsx
+++ b/apps/demo/puck.config.tsx
@@ -1,4 +1,4 @@
-import { Config } from "@measured/puck/types/Config";
+import { Config } from "@measured/puck";
 
 type Props = {
   HeadingBlock: { title: string };

--- a/packages/create-puck-app/templates/next/app/[...puckPath]/client.tsx
+++ b/packages/create-puck-app/templates/next/app/[...puckPath]/client.tsx
@@ -21,7 +21,7 @@ export function Client({
         onPublish={async (data: Data) => {
           await fetch("/api/puck", {
             method: "post",
-            body: JSON.stringify({ [path]: data }),
+            body: JSON.stringify({ data, path }),
           });
         }}
       />

--- a/packages/create-puck-app/templates/next/app/[...puckPath]/page.tsx
+++ b/packages/create-puck-app/templates/next/app/[...puckPath]/page.tsx
@@ -3,6 +3,16 @@ import { notFound } from "next/navigation";
 import resolvePuckPath from "./resolve-puck-path";
 import { Metadata } from "next";
 import { Data } from "@measured/puck";
+import fs from "fs";
+
+// Replace with call to your database
+const getPage = (path: string) => {
+  const allData: Data | null = fs.existsSync("database.json")
+    ? JSON.parse(fs.readFileSync("database.json", "utf-8"))
+    : null;
+
+  return allData ? allData[path] : null;
+};
 
 export async function generateMetadata({
   params,
@@ -17,14 +27,8 @@ export async function generateMetadata({
     };
   }
 
-  const data: Data = (
-    await fetch("http://localhost:3000/api/puck", {
-      next: { revalidate: 0 },
-    }).then((d) => d.json())
-  )[path];
-
   return {
-    title: data?.root?.title,
+    title: getPage(path),
   };
 }
 
@@ -35,11 +39,7 @@ export default async function Page({
 }) {
   const { isEdit, path } = resolvePuckPath(params.puckPath);
 
-  const data = (
-    await fetch("http://localhost:3000/api/puck", {
-      next: { revalidate: 0 },
-    }).then((d) => d.json())
-  )[path];
+  const data = getPage(path);
 
   if (!data && !isEdit) {
     return notFound();

--- a/packages/create-puck-app/templates/next/app/[...puckPath]/page.tsx
+++ b/packages/create-puck-app/templates/next/app/[...puckPath]/page.tsx
@@ -7,7 +7,7 @@ import fs from "fs";
 
 // Replace with call to your database
 const getPage = (path: string) => {
-  const allData: Data | null = fs.existsSync("database.json")
+  const allData: Record<string, Data> | null = fs.existsSync("database.json")
     ? JSON.parse(fs.readFileSync("database.json", "utf-8"))
     : null;
 
@@ -28,7 +28,7 @@ export async function generateMetadata({
   }
 
   return {
-    title: getPage(path),
+    title: getPage(path).root.title,
   };
 }
 

--- a/packages/create-puck-app/templates/next/app/[...puckPath]/page.tsx
+++ b/packages/create-puck-app/templates/next/app/[...puckPath]/page.tsx
@@ -2,7 +2,7 @@ import { Client } from "./client";
 import { notFound } from "next/navigation";
 import resolvePuckPath from "./resolve-puck-path";
 import { Metadata } from "next";
-import { Data } from "@measured/puck/types/Config";
+import { Data } from "@measured/puck";
 
 export async function generateMetadata({
   params,
@@ -24,7 +24,7 @@ export async function generateMetadata({
   )[path];
 
   return {
-    title: data?.page?.title,
+    title: data?.root?.title,
   };
 }
 

--- a/packages/create-puck-app/templates/next/app/api/puck/route.ts
+++ b/packages/create-puck-app/templates/next/app/api/puck/route.ts
@@ -1,14 +1,6 @@
 import { NextResponse } from "next/server";
 import fs from "fs";
 
-export async function GET() {
-  const data = fs.existsSync("database.json")
-    ? fs.readFileSync("database.json", "utf-8")
-    : null;
-
-  return NextResponse.json(JSON.parse(data || "{}"));
-}
-
 export async function POST(request: Request) {
   const data = await request.json();
 

--- a/packages/create-puck-app/templates/next/app/api/puck/route.ts
+++ b/packages/create-puck-app/templates/next/app/api/puck/route.ts
@@ -1,8 +1,9 @@
+import { revalidatePath } from "next/cache";
 import { NextResponse } from "next/server";
 import fs from "fs";
 
 export async function POST(request: Request) {
-  const data = await request.json();
+  const payload = await request.json();
 
   const existingData = JSON.parse(
     fs.existsSync("database.json")
@@ -12,12 +13,13 @@ export async function POST(request: Request) {
 
   const updatedData = {
     ...existingData,
-    ...data,
+    [payload.path]: payload.data,
   };
 
   fs.writeFileSync("database.json", JSON.stringify(updatedData));
 
+  // Purge Next.js cache
+  revalidatePath(payload.path);
+
   return NextResponse.json({ status: "ok" });
 }
-
-export const revalidate = 0;

--- a/packages/plugin-heading-analyzer/src/HeadingAnalyzer.tsx
+++ b/packages/plugin-heading-analyzer/src/HeadingAnalyzer.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, ReactNode, useEffect, useState } from "react";
 
-import { Data } from "@measured/puck/types/Config";
+import { Data } from "@measured/puck";
 import { Plugin } from "@measured/puck/types/Plugin";
 import { SidebarSection } from "@measured/puck/components/SidebarSection";
 import { OutlineList } from "@measured/puck/components/OutlineList";

--- a/recipes/next/app/[...puckPath]/client.tsx
+++ b/recipes/next/app/[...puckPath]/client.tsx
@@ -21,7 +21,7 @@ export function Client({
         onPublish={async (data: Data) => {
           await fetch("/api/puck", {
             method: "post",
-            body: JSON.stringify({ [path]: data }),
+            body: JSON.stringify({ data, path }),
           });
         }}
       />

--- a/recipes/next/app/[...puckPath]/page.tsx
+++ b/recipes/next/app/[...puckPath]/page.tsx
@@ -2,7 +2,7 @@ import { Client } from "./client";
 import { notFound } from "next/navigation";
 import resolvePuckPath from "./resolve-puck-path";
 import { Metadata } from "next";
-import { Data } from "@measured/puck/types/Config";
+import { Data } from "@measured/puck";
 
 export async function generateMetadata({
   params,

--- a/recipes/next/app/[...puckPath]/page.tsx
+++ b/recipes/next/app/[...puckPath]/page.tsx
@@ -3,6 +3,16 @@ import { notFound } from "next/navigation";
 import resolvePuckPath from "./resolve-puck-path";
 import { Metadata } from "next";
 import { Data } from "@measured/puck";
+import fs from "fs";
+
+// Replace with call to your database
+const getPage = (path: string) => {
+  const allData: Record<string, Data> | null = fs.existsSync("database.json")
+    ? JSON.parse(fs.readFileSync("database.json", "utf-8"))
+    : null;
+
+  return allData ? allData[path] : null;
+};
 
 export async function generateMetadata({
   params,
@@ -17,14 +27,8 @@ export async function generateMetadata({
     };
   }
 
-  const data: Data = (
-    await fetch("http://localhost:3000/api/puck", {
-      next: { revalidate: 0 },
-    }).then((d) => d.json())
-  )[path];
-
   return {
-    title: data?.root?.title,
+    title: getPage(path).root.title,
   };
 }
 
@@ -35,11 +39,7 @@ export default async function Page({
 }) {
   const { isEdit, path } = resolvePuckPath(params.puckPath);
 
-  const data = (
-    await fetch("http://localhost:3000/api/puck", {
-      next: { revalidate: 0 },
-    }).then((d) => d.json())
-  )[path];
+  const data = getPage(path);
 
   if (!data && !isEdit) {
     return notFound();

--- a/recipes/next/app/[...puckPath]/page.tsx
+++ b/recipes/next/app/[...puckPath]/page.tsx
@@ -24,7 +24,7 @@ export async function generateMetadata({
   )[path];
 
   return {
-    title: data?.page?.title,
+    title: data?.root?.title,
   };
 }
 

--- a/recipes/next/package.json
+++ b/recipes/next/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@measured/puck": "^0.2.2",
+    "@measured/puck": "^0.6.1",
     "classnames": "^2.3.2",
     "next": "^13.4.6",
     "react": "^18.2.0",


### PR DESCRIPTION
* Fix invalid types preventing build
* Fix invalid behaviour when Next.js was trying to call itself via an API call during build time
* Bust cache on page publish

## Testing

1. Run test generator: `npx cpa-test my-app`
2. Install will fail. Update `@measured/puck` version to `0.6.1` and re-run `npm` or `yarn`.
3. Run `npm run build` or `yarn build`.
4. Start app with `npm start`
5. Confirm homepage renders at `/`
6. Edit homepage via `/edit`.
7. Confirm changes appear at `/`.

---

Closes #46 