### PR TITLE
Feat: enable `classNames` for Dropzone component

### DIFF
--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -1,4 +1,5 @@
 import { CSSProperties, useContext, useEffect } from "react";
+import classnames from "classnames";
 import { DraggableComponent } from "../DraggableComponent";
 import DroppableStrictMode from "../DroppableStrictMode";
 import { getItem } from "../../lib/get-item";
@@ -16,9 +17,10 @@ export { DropZoneProvider, dropZoneContext } from "./context";
 type DropZoneProps = {
   zone: string;
   style?: CSSProperties;
+  className?: string;
 };
 
-function DropZoneEdit({ zone, style }: DropZoneProps) {
+function DropZoneEdit({ zone, style, className }: DropZoneProps) {
   const ctx = useContext(dropZoneContext);
 
   const {
@@ -155,7 +157,7 @@ function DropZoneEdit({ zone, style }: DropZoneProps) {
           return (
             <div
               {...(provided || { droppableProps: {} }).droppableProps}
-              className={getClassName("content")}
+              className={classnames(getClassName("content"), className)}
               ref={provided?.innerRef}
               style={style}
               id={zoneCompound}


### PR DESCRIPTION
It's possible to pass inline styles to the Dropzone component, but it would be great to be able to pass class names as well.