### PR TITLE
Enhancement(core/Puck): renderHeader

### DIFF
--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -77,6 +77,7 @@ export function Puck({
   renderHeader?: (props: {
     children: ReactNode;
     data: Data;
+    toggleLeftSidebar: (visible?: boolean) => void;
     dispatch: (action: PuckAction) => void;
   }) => ReactElement;
   renderHeaderActions?: (props: {
@@ -160,6 +161,10 @@ export function Puck({
   const { onDragStartOrUpdate, placeholderStyle } = usePlaceholderStyle();
 
   const [leftSidebarVisible, setLeftSidebarVisible] = useState(true);
+  const toggleLeftSidebar = (visible?: boolean) =>
+    typeof visible === "boolean"
+      ? setLeftSidebarVisible(visible)
+      : setLeftSidebarVisible(!leftSidebarVisible);
 
   const [draggedItem, setDraggedItem] = useState<
     DragStart & Partial<DragUpdate>
@@ -282,6 +287,7 @@ export function Puck({
                   >
                     {renderHeader ? (
                       renderHeader({
+                        toggleLeftSidebar,
                         children: (
                           <Button
                             onClick={() => {
@@ -312,9 +318,7 @@ export function Puck({
                           }}
                         >
                           <IconButton
-                            onClick={() =>
-                              setLeftSidebarVisible(!leftSidebarVisible)
-                            }
+                            onClick={() => toggleLeftSidebar()}
                             title="Toggle left sidebar"
                           >
                             <Sidebar />


### PR DESCRIPTION
# Problem
When customizing the header via ```renderHeader```, there is no way to control the Left Sidebar visibility
```jsx
// no way to control the header sidebar visibility
<Puck config={config} data={initialData} onPublish={save} renderHeader={({
 children, 
 data,
 dispatch 
 }) => ...} />
```

# Fix
- pass sidebar state toggle to the ```renderHeader```

usage example:
```diff
<Puck config={config} data={initialData} onPublish={save} renderHeader={({
 children, 
 data,
 dispatch,
+ toggleLeftSidebar
 }) => ...} />
```