### PR TITLE
fix: prevent removal of fieldset padding

### DIFF
--- a/packages/core/components/InputOrGroup/styles.module.css
+++ b/packages/core/components/InputOrGroup/styles.module.css
@@ -97,8 +97,7 @@
   border: none;
   border-top: 1px solid var(--puck-color-grey-8);
   margin: 0;
-  padding-bottom: 16px;
-  padding-top: 16px;
+  padding: 16px;
 }
 
 .Input-arrayItem


### PR DESCRIPTION
Some environments reset padding, resulting in broken styles. This PR explicitly adds the padding to override this reset.

## Example

<img width="279" alt="image" src="https://github.com/measuredco/puck/assets/985961/ce671bc8-bdb2-45a7-817d-cd1f093bb4a9">

## CSS

<img width="145" alt="image" src="https://github.com/measuredco/puck/assets/985961/a4240971-6743-4caa-bd79-e10181dd5906">
