### PR TITLE
fix: revert "fix: stop `position: fixed;` elements from escaping editor"

### DIFF
--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -456,7 +456,6 @@ export function Puck({
                       <div
                         style={{
                           border: "1px solid var(--puck-color-grey-8)",
-                          transform: "scale(1, 1)",
                         }}
                       >
                         <Page data={data} {...data.root}>


### PR DESCRIPTION
This reverts commit efa4f456458ea8aaab346b21e72dc521e9826279, introduced in #140, which introduces a bug that causes the position of dragged items to lose their position.