### PR TITLE
Fix issues introduced in #132

### DIFF
--- a/packages/core/components/DraggableComponent/styles.module.css
+++ b/packages/core/components/DraggableComponent/styles.module.css
@@ -46,6 +46,11 @@
   pointer-events: none;
 }
 
+.DraggableComponent:not(.DraggableComponent--isSelected)
+  > .DraggableComponent-overlay {
+  outline: 2px var(--puck-color-azure-8) solid;
+}
+
 .DraggableComponent--indicativeHover > .DraggableComponent-overlay {
   display: block;
   background: transparent; /* We only use backgrounds on natural hovers */

--- a/packages/core/components/DraggableComponent/styles.module.css
+++ b/packages/core/components/DraggableComponent/styles.module.css
@@ -11,6 +11,7 @@
 .DraggableComponent-contents {
   position: relative; /* Reset stacking context */
   pointer-events: none;
+  z-index: 0;
 }
 
 /* Prevent margin collapsing  */


### PR DESCRIPTION
Fixes 2 issues introduced in #132. Using `chore:` commits to avoid polluting diff.

## Overlay actions behind contents

### Before
<img width="342" alt="image" src="https://github.com/measuredco/puck/assets/985961/e751921e-aa4f-4f23-9d2a-4d82895c5fb5">

### After

<img width="314" alt="image" src="https://github.com/measuredco/puck/assets/985961/b67bf893-b67c-44ac-a2a0-2c1501ecc900">

## Missing outline on hover

### Before

<img width="373" alt="image" src="https://github.com/measuredco/puck/assets/985961/efd35ca3-e360-45da-85c7-f4a61e05166e">

### After

<img width="297" alt="image" src="https://github.com/measuredco/puck/assets/985961/10d4828e-844d-45b2-9593-32fd4dacf937">
