### PR TITLE
Feature: restrict dragged/dropped components

### DIFF
--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -139,7 +139,7 @@ function DropZoneEdit<Props extends Record<string, any> = Record<string, any>>({
   if (
     draggedItem?.draggableId &&
     allow &&
-    !allow.includes(draggedItem?.draggableId)
+    !allow.includes(draggedItem.draggableId)
   ) {
     isEnabled = false;
   }
@@ -147,7 +147,7 @@ function DropZoneEdit<Props extends Record<string, any> = Record<string, any>>({
   if (
     draggedItem?.draggableId &&
     disallow &&
-    disallow.includes(draggedItem?.draggableId)
+    disallow.includes(draggedItem.draggableId)
   ) {
     isEnabled = false;
   }

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -13,14 +13,19 @@ const getClassName = getClassNameFactory("DropZone", styles);
 
 export { DropZoneProvider, dropZoneContext } from "./context";
 
-type DropZoneProps = {
+type DropZoneProps<Props extends Record<string, any> = Record<string, any>> = {
   zone: string;
-  allow?: readonly string[];
-  disallow?: readonly string[];
+  allow?: readonly (keyof Props)[];
+  disallow?: readonly (keyof Props)[];
   style?: CSSProperties;
 };
 
-function DropZoneEdit({ zone, allow, disallow, style }: DropZoneProps) {
+function DropZoneEdit<Props extends Record<string, any> = Record<string, any>>({
+  zone,
+  allow,
+  disallow,
+  style,
+}: DropZoneProps<Props>) {
   const ctx = useContext(dropZoneContext);
 
   const {
@@ -339,7 +344,9 @@ function DropZoneEdit({ zone, allow, disallow, style }: DropZoneProps) {
   );
 }
 
-function DropZoneRender({ zone }: DropZoneProps) {
+function DropZoneRender<
+  Props extends Record<string, any> = Record<string, any>
+>({ zone }: DropZoneProps<Props>) {
   const ctx = useContext(dropZoneContext);
 
   const { data, areaId = "root", config } = ctx || {};
@@ -378,7 +385,9 @@ function DropZoneRender({ zone }: DropZoneProps) {
   );
 }
 
-export function DropZone(props: DropZoneProps) {
+export function DropZone<
+  Props extends Record<string, any> = Record<string, any>
+>(props: DropZoneProps<Props>) {
   const ctx = useContext(dropZoneContext);
 
   if (ctx?.mode === "edit") {

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -15,10 +15,12 @@ export { DropZoneProvider, dropZoneContext } from "./context";
 
 type DropZoneProps = {
   zone: string;
+  allow?: readonly string[];
+  disallow?: readonly string[];
   style?: CSSProperties;
 };
 
-function DropZoneEdit({ zone, style }: DropZoneProps) {
+function DropZoneEdit({ zone, allow, disallow, style }: DropZoneProps) {
   const ctx = useContext(dropZoneContext);
 
   const {
@@ -127,6 +129,22 @@ function DropZoneEdit({ zone, style }: DropZoneProps) {
     } else {
       isEnabled = draggingOverArea && hoveringOverZone;
     }
+  }
+
+  if (
+    draggedItem?.draggableId &&
+    allow?.length &&
+    !allow.includes(draggedItem?.draggableId)
+  ) {
+    isEnabled = false;
+  }
+
+  if (
+    draggedItem?.draggableId &&
+    disallow?.length &&
+    disallow.includes(draggedItem?.draggableId)
+  ) {
+    isEnabled = false;
   }
 
   const selectedItem = itemSelector ? getItem(itemSelector, data) : null;

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -138,7 +138,7 @@ function DropZoneEdit<Props extends Record<string, any> = Record<string, any>>({
 
   if (
     draggedItem?.draggableId &&
-    allow?.length &&
+    allow &&
     !allow.includes(draggedItem?.draggableId)
   ) {
     isEnabled = false;
@@ -146,7 +146,7 @@ function DropZoneEdit<Props extends Record<string, any> = Record<string, any>>({
 
   if (
     draggedItem?.draggableId &&
-    disallow?.length &&
+    disallow &&
     disallow.includes(draggedItem?.draggableId)
   ) {
     isEnabled = false;


### PR DESCRIPTION
Resolves #103

Adds `allow` and `disallow` props to `DropZone`. Either of these can be an array of component names.

I have made `DropZone` generic so that you _can_ (but are not required to) restrict which component names can be provided in the `allow` and `disallow` props. This means that if/when you rename a component you are forced to update DropZones where it was referenced.

E.g.

```tsx
type Props = {
  ButtonGroup: ButtonGroupProps;
  Card: CardProps;
  Columns: ColumnsProps;
  Hero: HeroProps;
  Heading: HeadingProps;
  Flex: FlexProps;
  Logos: LogosProps;
  Stats: StatsProps;
  Text: TextProps;
  VerticalSpace: VerticalSpaceProps;
};

<DropZone<Props> zone={`column-${idx}`} allow={["ThisIsNotOkay"]} />
```