### PR TITLE
fix: scope styles in OutlineList

### DIFF
--- a/packages/core/components/OutlineList/index.tsx
+++ b/packages/core/components/OutlineList/index.tsx
@@ -3,6 +3,7 @@ import getClassNameFactory from "../../lib/get-class-name-factory";
 import { ReactNode, SyntheticEvent } from "react";
 
 const getClassName = getClassNameFactory("OutlineList", styles);
+const getClassNameItem = getClassNameFactory("OutlineListItem", styles);
 
 export const OutlineList = ({ children }: { children: ReactNode }) => {
   return <ul className={getClassName()}>{children}</ul>;
@@ -10,7 +11,7 @@ export const OutlineList = ({ children }: { children: ReactNode }) => {
 
 // eslint-disable-next-line react/display-name
 OutlineList.Clickable = ({ children }: { children: ReactNode }) => (
-  <div className={getClassName("clickableItem")}>{children}</div>
+  <div className={getClassNameItem({ clickable: true })}>{children}</div>
 );
 
 // eslint-disable-next-line react/display-name
@@ -23,7 +24,7 @@ OutlineList.Item = ({
 }) => {
   return (
     <li
-      className={onClick ? getClassName("clickableItem") : ""}
+      className={getClassNameItem({ clickable: !!onClick })}
       onClick={onClick}
     >
       {children}

--- a/packages/core/components/OutlineList/styles.module.css
+++ b/packages/core/components/OutlineList/styles.module.css
@@ -18,12 +18,12 @@
   content: "";
 }
 
-.OutlineList li {
+.OutlineListItem {
   position: relative;
   margin-bottom: 4px;
 }
 
-.OutlineList li::before {
+.OutlineListItem::before {
   background: var(--puck-color-grey-7);
   position: absolute;
   left: -17px;
@@ -33,11 +33,11 @@
   content: "";
 }
 
-.OutlineList .OutlineList-clickableItem:hover {
+.OutlineListItem--clickable:hover {
   color: var(--puck-color-blue);
   cursor: pointer;
 }
 
-.OutlineList li > .OutlineList {
+.OutlineListItem > .OutlineList {
   margin: 8px;
 }


### PR DESCRIPTION
Some environments were overriding them. Generally we should avoid any element selectors.