### PR TITLE
Fix: `position: fixed;` elements escape editor

### DIFF
--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -456,6 +456,7 @@ export function Puck({
                       <div
                         style={{
                           border: "1px solid var(--puck-color-grey-8)",
+                          transform: "scale(1, 1)",
                         }}
                       >
                         <Page data={data} {...data.root}>


### PR DESCRIPTION
Added transform to root element so `position: fixed;` elements sit relative to it.

Pictured below is the `apps/demo` with the following added to the `config/root.tsx`.

```tsx
    <header
        style={{
          position: "fixed",
          top: 0,
          left: 0,
          width: "100%",
          backgroundColor: "white",
          zIndex: 1000,
        }}
      >
```

It doesn't behave like a `position: fixed;` element normally would due to the scrolling being on an element outside of the one with the transform, but it does allow you to access the editor navigation while you have a fixed navbar.

<img width="1005" alt="Screenshot 2023-10-07 at 22 53 13" src="https://github.com/measuredco/puck/assets/5850625/b0b9936d-91b6-4020-9787-1e3825bac823">
