### PR TITLE
ci: ensure canary pipeline determines correct version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,9 @@ jobs:
         uses: actions/checkout@v2.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: "18.16.1"
-          registry-url: "https://registry.npmjs.org"
+          node-version: 18
 
       - name: Check Yarn Version
         run: yarn --version

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -11,7 +11,9 @@ jobs:
     # Don't run on regular releases
     if: "!startsWith(github.event.head_commit.message, 'release: ')"
     steps:
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v4.0.0
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -16,10 +16,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: "18.16.1"
-          registry-url: "https://registry.npmjs.org"
+          node-version: 18
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,10 +20,9 @@ jobs:
           tag: ${{ env.TAG_NAME }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: "18.16.1"
-          registry-url: "https://registry.npmjs.org"
+          node-version: 18
 
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
To review, check the logs in this build mention `v0.8.0-canary.HASH` under the "Run release script" step: https://github.com/measuredco/puck/actions/runs/6274146765/job/17038992854?pr=102

<img width="664" alt="image" src="https://github.com/measuredco/puck/assets/985961/44d18e55-23e0-481b-9908-b5ebca5e9283">
