### PR TITLE
perf: bundle used react-feather icons only

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,7 @@
     "@types/react-dom": "^18.2.0",
     "eslint": "^7.32.0",
     "eslint-config-custom": "*",
+    "react-feather": "^2.0.10",
     "tsconfig": "*",
     "tsup": "^6.7.0",
     "tsup-config": "*",
@@ -27,7 +28,6 @@
   },
   "dependencies": {
     "react-beautiful-dnd": "^13.1.1",
-    "react-feather": "^2.0.10",
     "react-spinners": "^0.13.8",
     "use-debounce": "^9.0.4"
   },


### PR DESCRIPTION
Moving to dev dependencies causes `tsup` to bundle the external dependencies where necessary.

This increases the direct bundle size by 72KB but should drop the [328KB react-feather dependency](https://bundlephobia.com/package/@measured/puck@0.8.0-canary.e4cab76).

**Before**
CJS dist/index.js  94.00 KB

**After**
CJS dist/index.js  166.42 KB

Closes #118 