### PR TITLE
ci: add missing registry-url to GitHub publish action to restore publishing

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
#102 fixed the canary version determination but broke publishing. See https://stackoverflow.com/a/76764356