### PR TITLE
fix: style clashing with dark mode root element

### DIFF
--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -269,6 +269,8 @@ export function Puck({
                   <header
                     style={{
                       gridArea: "header",
+                      color: "var(--puck-color-black)",
+                      background: "var(--puck-color-white)",
                       borderBottom: "1px solid var(--puck-color-grey-8)",
                     }}
                   >
@@ -398,7 +400,6 @@ export function Puck({
 
                   <div
                     style={{
-                      background: "var(--puck-color-grey-10)",
                       padding: 32,
                       overflowY: "auto",
                       gridArea: "editor",
@@ -410,8 +411,8 @@ export function Puck({
                     <div
                       className="puck-root"
                       style={{
-                        background: "white",
                         border: "1px solid var(--puck-color-grey-8)",
+                        boxShadow: "0px 0px 0px 3rem var(--puck-color-grey-10)",
                         zoom: 0.75,
                       }}
                     >
@@ -428,6 +429,7 @@ export function Puck({
                       fontFamily: "var(--puck-font-stack)",
                       display: "flex",
                       flexDirection: "column",
+                      background: "var(--puck-color-white)",
                     }}
                   >
                     <FieldWrapper data={data}>

--- a/packages/core/components/SidebarSection/styles.module.css
+++ b/packages/core/components/SidebarSection/styles.module.css
@@ -2,6 +2,7 @@
   display: flex;
   position: relative;
   flex-direction: column;
+  color: black;
 }
 
 .SidebarSection:last-of-type {

--- a/packages/core/components/SidebarSection/styles.module.css
+++ b/packages/core/components/SidebarSection/styles.module.css
@@ -13,7 +13,7 @@
   background: white;
   padding: 16px;
   border-bottom: 1px solid var(--puck-color-grey-8);
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .SidebarSection-content {


### PR DESCRIPTION
- Adds in styles so Puck doesn't inherit styles from the document body. 
- Fixes an issue where the preview root would inherit/be blocked by the editor frame. 
  - I'm just faking the frame with a box shadow.
- Fixes an issue where horizontal scrollbars were always visible for `SidebarSection`'s even when not overflowing.
- Closes #106 