### PR TITLE
feat: make root and content optional in data, easing initalisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,7 @@ const config = {
 };
 
 // Describe the initial data
-const initialData = {
-  content: [],
-  root: {},
-};
+const initialData = {};
 
 // Save the data to your database
 const save = (data) => {};

--- a/packages/core/components/LayerTree/index.tsx
+++ b/packages/core/components/LayerTree/index.tsx
@@ -44,10 +44,10 @@ export const LayerTree = ({
         </div>
       )}
       <ul className={getClassName()}>
-        {zoneContent.length === 0 && (
+        {zoneContent?.length === 0 && (
           <div className={getClassName("helper")}>No items</div>
         )}
-        {zoneContent.map((item, i) => {
+        {zoneContent?.map((item, i) => {
           const isSelected =
             itemSelector?.index === i &&
             (itemSelector.zone === zone ||

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -328,7 +328,7 @@ export function Puck({
                           }}
                         >
                           <Heading rank={2} size="xs">
-                            {headerTitle || data.root.title || "Page"}
+                            {headerTitle || data.root?.title || "Page"}
                             {headerPath && (
                               <small style={{ fontWeight: 400, marginLeft: 4 }}>
                                 <code>{headerPath}</code>
@@ -581,10 +581,12 @@ export function Puck({
                                 name={fieldName}
                                 label={field.label}
                                 readOnly={
-                                  data.root._meta?.locked?.indexOf(fieldName) >
+                                  data.root?._meta?.locked?.indexOf(fieldName) >
                                   -1
                                 }
-                                value={data.root[fieldName]}
+                                value={
+                                  data.root ? data.root[fieldName] : undefined
+                                }
                                 onChange={onChange}
                               />
                             );

--- a/packages/core/components/Render/index.tsx
+++ b/packages/core/components/Render/index.tsx
@@ -8,7 +8,11 @@ export function Render({ config, data }: { config: Config; data: Data }) {
   if (config.root) {
     return (
       <DropZoneProvider value={{ data, config, mode: "render" }}>
-        <config.root.render {...data.root} editMode={false} id={"puck-root"}>
+        <config.root.render
+          {...(data.root || { title: "" })}
+          editMode={false}
+          id={"puck-root"}
+        >
           <DropZone zone={rootDroppableId} />
         </config.root.render>
       </DropZoneProvider>

--- a/packages/core/lib/get-item.ts
+++ b/packages/core/lib/get-item.ts
@@ -1,4 +1,4 @@
-import { Data } from "../types/Config";
+import { ContentItem, Data } from "../types/Config";
 import { rootDroppableId } from "./root-droppable-id";
 import { setupZone } from "./setup-zone";
 
@@ -10,8 +10,12 @@ export type ItemSelector = {
 export const getItem = (
   selector: ItemSelector,
   data: Data
-): Data["content"][0] | undefined => {
+): ContentItem | undefined => {
   if (!selector.zone || selector.zone === rootDroppableId) {
+    if (!data.content) {
+      return;
+    }
+
     return data.content[selector.index];
   }
 

--- a/packages/core/lib/reducer.ts
+++ b/packages/core/lib/reducer.ts
@@ -119,7 +119,7 @@ export const createReducer = ({ config }: { config: Config }): StateReducer =>
         return {
           ...data,
           content: insert(
-            data.content,
+            data.content || [],
             action.destinationIndex,
             emptyComponentData
           ),
@@ -164,7 +164,7 @@ export const createReducer = ({ config }: { config: Config }): StateReducer =>
       if (action.sourceZone === rootDroppableId) {
         return {
           ...dataWithRelatedDuplicated,
-          content: insert(data.content, action.sourceIndex + 1, newItem),
+          content: insert(data.content || [], action.sourceIndex + 1, newItem),
         };
       }
 
@@ -186,7 +186,7 @@ export const createReducer = ({ config }: { config: Config }): StateReducer =>
         return {
           ...data,
           content: reorder(
-            data.content,
+            data.content || [],
             action.sourceIndex,
             action.destinationIndex
           ),
@@ -270,7 +270,11 @@ export const createReducer = ({ config }: { config: Config }): StateReducer =>
       if (action.destinationZone === rootDroppableId) {
         return {
           ...data,
-          content: replace(data.content, action.destinationIndex, action.data),
+          content: replace(
+            data.content || [],
+            action.destinationIndex,
+            action.data
+          ),
         };
       }
 
@@ -301,7 +305,7 @@ export const createReducer = ({ config }: { config: Config }): StateReducer =>
       if (action.zone === rootDroppableId) {
         return {
           ...dataWithRelatedRemoved,
-          content: remove(data.content, action.index),
+          content: remove(data.content || [], action.index),
         };
       }
 

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -65,7 +65,7 @@ export type Fields<
 
 export type Content<
   Props extends { [key: string]: any } = { [key: string]: any }
-> = MappedItem<Props>[];
+> = ContentItem<Props>[];
 
 export type ComponentConfig<
   ComponentProps extends DefaultComponentProps = DefaultComponentProps,
@@ -92,13 +92,14 @@ export type Config<
   >;
 };
 
-type MappedItem<Props extends { [key: string]: any } = { [key: string]: any }> =
-  {
-    type: keyof Props;
-    props: WithId<{
-      [key: string]: any;
-    }>;
-  };
+export type ContentItem<
+  Props extends { [key: string]: any } = { [key: string]: any }
+> = {
+  type: keyof Props;
+  props: WithId<{
+    [key: string]: any;
+  }>;
+};
 
 export type Data<
   Props extends { [key: string]: any } = { [key: string]: any },
@@ -107,7 +108,7 @@ export type Data<
     [key: string]: any;
   }
 > = {
-  root: RootProps;
-  content: Content<Props>;
+  root?: RootProps;
+  content?: Content<Props>;
   zones?: Record<string, Content<Props>>;
 };


### PR DESCRIPTION
Follow on from #80, this makes `root` and `content` optional in the `Data` shape, making it simpler to instantiate Puck.

This was the original intention. Could also mark this as a `fix`. Could probably go either way.

## Before
```tsx
<Puck data={{ root: {}, content: [] }} config={config} />
```
## Now

```tsx
<Puck data={{}} config={config} />
```

CC @philipodev