### PR TITLE
fix: add missing optional chaining operator

### DIFF
--- a/packages/create-puck-app/templates/next/app/[...puckPath]/page.tsx
+++ b/packages/create-puck-app/templates/next/app/[...puckPath]/page.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata({
   }
 
   return {
-    title: getPage(path).root.title,
+    title: getPage(path)?.root.title,
   };
 }
 

--- a/recipes/next/app/[...puckPath]/page.tsx
+++ b/recipes/next/app/[...puckPath]/page.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata({
   }
 
   return {
-    title: getPage(path).root.title,
+    title: getPage(path)?.root.title,
   };
 }
 


### PR DESCRIPTION
## Description

Add missing `?.` optional chaining operator in `export async function generateMetadata` in `recipes/next/app/[...puckPath]/page.tsx`.

## Error:
```
next-recipe:dev:  ⨯ app/[...puckPath]/page.tsx (31:25) @ root
next-recipe:dev:  ⨯ TypeError: Cannot read properties of undefined (reading 'root')
next-recipe:dev:     at Module.generateMetadata (./app/[...puckPath]/page.tsx:32:29)
next-recipe:dev: digest: "1676022290"
next-recipe:dev:   29 | 
next-recipe:dev:   30 |   return {
next-recipe:dev: > 31 |     title: getPage(path).root.title,
next-recipe:dev:      |                         ^
next-recipe:dev:   32 |   };
next-recipe:dev:   33 | }
next-recipe:dev:   34 |
```

## Why this happens:

By default the browser attempts to load the `http://localhost:3000/favicon.ico` file but because this file does not exist as a static file, `next.js` server attempts to handle the request using `/app/[...puckPath]/page.tsx` route and because `favicon.ico` path is not defined in `/database.json` this error occurs.

## Steps to reproduce:
### Option 1.
#### Clone this repo
```bash
git clone git@github.com:measuredco/puck.git
cd puck
```

#### Start dev
```bash
yarn dev --scope next-recipe --no-deps
```

### Option 2.
#### Create new project using `next` recipe
```bash
npx create-puck-app my-app
cd my-app
```

#### Start dev
```bash
yarn dev
```

### Open puck editor
```
Browser navigate to -> http://localhost:3000/edit
```

## Commit that introduced this error
https://github.com/measuredco/puck/commit/34f248cd0ca47c79d5c23bc41f366fe870ea3ad9#diff-03f6d84aea18b78020e4edaabac75a948a5c6b56b5212194570e0364684f3f41R31

## Environment
```
$ uname -a
Linux *** 5.15.90.1-microsoft-standard-WSL2 #1 SMP Fri Jan 27 02:56:13 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
$ node -v
v18.17.1
$ yarn -v
1.22.19
$ git rev-parse HEAD
e4cab76e385ba735778de9cb2514a15338ead10a

Browser:
Microsoft Edge
Version 117.0.2045.43 (Official build) (64-bit)

```