### PR TITLE
Fix components with hooks

### DIFF
--- a/apps/demo/app/configs/custom/blocks/Hero/index.tsx
+++ b/apps/demo/app/configs/custom/blocks/Hero/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @next/next/no-img-element */
-import React from "react";
+import React, { useState } from "react";
 import { ComponentConfig } from "@measured/puck";
 import styles from "./styles.module.css";
 import { getClassNameFactory } from "@measured/puck/lib";
@@ -86,6 +86,10 @@ export const Hero: ComponentConfig<HeroProps> = {
     imageUrl,
     imageMode,
   }) => {
+    // Empty state allows us to test that components support hooks
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [_] = useState(0);
+
     return (
       <Section
         padding={padding}

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -371,6 +371,14 @@ export function Puck({
                       id="puck-drop-zone"
                     >
                       {data.content.map((item, i) => {
+                        const Render = config.components[item.type]
+                          ? config.components[item.type].render
+                          : () => (
+                              <div style={{ padding: 48, textAlign: "center" }}>
+                                No configuration for {item.type}
+                              </div>
+                            );
+
                         return (
                           <DraggableComponent
                             key={item.props.id}
@@ -411,19 +419,11 @@ export function Puck({
                             }}
                           >
                             <div style={{ zoom: 0.75 }}>
-                              {config.components[item.type] ? (
-                                config.components[item.type].render({
-                                  ...config.components[item.type].defaultProps,
-                                  ...item.props,
-                                  editMode: true,
-                                })
-                              ) : (
-                                <div
-                                  style={{ padding: 48, textAlign: "center" }}
-                                >
-                                  No configuration for {item.type}
-                                </div>
-                              )}
+                              <Render
+                                {...config.components[item.type]?.defaultProps}
+                                {...item.props}
+                                editMode={true}
+                              />
                             </div>
                           </DraggableComponent>
                         );


### PR DESCRIPTION
When using hooks directly inside a render function (rather than a sub-component), React will often complain that we're breaking the rules of hooks.

In main, using `useState` inside a render function would result in a hooks error when adding a component containing hooks:

> Error: Rendered more hooks than during the previous render.

Or this when removing a component containing hooks:

> Error: Rendered fewer hooks than expected. This may be caused by an accidental early return statement.

This occurs is because React expects the render function to start with an uppercase letter. This PR assigns the render function to a constant with an upper case letter to eliminate this issue.

_NB: whilst this PR fixes this issue, but does cause eslint to trip-up because `render` starts with a lower-case character. Going to ignore that issue for now and assume people can disable the linting. To fix that may require a breaking API change._

Closes #82 

## Testing

To test, I've added `useState` to the demo Hero. It doesn't do anything, but allows us to validate this fix is working by deleting the Hero component from our demo page.

1. Visit the root page of the deployment URL
2. Delete the Hero
3. Confirm there are no errors

