### PR TITLE
fix: render `icon` if provided to FieldLabel

### DIFF
--- a/packages/core/components/InputOrGroup/index.tsx
+++ b/packages/core/components/InputOrGroup/index.tsx
@@ -29,7 +29,7 @@ export const FieldLabel = ({
   return (
     <label>
       <div className={getClassName("label")}>
-        {icon && <div className={getClassName("labelIcon")}></div>}
+        {icon ? <div className={getClassName("labelIcon")}>{icon}</div> : <></>}
         {label}
       </div>
       {children}


### PR DESCRIPTION
Currently the `FieldLabel` component expects an optional prop `icon`, but it doesn't render it. This PR should fix that.