### PR TITLE
Adding 'object' type as a datatype option

### DIFF
--- a/apps/demo/app/configs/custom/blocks/Hero/index.tsx
+++ b/apps/demo/app/configs/custom/blocks/Hero/index.tsx
@@ -78,14 +78,14 @@ export const Hero: ComponentConfig<HeroProps> = {
     padding: "64px",
   },
   render: ({
-             align,
-             title,
-             description,
-             buttons,
-             padding,
-             imageUrl,
-             imageMode,
-           }) => {
+    align,
+    title,
+    description,
+    buttons,
+    padding,
+    imageUrl,
+    imageMode,
+  }) => {
     return (
       <Section
         padding={padding}

--- a/apps/demo/app/configs/custom/blocks/Hero/index.tsx
+++ b/apps/demo/app/configs/custom/blocks/Hero/index.tsx
@@ -1,147 +1,187 @@
 /* eslint-disable @next/next/no-img-element */
 import React from "react";
-import { ComponentConfig } from "@measured/puck";
+import {ComponentConfig} from "@measured/puck";
 import styles from "./styles.module.css";
-import { getClassNameFactory } from "@measured/puck/lib";
-import { Button } from "@measured/puck/components/Button";
-import { Section } from "../../components/Section";
-import { quotes } from "./quotes";
+import {getClassNameFactory} from "@measured/puck/lib";
+import {Button} from "@measured/puck/components/Button";
+import {Section} from "../../components/Section";
+import {quotes} from "./quotes";
+import {Heading as HeadingEditor} from "../Heading";
+import {Heading} from "@measured/puck/components/Heading";
 
 const getClassName = getClassNameFactory("Hero", styles);
 
 export type HeroProps = {
-  _data?: object;
-  title: string;
-  description: string;
-  align?: string;
-  padding: string;
-  imageMode?: "inline" | "background";
-  imageUrl?: string;
-  buttons: { label: string; href: string; variant?: "primary" | "secondary" }[];
+    _data?: object;
+    title: string;
+    description: string;
+    align?: string;
+    padding: string;
+    imageMode?: "inline" | "background";
+    imageUrl?: string;
+    buttons: {
+        label: string;
+        href: string;
+        variant?: "primary" | "secondary"
+    }[];
+    headingTheme: object[];
+    blockTheme: object[];
 };
 
 const quotesAdaptor = {
-  name: "Quotes API",
-  fetchList: async (): Promise<Partial<HeroProps>[]> =>
-    quotes.map((quote) => ({
-      title: quote.author,
-      description: quote.content,
-    })),
+    name: "Quotes API",
+    fetchList: async (): Promise<Partial<HeroProps>[]> =>
+        quotes.map((quote) => ({
+            title: quote.author,
+            description: quote.content,
+        })),
 };
 
 export const Hero: ComponentConfig<HeroProps> = {
-  fields: {
-    _data: {
-      type: "external",
-      adaptor: quotesAdaptor,
-      getItemSummary: (item: Partial<HeroProps>) => item.description,
-    },
-    title: { type: "text" },
-    description: { type: "textarea" },
-    buttons: {
-      type: "array",
-      getItemSummary: (item) => item.label || "Button",
-      arrayFields: {
-        label: { type: "text" },
-        href: { type: "text" },
-        variant: {
-          type: "select",
-          options: [
-            { label: "primary", value: "primary" },
-            { label: "secondary", value: "secondary" },
-          ],
+    fields: {
+        _data: {
+            type: "external",
+            adaptor: quotesAdaptor,
+            getItemSummary: (item: Partial<HeroProps>) => item.description,
         },
-      },
+        title: {type: "text"},
+        description: {type: "textarea"},
+        buttons: {
+            type: "array",
+            getItemSummary: (item) => item.label || "Button",
+            arrayFields: {
+                label: {type: "text"},
+                href: {type: "text"},
+                variant: {
+                    type: "select",
+                    options: [
+                        {label: "primary", value: "primary"},
+                        {label: "secondary", value: "secondary"},
+                    ],
+                },
+            },
+        },
+        headingTheme: {
+            type: "object",
+            objectFields: {
+                ...HeadingEditor.fields,
+            }
+        },
+        blockTheme: {
+            type: "object",
+            objectFields: {
+                color: "fafafa"
+            }
+        },
+        align: {
+            type: "radio",
+            options: [
+                {label: "left", value: "left"},
+                {label: "center", value: "center"},
+            ],
+        },
+        imageUrl: {type: "text"},
+        imageMode: {
+            type: "radio",
+            options: [
+                {label: "inline", value: "inline"},
+                {label: "background", value: "background"},
+            ],
+        },
+        padding: {type: "text"},
     },
-    align: {
-      type: "radio",
-      options: [
-        { label: "left", value: "left" },
-        { label: "center", value: "center" },
-      ],
+    defaultProps: {
+        title: "Title1",
+        align: "left",
+        description: "Description",
+        buttons: [
+            {
+                label: "Learn more",
+                href: "#"
+            }
+        ],
+        // @ts-ignore
+        headingTheme: {
+            ...HeadingEditor.defaultProps
+        },
+        blockTheme: [{
+            color: "#fafafa",
+            size: "H1"
+        }],
+        padding: "64px",
     },
-    imageUrl: { type: "text" },
-    imageMode: {
-      type: "radio",
-      options: [
-        { label: "inline", value: "inline" },
-        { label: "background", value: "background" },
-      ],
+    render: ({
+                 align,
+                 title,
+                 description,
+                 buttons,
+                 padding,
+                 imageUrl,
+                 imageMode,
+                 headingTheme,
+                 blockTheme
+             }) => {
+
+        return (
+            <Section
+                padding={padding}
+                className={getClassName({
+                    left: align === "left",
+                    center: align === "center",
+                    hasImageBackground: imageMode === "background",
+                })}
+            >
+                {imageMode === "background" && (
+                    <>
+                        <div
+                            className={getClassName("image")}
+                            style={{
+                                backgroundImage: `url("${imageUrl}")`,
+                            }}
+                        ></div>
+
+                        <div className={getClassName("imageOverlay")}></div>
+                    </>
+                )}
+
+                <div className={getClassName("inner")}>
+                    <div className={getClassName("content")}>
+                        {/*@ts-ignore*/}
+                        <Heading size={headingTheme['size']} rank={headingTheme['level']}>
+                            {title}
+                        </Heading>
+
+                        <p className={getClassName("subtitle")}>{description}</p>
+                        <div className={getClassName("actions")}>
+                            {buttons.map((button, i) => (
+                                <Button
+                                    key={i}
+                                    href={button.href}
+                                    variant={button.variant}
+                                    size="large"
+                                >
+                                    {button.label}
+                                </Button>
+                            ))}
+                        </div>
+                    </div>
+
+                    {align !== "center" && imageMode !== "background" && imageUrl && (
+                        <div
+                            style={{
+                                backgroundImage: `url('${imageUrl}')`,
+                                backgroundSize: "cover",
+                                backgroundRepeat: "no-repeat",
+                                backgroundPosition: "center",
+                                borderRadius: 24,
+                                height: 356,
+                                marginLeft: "auto",
+                                width: "100%",
+                            }}
+                        />
+                    )}
+                </div>
+            </Section>
+        );
     },
-    padding: { type: "text" },
-  },
-  defaultProps: {
-    title: "Hero",
-    align: "left",
-    description: "Description",
-    buttons: [{ label: "Learn more", href: "#" }],
-    padding: "64px",
-  },
-  render: ({
-    align,
-    title,
-    description,
-    buttons,
-    padding,
-    imageUrl,
-    imageMode,
-  }) => {
-    return (
-      <Section
-        padding={padding}
-        className={getClassName({
-          left: align === "left",
-          center: align === "center",
-          hasImageBackground: imageMode === "background",
-        })}
-      >
-        {imageMode === "background" && (
-          <>
-            <div
-              className={getClassName("image")}
-              style={{
-                backgroundImage: `url("${imageUrl}")`,
-              }}
-            ></div>
-
-            <div className={getClassName("imageOverlay")}></div>
-          </>
-        )}
-
-        <div className={getClassName("inner")}>
-          <div className={getClassName("content")}>
-            <h1>{title}</h1>
-            <p className={getClassName("subtitle")}>{description}</p>
-            <div className={getClassName("actions")}>
-              {buttons.map((button, i) => (
-                <Button
-                  key={i}
-                  href={button.href}
-                  variant={button.variant}
-                  size="large"
-                >
-                  {button.label}
-                </Button>
-              ))}
-            </div>
-          </div>
-
-          {align !== "center" && imageMode !== "background" && imageUrl && (
-            <div
-              style={{
-                backgroundImage: `url('${imageUrl}')`,
-                backgroundSize: "cover",
-                backgroundRepeat: "no-repeat",
-                backgroundPosition: "center",
-                borderRadius: 24,
-                height: 356,
-                marginLeft: "auto",
-                width: "100%",
-              }}
-            />
-          )}
-        </div>
-      </Section>
-    );
-  },
 };

--- a/apps/demo/app/configs/custom/blocks/Hero/index.tsx
+++ b/apps/demo/app/configs/custom/blocks/Hero/index.tsx
@@ -1,13 +1,13 @@
 /* eslint-disable @next/next/no-img-element */
 import React from "react";
-import {ComponentConfig} from "@measured/puck";
+import { ComponentConfig } from "@measured/puck";
 import styles from "./styles.module.css";
-import {getClassNameFactory} from "@measured/puck/lib";
-import {Button} from "@measured/puck/components/Button";
-import {Section} from "../../components/Section";
-import {quotes} from "./quotes";
-import {Heading as HeadingEditor} from "../Heading";
-import {Heading} from "@measured/puck/components/Heading";
+import { getClassNameFactory } from "@measured/puck/lib";
+import { Button } from "@measured/puck/components/Button";
+import { Section } from "../../components/Section";
+import { quotes } from "./quotes";
+import { Heading as HeadingEditor } from "../Heading";
+import { Heading } from "@measured/puck/components/Heading";
 
 const getClassName = getClassNameFactory("Hero", styles);
 
@@ -104,10 +104,10 @@ export const Hero: ComponentConfig<HeroProps> = {
     headingTheme: {
       ...HeadingEditor.defaultProps
     },
-    blockTheme: [{
+    blockTheme: [ {
       color: "#fafafa",
       size: "H1"
-    }],
+    } ],
     padding: "64px",
   },
   render: ({
@@ -124,52 +124,52 @@ export const Hero: ComponentConfig<HeroProps> = {
 
     return (
       <Section
-        padding={padding}
-        className={getClassName({
+        padding={ padding }
+        className={ getClassName({
           left: align === "left",
           center: align === "center",
           hasImageBackground: imageMode === "background",
-        })}
+        }) }
       >
-        {imageMode === "background" && (
+        { imageMode === "background" && (
           <>
             <div
-              className={getClassName("image")}
-              style={{
-                backgroundImage: `url("${imageUrl}")`,
-              }}
+              className={ getClassName("image") }
+              style={ {
+                backgroundImage: `url("${ imageUrl }")`,
+              } }
             ></div>
 
-            <div className={getClassName("imageOverlay")}></div>
+            <div className={ getClassName("imageOverlay") }></div>
           </>
-        )}
+        ) }
 
-        <div className={getClassName("inner")}>
-          <div className={getClassName("content")}>
-            {/*@ts-ignore*/}
-            <Heading size={headingTheme['size']} rank={headingTheme['level']}>
-              {title}
+        <div className={ getClassName("inner") }>
+          <div className={ getClassName("content") }>
+            {/*@ts-ignore*/ }
+            <Heading size={ headingTheme['size'] } rank={ headingTheme['level'] }>
+              { title }
             </Heading>
 
-            <p className={getClassName("subtitle")}>{description}</p>
-            <div className={getClassName("actions")}>
-              {buttons.map((button, i) => (
+            <p className={ getClassName("subtitle") }>{ description }</p>
+            <div className={ getClassName("actions") }>
+              { buttons.map((button, i) => (
                 <Button
-                  key={i}
-                  href={button.href}
-                  variant={button.variant}
+                  key={ i }
+                  href={ button.href }
+                  variant={ button.variant }
                   size="large"
                 >
-                  {button.label}
+                  { button.label }
                 </Button>
-              ))}
+              )) }
             </div>
           </div>
 
-          {align !== "center" && imageMode !== "background" && imageUrl && (
+          { align !== "center" && imageMode !== "background" && imageUrl && (
             <div
-              style={{
-                backgroundImage: `url('${imageUrl}')`,
+              style={ {
+                backgroundImage: `url('${ imageUrl }')`,
                 backgroundSize: "cover",
                 backgroundRepeat: "no-repeat",
                 backgroundPosition: "center",
@@ -177,9 +177,9 @@ export const Hero: ComponentConfig<HeroProps> = {
                 height: 356,
                 marginLeft: "auto",
                 width: "100%",
-              }}
+              } }
             />
-          )}
+          ) }
         </div>
       </Section>
     );

--- a/apps/demo/app/configs/custom/blocks/Hero/index.tsx
+++ b/apps/demo/app/configs/custom/blocks/Hero/index.tsx
@@ -6,8 +6,6 @@ import { getClassNameFactory } from "@measured/puck/lib";
 import { Button } from "@measured/puck/components/Button";
 import { Section } from "../../components/Section";
 import { quotes } from "./quotes";
-import { Heading as HeadingEditor } from "../Heading";
-import { Heading } from "@measured/puck/components/Heading";
 
 const getClassName = getClassNameFactory("Hero", styles);
 
@@ -19,13 +17,7 @@ export type HeroProps = {
   padding: string;
   imageMode?: "inline" | "background";
   imageUrl?: string;
-  buttons: {
-    label: string;
-    href: string;
-    variant?: "primary" | "secondary"
-  }[];
-  headingTheme: object[];
-  blockTheme: object[];
+  buttons: { label: string; href: string; variant?: "primary" | "secondary" }[];
 };
 
 const quotesAdaptor = {
@@ -44,70 +36,45 @@ export const Hero: ComponentConfig<HeroProps> = {
       adaptor: quotesAdaptor,
       getItemSummary: (item: Partial<HeroProps>) => item.description,
     },
-    title: {type: "text"},
-    description: {type: "textarea"},
+    title: { type: "text" },
+    description: { type: "textarea" },
     buttons: {
       type: "array",
       getItemSummary: (item) => item.label || "Button",
       arrayFields: {
-        label: {type: "text"},
-        href: {type: "text"},
+        label: { type: "text" },
+        href: { type: "text" },
         variant: {
           type: "select",
           options: [
-            {label: "primary", value: "primary"},
-            {label: "secondary", value: "secondary"},
+            { label: "primary", value: "primary" },
+            { label: "secondary", value: "secondary" },
           ],
         },
       },
     },
-    headingTheme: {
-      type: "object",
-      objectFields: {
-        ...HeadingEditor.fields,
-      }
-    },
-    blockTheme: {
-      type: "object",
-      objectFields: {
-        color: "fafafa"
-      }
-    },
     align: {
       type: "radio",
       options: [
-        {label: "left", value: "left"},
-        {label: "center", value: "center"},
+        { label: "left", value: "left" },
+        { label: "center", value: "center" },
       ],
     },
-    imageUrl: {type: "text"},
+    imageUrl: { type: "text" },
     imageMode: {
       type: "radio",
       options: [
-        {label: "inline", value: "inline"},
-        {label: "background", value: "background"},
+        { label: "inline", value: "inline" },
+        { label: "background", value: "background" },
       ],
     },
-    padding: {type: "text"},
+    padding: { type: "text" },
   },
   defaultProps: {
-    title: "Title1",
+    title: "Hero",
     align: "left",
     description: "Description",
-    buttons: [
-      {
-        label: "Learn more",
-        href: "#"
-      }
-    ],
-    // @ts-ignore
-    headingTheme: {
-      ...HeadingEditor.defaultProps
-    },
-    blockTheme: [ {
-      color: "#fafafa",
-      size: "H1"
-    } ],
+    buttons: [{ label: "Learn more", href: "#" }],
     padding: "64px",
   },
   render: ({
@@ -118,58 +85,51 @@ export const Hero: ComponentConfig<HeroProps> = {
              padding,
              imageUrl,
              imageMode,
-             headingTheme,
-             blockTheme
            }) => {
-
     return (
       <Section
-        padding={ padding }
-        className={ getClassName({
+        padding={padding}
+        className={getClassName({
           left: align === "left",
           center: align === "center",
           hasImageBackground: imageMode === "background",
-        }) }
+        })}
       >
-        { imageMode === "background" && (
+        {imageMode === "background" && (
           <>
             <div
-              className={ getClassName("image") }
-              style={ {
-                backgroundImage: `url("${ imageUrl }")`,
-              } }
+              className={getClassName("image")}
+              style={{
+                backgroundImage: `url("${imageUrl}")`,
+              }}
             ></div>
 
-            <div className={ getClassName("imageOverlay") }></div>
+            <div className={getClassName("imageOverlay")}></div>
           </>
-        ) }
+        )}
 
-        <div className={ getClassName("inner") }>
-          <div className={ getClassName("content") }>
-            {/*@ts-ignore*/ }
-            <Heading size={ headingTheme['size'] } rank={ headingTheme['level'] }>
-              { title }
-            </Heading>
-
-            <p className={ getClassName("subtitle") }>{ description }</p>
-            <div className={ getClassName("actions") }>
-              { buttons.map((button, i) => (
+        <div className={getClassName("inner")}>
+          <div className={getClassName("content")}>
+            <h1>{title}</h1>
+            <p className={getClassName("subtitle")}>{description}</p>
+            <div className={getClassName("actions")}>
+              {buttons.map((button, i) => (
                 <Button
-                  key={ i }
-                  href={ button.href }
-                  variant={ button.variant }
+                  key={i}
+                  href={button.href}
+                  variant={button.variant}
                   size="large"
                 >
-                  { button.label }
+                  {button.label}
                 </Button>
-              )) }
+              ))}
             </div>
           </div>
 
-          { align !== "center" && imageMode !== "background" && imageUrl && (
+          {align !== "center" && imageMode !== "background" && imageUrl && (
             <div
-              style={ {
-                backgroundImage: `url('${ imageUrl }')`,
+              style={{
+                backgroundImage: `url('${imageUrl}')`,
                 backgroundSize: "cover",
                 backgroundRepeat: "no-repeat",
                 backgroundPosition: "center",
@@ -177,9 +137,9 @@ export const Hero: ComponentConfig<HeroProps> = {
                 height: 356,
                 marginLeft: "auto",
                 width: "100%",
-              } }
+              }}
             />
-          ) }
+          )}
         </div>
       </Section>
     );

--- a/apps/demo/app/configs/custom/blocks/Hero/index.tsx
+++ b/apps/demo/app/configs/custom/blocks/Hero/index.tsx
@@ -12,176 +12,176 @@ import {Heading} from "@measured/puck/components/Heading";
 const getClassName = getClassNameFactory("Hero", styles);
 
 export type HeroProps = {
-    _data?: object;
-    title: string;
-    description: string;
-    align?: string;
-    padding: string;
-    imageMode?: "inline" | "background";
-    imageUrl?: string;
-    buttons: {
-        label: string;
-        href: string;
-        variant?: "primary" | "secondary"
-    }[];
-    headingTheme: object[];
-    blockTheme: object[];
+  _data?: object;
+  title: string;
+  description: string;
+  align?: string;
+  padding: string;
+  imageMode?: "inline" | "background";
+  imageUrl?: string;
+  buttons: {
+    label: string;
+    href: string;
+    variant?: "primary" | "secondary"
+  }[];
+  headingTheme: object[];
+  blockTheme: object[];
 };
 
 const quotesAdaptor = {
-    name: "Quotes API",
-    fetchList: async (): Promise<Partial<HeroProps>[]> =>
-        quotes.map((quote) => ({
-            title: quote.author,
-            description: quote.content,
-        })),
+  name: "Quotes API",
+  fetchList: async (): Promise<Partial<HeroProps>[]> =>
+    quotes.map((quote) => ({
+      title: quote.author,
+      description: quote.content,
+    })),
 };
 
 export const Hero: ComponentConfig<HeroProps> = {
-    fields: {
-        _data: {
-            type: "external",
-            adaptor: quotesAdaptor,
-            getItemSummary: (item: Partial<HeroProps>) => item.description,
-        },
-        title: {type: "text"},
-        description: {type: "textarea"},
-        buttons: {
-            type: "array",
-            getItemSummary: (item) => item.label || "Button",
-            arrayFields: {
-                label: {type: "text"},
-                href: {type: "text"},
-                variant: {
-                    type: "select",
-                    options: [
-                        {label: "primary", value: "primary"},
-                        {label: "secondary", value: "secondary"},
-                    ],
-                },
-            },
-        },
-        headingTheme: {
-            type: "object",
-            objectFields: {
-                ...HeadingEditor.fields,
-            }
-        },
-        blockTheme: {
-            type: "object",
-            objectFields: {
-                color: "fafafa"
-            }
-        },
-        align: {
-            type: "radio",
-            options: [
-                {label: "left", value: "left"},
-                {label: "center", value: "center"},
-            ],
-        },
-        imageUrl: {type: "text"},
-        imageMode: {
-            type: "radio",
-            options: [
-                {label: "inline", value: "inline"},
-                {label: "background", value: "background"},
-            ],
-        },
-        padding: {type: "text"},
+  fields: {
+    _data: {
+      type: "external",
+      adaptor: quotesAdaptor,
+      getItemSummary: (item: Partial<HeroProps>) => item.description,
     },
-    defaultProps: {
-        title: "Title1",
-        align: "left",
-        description: "Description",
-        buttons: [
-            {
-                label: "Learn more",
-                href: "#"
-            }
-        ],
-        // @ts-ignore
-        headingTheme: {
-            ...HeadingEditor.defaultProps
+    title: {type: "text"},
+    description: {type: "textarea"},
+    buttons: {
+      type: "array",
+      getItemSummary: (item) => item.label || "Button",
+      arrayFields: {
+        label: {type: "text"},
+        href: {type: "text"},
+        variant: {
+          type: "select",
+          options: [
+            {label: "primary", value: "primary"},
+            {label: "secondary", value: "secondary"},
+          ],
         },
-        blockTheme: [{
-            color: "#fafafa",
-            size: "H1"
-        }],
-        padding: "64px",
+      },
     },
-    render: ({
-                 align,
-                 title,
-                 description,
-                 buttons,
-                 padding,
-                 imageUrl,
-                 imageMode,
-                 headingTheme,
-                 blockTheme
-             }) => {
-
-        return (
-            <Section
-                padding={padding}
-                className={getClassName({
-                    left: align === "left",
-                    center: align === "center",
-                    hasImageBackground: imageMode === "background",
-                })}
-            >
-                {imageMode === "background" && (
-                    <>
-                        <div
-                            className={getClassName("image")}
-                            style={{
-                                backgroundImage: `url("${imageUrl}")`,
-                            }}
-                        ></div>
-
-                        <div className={getClassName("imageOverlay")}></div>
-                    </>
-                )}
-
-                <div className={getClassName("inner")}>
-                    <div className={getClassName("content")}>
-                        {/*@ts-ignore*/}
-                        <Heading size={headingTheme['size']} rank={headingTheme['level']}>
-                            {title}
-                        </Heading>
-
-                        <p className={getClassName("subtitle")}>{description}</p>
-                        <div className={getClassName("actions")}>
-                            {buttons.map((button, i) => (
-                                <Button
-                                    key={i}
-                                    href={button.href}
-                                    variant={button.variant}
-                                    size="large"
-                                >
-                                    {button.label}
-                                </Button>
-                            ))}
-                        </div>
-                    </div>
-
-                    {align !== "center" && imageMode !== "background" && imageUrl && (
-                        <div
-                            style={{
-                                backgroundImage: `url('${imageUrl}')`,
-                                backgroundSize: "cover",
-                                backgroundRepeat: "no-repeat",
-                                backgroundPosition: "center",
-                                borderRadius: 24,
-                                height: 356,
-                                marginLeft: "auto",
-                                width: "100%",
-                            }}
-                        />
-                    )}
-                </div>
-            </Section>
-        );
+    headingTheme: {
+      type: "object",
+      objectFields: {
+        ...HeadingEditor.fields,
+      }
     },
+    blockTheme: {
+      type: "object",
+      objectFields: {
+        color: "fafafa"
+      }
+    },
+    align: {
+      type: "radio",
+      options: [
+        {label: "left", value: "left"},
+        {label: "center", value: "center"},
+      ],
+    },
+    imageUrl: {type: "text"},
+    imageMode: {
+      type: "radio",
+      options: [
+        {label: "inline", value: "inline"},
+        {label: "background", value: "background"},
+      ],
+    },
+    padding: {type: "text"},
+  },
+  defaultProps: {
+    title: "Title1",
+    align: "left",
+    description: "Description",
+    buttons: [
+      {
+        label: "Learn more",
+        href: "#"
+      }
+    ],
+    // @ts-ignore
+    headingTheme: {
+      ...HeadingEditor.defaultProps
+    },
+    blockTheme: [{
+      color: "#fafafa",
+      size: "H1"
+    }],
+    padding: "64px",
+  },
+  render: ({
+             align,
+             title,
+             description,
+             buttons,
+             padding,
+             imageUrl,
+             imageMode,
+             headingTheme,
+             blockTheme
+           }) => {
+
+    return (
+      <Section
+        padding={padding}
+        className={getClassName({
+          left: align === "left",
+          center: align === "center",
+          hasImageBackground: imageMode === "background",
+        })}
+      >
+        {imageMode === "background" && (
+          <>
+            <div
+              className={getClassName("image")}
+              style={{
+                backgroundImage: `url("${imageUrl}")`,
+              }}
+            ></div>
+
+            <div className={getClassName("imageOverlay")}></div>
+          </>
+        )}
+
+        <div className={getClassName("inner")}>
+          <div className={getClassName("content")}>
+            {/*@ts-ignore*/}
+            <Heading size={headingTheme['size']} rank={headingTheme['level']}>
+              {title}
+            </Heading>
+
+            <p className={getClassName("subtitle")}>{description}</p>
+            <div className={getClassName("actions")}>
+              {buttons.map((button, i) => (
+                <Button
+                  key={i}
+                  href={button.href}
+                  variant={button.variant}
+                  size="large"
+                >
+                  {button.label}
+                </Button>
+              ))}
+            </div>
+          </div>
+
+          {align !== "center" && imageMode !== "background" && imageUrl && (
+            <div
+              style={{
+                backgroundImage: `url('${imageUrl}')`,
+                backgroundSize: "cover",
+                backgroundRepeat: "no-repeat",
+                backgroundPosition: "center",
+                borderRadius: 24,
+                height: 356,
+                marginLeft: "auto",
+                width: "100%",
+              }}
+            />
+          )}
+        </div>
+      </Section>
+    );
+  },
 };

--- a/packages/core/components/InputOrGroup/index.tsx
+++ b/packages/core/components/InputOrGroup/index.tsx
@@ -63,7 +63,6 @@ export const InputOrGroup = ({
                         value={existingValue[fieldName] ?? ""}
                         onChange={(val) =>
                           onChange(
-                            // replace(existingValue, 0, { ...existingValue, [fieldName]: val })
                               existingValue = {
                                 ...existingValue,
                                   [fieldName]: val
@@ -75,7 +74,6 @@ export const InputOrGroup = ({
                   })}
                 </fieldset>
               </details>
-            
         </div>
       </div>
     );

--- a/packages/core/components/InputOrGroup/index.tsx
+++ b/packages/core/components/InputOrGroup/index.tsx
@@ -31,6 +31,59 @@ export const InputOrGroup = ({
   onChange: (value: any) => void;
   readOnly?: boolean;
 }) => {
+  if (field.type === "object") {
+    if (!field.objectFields) {
+      return null;
+    }
+    let existingValue = value || {};
+
+    return (
+      <div className={getClassName()}>
+
+        <b className={getClassName("label")}>
+          <div className={getClassName("labelIcon")}>
+            <List size={16} />
+          </div>
+          {label || name}
+        </b>
+        <div className={getClassName("array")}>
+              <details
+                className={getClassName("arrayItem")}
+              >
+                <summary>
+                     {label || name}
+                </summary>
+                <fieldset>
+                  {Object.keys(field.objectFields!).map((fieldName, i) => {
+                    const subField = field.objectFields![fieldName];
+
+                    return (
+                      <InputOrGroup
+                        key={`${name}_${i}_${fieldName}`}
+                        name={`${name}_${i}_${fieldName}`}
+                        label={fieldName}
+                        field={subField}
+                        value={existingValue[fieldName] ?? ""}
+                        onChange={(val) =>
+                          onChange(
+                            // replace(existingValue, 0, { ...existingValue, [fieldName]: val })
+                              existingValue = {
+                                ...existingValue,
+                                  [fieldName]: val
+                              }
+                          )
+                        }
+                      />
+                    );
+                  })}
+                </fieldset>
+              </details>
+            
+        </div>
+      </div>
+    );
+  }
+
   if (field.type === "array") {
     if (!field.arrayFields) {
       return null;

--- a/packages/core/components/InputOrGroup/index.tsx
+++ b/packages/core/components/InputOrGroup/index.tsx
@@ -10,7 +10,7 @@ import {
   List,
   ChevronDown,
   CheckCircle,
-  Hash,
+  Hash, MoreVertical,
 } from "react-feather";
 import { IconButton } from "../IconButton";
 
@@ -39,20 +39,17 @@ export const InputOrGroup = ({
 
     return (
       <div className={getClassName()}>
-
-        <b className={getClassName("label")}>
-          <div className={getClassName("labelIcon")}>
-            <List size={16} />
-          </div>
-          {label || name}
-        </b>
         <div className={getClassName("array")}>
               <details
                 className={getClassName("arrayItem")}
               >
-                <summary>
-                     {label || name}
+                <summary className={getClassName("objectItem") }>
+                  <div className={getClassName("labelIcon")}>
+                    <MoreVertical size={16} />
+                  </div>
+                  {label || name}
                 </summary>
+
                 <fieldset>
                   {Object.keys(field.objectFields!).map((fieldName, i) => {
                     const subField = field.objectFields![fieldName];

--- a/packages/core/components/InputOrGroup/styles.module.css
+++ b/packages/core/components/InputOrGroup/styles.module.css
@@ -83,6 +83,10 @@
   position: relative;
 }
 
+.Input-objectItem {
+  justify-content: start !important;
+}
+
 .Input-arrayItem > summary:hover {
   cursor: pointer;
   color: var(--puck-color-blue);

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -16,13 +16,16 @@ export type Field<
     | "textarea"
     | "number"
     | "select"
+    | "object"
     | "array"
     | "external"
     | "radio";
   label?: string;
   adaptor?: Adaptor;
   adaptorParams?: object;
-  arrayFields?: {
+  objectFields?: {
+    [SubPropName in keyof Props]: Field<Props[SubPropName]>;
+  };  arrayFields?: {
     [SubPropName in keyof Props]: Field<Props[SubPropName]>;
   };
   getItemSummary?: (item: Props, index?: number) => string;


### PR DESCRIPTION
Which can be used to embed objects within the sidebar to embed other editor objects within blocks or to create more details objects.

In this case you can see the 'component' Heading is used to supply object fields to the Block Hero, the values are then used to actually style the heading object within the hero.

https://github.com/measuredco/puck/assets/1926968/f4fd1251-5f5a-46d9-8003-f45661e71c35


#60 

