### PR TITLE
Fix various type issues

### DIFF
--- a/packages/core/components/Render/index.tsx
+++ b/packages/core/components/Render/index.tsx
@@ -8,7 +8,7 @@ export function Render({ config, data }: { config: Config; data: Data }) {
   if (config.root) {
     return (
       <DropZoneProvider value={{ data, config, mode: "render" }}>
-        <config.root.render {...data.root} editMode={false}>
+        <config.root.render {...data.root} editMode={false} id={"puck-root"}>
           <DropZone zone={rootDroppableId} />
         </config.root.render>
       </DropZoneProvider>

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -8,6 +8,10 @@ export type Adaptor<AdaptorParams = {}> = {
   ) => Promise<Record<string, any>[] | null>;
 };
 
+type WithId<T> = T & {
+  id: string;
+};
+
 export type Field<
   Props extends { [key: string]: any } = { [key: string]: any }
 > = {
@@ -67,7 +71,7 @@ export type ComponentConfig<
   ComponentProps extends DefaultComponentProps = DefaultComponentProps,
   DefaultProps = ComponentProps
 > = {
-  render: (props: ComponentProps) => ReactElement;
+  render: (props: WithId<ComponentProps>) => ReactElement;
   defaultProps?: DefaultProps;
   fields?: Fields<ComponentProps>;
 };
@@ -91,9 +95,9 @@ export type Config<
 type MappedItem<Props extends { [key: string]: any } = { [key: string]: any }> =
   {
     type: keyof Props;
-    props: {
+    props: WithId<{
       [key: string]: any;
-    } & { id: string };
+    }>;
   };
 
 export type Data<

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -28,7 +28,7 @@ export type Field<
   adaptor?: Adaptor;
   adaptorParams?: object;
   arrayFields?: {
-    [SubPropName in keyof Props]: Field<Props[SubPropName]>;
+    [SubPropName in keyof Props]: Field<Props[SubPropName][0]>;
   };
   getItemSummary?: (item: Props, index?: number) => string;
   defaultItemProps?: Props;


### PR DESCRIPTION
Fixes two type issues.

## Add missing id type to render props

Currently the type definition for props being passed into the `render()` function for each component isn't specifying the `id` prop, even though it's always there. This adds it.

**Error**
<img width="460" alt="image" src="https://github.com/measuredco/puck/assets/985961/0c88f4d8-89e6-446d-84bb-e247e07a477a">

## Ensure types allow for nested arrays

The types don't currently allow users to nest arrays, even though Puck supports it.

**Props**

```tsx
type Props = {
  MyComponent: {
    items: {
      subItems: { label: string }[];
    }[];
  };
};
```

**Component**

<img width="404" alt="image" src="https://github.com/measuredco/puck/assets/985961/926bda02-a423-4a76-bfbe-ec870d168699">

**Error**

<img width="1142" alt="image" src="https://github.com/measuredco/puck/assets/985961/52c96d60-7ec5-44e1-9861-e835252f67dc">
