### PR TITLE
undo redo history

### DIFF
--- a/apps/demo/app/Framework.ts
+++ b/apps/demo/app/Framework.ts
@@ -1,2 +1,2 @@
-export const validFrameworks = ["antd", "material-ui", "custom"];
-export type Framework = "antd" | "material-ui" | "custom";
+export const validFrameworks = ["antd", "material-ui", "custom"] as const;
+export type Framework = (typeof validFrameworks)[number];

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from "react";
 import { DragDropContext } from "react-beautiful-dnd";
+import useUndo from "use-undo";
 import DroppableStrictMode from "../DroppableStrictMode";
 import { DraggableComponent } from "../DraggableComponent";
 import type { Config, Data, Field } from "../../types/Config";
@@ -22,7 +23,7 @@ import { usePlaceholderStyle } from "../../lib/use-placeholder-style";
 
 import { SidebarSection } from "../SidebarSection";
 import { scrollIntoView } from "../../lib/scroll-into-view";
-import { Globe, Sidebar } from "react-feather";
+import { Globe, Sidebar, ChevronLeft, ChevronRight } from "react-feather";
 import { Heading } from "../Heading";
 import { IconButton } from "../IconButton/IconButton";
 
@@ -80,7 +81,11 @@ export function Puck({
   headerTitle?: string;
   headerPath?: string;
 }) {
-  const [data, setData] = useState(initialData);
+  const [
+    { present: data },
+    { set: setData, undo: undoData, redo: redoData, canUndo, canRedo },
+  ] = useUndo(initialData);
+
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
 
   const Page = useCallback(
@@ -275,6 +280,28 @@ export function Puck({
                     justifyContent: "flex-end",
                   }}
                 >
+                  <div style={{ display: "flex" }}>
+                    <IconButton
+                      title="undo"
+                      disabled={!canUndo}
+                      onClick={undoData}
+                    >
+                      <ChevronLeft
+                        size={21}
+                        stroke={canUndo ? "black" : "#ddd"}
+                      />
+                    </IconButton>
+                    <IconButton
+                      title="redo"
+                      disabled={!canRedo}
+                      onClick={redoData}
+                    >
+                      <ChevronRight
+                        size={21}
+                        stroke={canRedo ? "black" : "#ddd"}
+                      />
+                    </IconButton>
+                  </div>
                   {renderHeaderActions &&
                     renderHeaderActions({ data, setData })}
                   <Button

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,8 @@
   "dependencies": {
     "react-beautiful-dnd": "^13.1.1",
     "react-feather": "^2.0.10",
-    "react-spinners": "^0.13.8"
+    "react-spinners": "^0.13.8",
+    "use-undo": "^1.1.1"
   },
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7774,6 +7774,11 @@ use-memo-one@^1.1.1:
   resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.3.tgz#2fd2e43a2169eabc7496960ace8c79efef975e99"
   integrity sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==
 
+use-undo@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/use-undo/-/use-undo-1.1.1.tgz#8c5a9143207b6a8f94fc30bb9aa31e19386ba1c4"
+  integrity sha512-2NNpJv7TDQpyETgRTG5I/CsABX5nhExpx8PEhWiDsnW9C5BA6Xnn8G9u/lPeg3+JsBrBtUx8/5bMbGmpnWz1Cw==
+
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"


### PR DESCRIPTION
Hi! I came across this project while researching for easy page development and interested in this project.
thank you for creating a good project.

I looked at #23 and made a simple draft. (using use-undo)
I think basic operations are possible. but as you know, It is not advisable to record all 'Data' for every change.

so I think it could be a good idea to define some actions using the command pattern.

```javascript
// pseudo
function Puck(){
  const [currentData, setCurrentData) = useState(initialData)
  const [commandHistory, setCommandHistory = setState([]) // or { [id]: { beforeAction: id, afterAction: id, ... } }

  // commands (it can make the related functions more abstract.)
  const changeField = (id, field) => {
    // todo
  }
  const addBlock = () => {}
  const removeBlock = () => {}
  // ...
  const undo = (id) => {
    commandHistory[id].inverse()
    setSelected(id)
    focus(field)
  }

  // ...

  <InputOrGroup onBlur={changeField} /> // for record once, not every change
}
```

How about your plan?
If the priority is not high and there is no one in charge of this feature, I can try this