### PR TITLE
docs: replace quotes API in demo with hardcoded quotes

### DIFF
--- a/apps/demo/app/configs/custom/blocks/Hero/index.tsx
+++ b/apps/demo/app/configs/custom/blocks/Hero/index.tsx
@@ -5,7 +5,7 @@ import styles from "./styles.module.css";
 import { getClassNameFactory } from "@measured/puck/lib";
 import { Button } from "@measured/puck/components/Button";
 import { Section } from "../../components/Section";
-import createAdaptor from "@measured/puck-adaptor-fetch/index";
+import { quotes } from "./quotes";
 
 const getClassName = getClassNameFactory("Hero", styles);
 
@@ -20,29 +20,21 @@ export type HeroProps = {
   buttons: { label: string; href: string; variant?: "primary" | "secondary" }[];
 };
 
-const quotesAdaptor = createAdaptor(
-  "Quotes API",
-  "https://api.quotable.io/quotes",
-  (body) =>
-    body.results.map((item) => ({
-      ...item,
-      title: item.author,
-      description: item.content,
-    }))
-);
+const quotesAdaptor = {
+  name: "Quotes API",
+  fetchList: async (): Promise<Partial<HeroProps>[]> =>
+    quotes.map((quote) => ({
+      title: quote.author,
+      description: quote.content,
+    })),
+};
 
 export const Hero: ComponentConfig<HeroProps> = {
   fields: {
     _data: {
       type: "external",
       adaptor: quotesAdaptor,
-      adaptorParams: {
-        resource: "movies",
-        url: "http://localhost:1337",
-        apiToken:
-          "1fb8c347243145a8824481bd1008b95367677654ebc1f06c5a0a766e57b8859bcfde77f9b21405011f20eb8a13abb7b0ea3ba2393167ffc4a2cdc3828586494cc9983d5f1db4bc195ff4afb885aa55ee28a88ca796e7b883b9e9b80c98b50eadf79f5a1639ce8e2ae4cf63c2e8b8659a8cbbfeaa8e8adcce222b827eec49f989",
-      },
-      getItemSummary: (item: any) => item.content,
+      getItemSummary: (item: Partial<HeroProps>) => item.description,
     },
     title: { type: "text" },
     description: { type: "textarea" },

--- a/apps/demo/app/configs/custom/blocks/Hero/quotes.ts
+++ b/apps/demo/app/configs/custom/blocks/Hero/quotes.ts
@@ -1,0 +1,56 @@
+export const quotes = [
+  {
+    content:
+      "Age is an issue of mind over matter. If you don't mind, it doesn't matter.",
+    author: "Mark Twain",
+  },
+  {
+    content:
+      "Anyone who stops learning is old, whether at twenty or eighty. Anyone who keeps learning stays young. The greatest thing in life is to keep your mind young.",
+    author: "Henry Ford",
+  },
+  {
+    content: "Wrinkles should merely indicate where smiles have been.",
+    author: "Mark Twain",
+  },
+  {
+    content:
+      "True terror is to wake up one morning and discover that your high school class is running the country.",
+    author: "Kurt Vonnegut",
+  },
+  {
+    content:
+      "A diplomat is a man who always remembers a woman's birthday but never remembers her age.",
+    author: "Robert Frost",
+  },
+  {
+    content:
+      "As I grow older, I pay less attention to what men say. I just watch what they do.",
+    author: "Andrew Carnegie",
+  },
+  {
+    content:
+      "How incessant and great are the ills with which a prolonged old age is replete.",
+    author: "C. S. Lewis",
+  },
+  {
+    content:
+      "Old age, believe me, is a good and pleasant thing. It is true you are gently shouldered off the stage, but then you are given such a comfortable front stall as spectator.",
+    author: "Confucius",
+  },
+  {
+    content:
+      "Old age has deformities enough of its own. It should never add to them the deformity of vice.",
+    author: "Eleanor Roosevelt",
+  },
+  {
+    content:
+      "Nobody grows old merely by living a number of years. We grow old by deserting our ideals. Years may wrinkle the skin, but to give up enthusiasm wrinkles the soul.",
+    author: "Samuel Ullman",
+  },
+  {
+    content:
+      "An archaeologist is the best husband a woman can have. The older she gets the more interested he is in her.",
+    author: "Agatha Christie",
+  },
+];


### PR DESCRIPTION
The [quotes API](https://github.com/lukePeavey/quotable/tree/master) we were using in the demo went down. Unsure if related to our sudden surge of traffic. If it is, apologies to maintainer @lukePeavey.

This PR replaces the API call with some hardcoded quotes.