### PR TITLE
refactor: rename appData to state and appData.state to appData.ui

### DIFF
--- a/packages/core/components/InputOrGroup/fields/ArrayField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/ArrayField/index.tsx
@@ -27,9 +27,9 @@ export const ArrayField = ({
 }: InputProps) => {
   const [arrayFieldId] = useState(generateId("ArrayField"));
 
-  const { appData, setState } = useAppContext();
+  const { state, setUi } = useAppContext();
 
-  const arrayState: ArrayState = appData.state.arrayState[arrayFieldId] || {
+  const arrayState: ArrayState = state.ui.arrayState[arrayFieldId] || {
     items: Array.from(value).map<ItemWithId>((v) => ({
       _arrayId: generateId("ArrayItem"),
       data: v,
@@ -39,10 +39,10 @@ export const ArrayField = ({
 
   const setArrayState = useCallback(
     (newArrayState: Partial<ArrayState>, recordHistory: boolean = false) => {
-      setState(
+      setUi(
         {
           arrayState: {
-            ...appData.state.arrayState,
+            ...state.ui.arrayState,
             [arrayFieldId]: { ...arrayState, ...newArrayState },
           },
         },

--- a/packages/core/components/Puck/context.tsx
+++ b/packages/core/components/Puck/context.tsx
@@ -1,23 +1,23 @@
 import { createContext, useContext } from "react";
-import { AppData, AppState } from "../../types/Config";
+import { AppState, UiState } from "../../types/Config";
 import { PuckAction } from "../../reducer";
 import { getItem } from "../../lib/get-item";
 
-export const defaultAppData: AppData = {
+export const defaultAppState: AppState = {
   data: { content: [], root: { title: "" } },
-  state: {
+  ui: {
     leftSideBarVisible: true,
     arrayState: {},
   },
 };
 
 type AppContext = {
-  appData: AppData;
+  state: AppState;
   dispatch: (action: PuckAction) => void;
 };
 
 export const appContext = createContext<AppContext>({
-  appData: defaultAppData,
+  state: defaultAppState,
   dispatch: () => null,
 });
 
@@ -26,18 +26,18 @@ export const AppProvider = appContext.Provider;
 export const useAppContext = () => {
   const mainContext = useContext(appContext);
 
-  const selectedItem = mainContext.appData.state.itemSelector
-    ? getItem(mainContext.appData.state.itemSelector, mainContext.appData.data)
+  const selectedItem = mainContext.state.ui.itemSelector
+    ? getItem(mainContext.state.ui.itemSelector, mainContext.state.data)
     : undefined;
 
   return {
     ...mainContext,
     // Helpers
     selectedItem,
-    setState: (state: Partial<AppState>, recordHistory?: boolean) => {
+    setUi: (ui: Partial<UiState>, recordHistory?: boolean) => {
       return mainContext.dispatch({
-        type: "setState",
-        state,
+        type: "setUi",
+        ui,
         recordHistory,
       });
     },

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -9,7 +9,7 @@ import {
   useState,
 } from "react";
 import { DragDropContext, DragStart, DragUpdate } from "react-beautiful-dnd";
-import type { AppData, Config, Data, Field } from "../../types/Config";
+import type { AppState, Config, Data, Field } from "../../types/Config";
 import { InputOrGroup } from "../InputOrGroup";
 import { ComponentList } from "../ComponentList";
 import { filter } from "../../lib";
@@ -31,7 +31,7 @@ import { findZonesForArea } from "../../lib/find-zones-for-area";
 import { areaContainsZones } from "../../lib/area-contains-zones";
 import { flushZones } from "../../lib/flush-zones";
 import { usePuckHistory } from "../../lib/use-puck-history";
-import { AppProvider } from "./context";
+import { AppProvider, defaultAppState } from "./context";
 
 const Field = () => {};
 
@@ -89,33 +89,30 @@ export function Puck({
 }) {
   const [reducer] = useState(() => createReducer({ config }));
 
-  const initialAppData: AppData = {
+  const initialAppState: AppState = {
+    ...defaultAppState,
     data: initialData,
-    state: {
-      leftSideBarVisible: true,
-      arrayState: {},
-    },
   };
 
-  const [appData, dispatch] = useReducer<StateReducer>(
+  const [appState, dispatch] = useReducer<StateReducer>(
     reducer,
-    flushZones(initialAppData)
+    flushZones(initialAppState)
   );
 
-  const { data, state } = appData;
+  const { data, ui } = appState;
 
   const { canForward, canRewind, rewind, forward } = usePuckHistory({
-    appData,
+    appState,
     dispatch,
   });
 
-  const { itemSelector, leftSideBarVisible } = state;
+  const { itemSelector, leftSideBarVisible } = ui;
 
   const setItemSelector = useCallback(
     (newItemSelector: ItemSelector | null) => {
       dispatch({
-        type: "setState",
-        state: { itemSelector: newItemSelector },
+        type: "setUi",
+        ui: { itemSelector: newItemSelector },
       });
     },
     []
@@ -187,7 +184,7 @@ export function Puck({
 
   return (
     <div className="puck">
-      <AppProvider value={{ appData, dispatch }}>
+      <AppProvider value={{ state: appState, dispatch }}>
         <DragDropContext
           onDragUpdate={(update) => {
             setDraggedItem({ ...draggedItem, ...update });
@@ -325,8 +322,8 @@ export function Puck({
                             <IconButton
                               onClick={() =>
                                 dispatch({
-                                  type: "setState",
-                                  state: {
+                                  type: "setUi",
+                                  ui: {
                                     leftSideBarVisible: !leftSideBarVisible,
                                   },
                                 })

--- a/packages/core/components/SidebarSection/index.tsx
+++ b/packages/core/components/SidebarSection/index.tsx
@@ -21,7 +21,7 @@ export const SidebarSection = ({
   showBreadcrumbs?: boolean;
   noPadding?: boolean;
 }) => {
-  const { setState } = useAppContext();
+  const { setUi } = useAppContext();
   const breadcrumbs = useBreadcrumbs(1);
 
   return (
@@ -33,9 +33,7 @@ export const SidebarSection = ({
                 <div key={i} className={getClassName("breadcrumb")}>
                   <div
                     className={getClassName("breadcrumbLabel")}
-                    onClick={() =>
-                      setState({ itemSelector: breadcrumb.selector })
-                    }
+                    onClick={() => setUi({ itemSelector: breadcrumb.selector })}
                   >
                     {breadcrumb.label}
                   </div>

--- a/packages/core/lib/__tests__/use-puck-history.spec.tsx
+++ b/packages/core/lib/__tests__/use-puck-history.spec.tsx
@@ -1,13 +1,13 @@
 import { _recordHistory } from "../use-puck-history";
-import { AppData } from "../../types/Config";
-import { defaultAppData } from "../../components/Puck/context";
+import { AppState } from "../../types/Config";
+import { defaultAppState } from "../../components/Puck/context";
 
 const mockDispatch = jest.fn();
 
-const mockedAppData1: AppData = {
-  ...defaultAppData,
+const mockedAppState1: AppState = {
+  ...defaultAppState,
   data: {
-    ...defaultAppData.data,
+    ...defaultAppState.data,
     content: [
       {
         type: "MyComponent",
@@ -20,10 +20,10 @@ const mockedAppData1: AppData = {
   },
 };
 
-const mockedAppData2: AppData = {
-  ...defaultAppData,
+const mockedAppState2: AppState = {
+  ...defaultAppState,
   data: {
-    ...defaultAppData.data,
+    ...defaultAppState.data,
     content: [
       {
         type: "MyComponent",
@@ -36,7 +36,7 @@ const mockedAppData2: AppData = {
   },
 };
 
-const mockedAppDataArray1: AppData = {
+const mockedAppStateArray1: AppState = {
   data: {
     content: [
       {
@@ -54,7 +54,7 @@ const mockedAppDataArray1: AppData = {
     root: { title: "" },
     zones: {},
   },
-  state: {
+  ui: {
     leftSideBarVisible: true,
     arrayState: {
       "ArrayField-6f94973722d42695d4e7b8678e7dcca5affc70df": {
@@ -79,7 +79,7 @@ const mockedAppDataArray1: AppData = {
   },
 };
 
-const mockedAppDataArray2: AppData = {
+const mockedAppStateArray2: AppState = {
   data: {
     content: [
       {
@@ -96,7 +96,7 @@ const mockedAppDataArray2: AppData = {
     root: { title: "" },
     zones: {},
   },
-  state: {
+  ui: {
     leftSideBarVisible: true,
     arrayState: {
       "ArrayField-6f94973722d42695d4e7b8678e7dcca5affc70df": {
@@ -131,8 +131,8 @@ describe("usePuckHistory", () => {
     const record = (history) => histories.push(history);
 
     _recordHistory({
-      snapshot: mockedAppData1,
-      newSnapshot: mockedAppData2,
+      snapshot: mockedAppState1,
+      newSnapshot: mockedAppState2,
       dispatch: mockDispatch,
       record,
     });
@@ -142,7 +142,7 @@ describe("usePuckHistory", () => {
 
     expect(mockDispatch).toHaveBeenCalledWith({
       type: "set",
-      appData: mockedAppData1,
+      state: mockedAppState1,
     });
   });
 
@@ -153,8 +153,8 @@ describe("usePuckHistory", () => {
     };
 
     _recordHistory({
-      snapshot: mockedAppData1,
-      newSnapshot: mockedAppData2,
+      snapshot: mockedAppState1,
+      newSnapshot: mockedAppState2,
       dispatch: mockDispatch,
       record,
     });
@@ -163,7 +163,7 @@ describe("usePuckHistory", () => {
 
     expect(mockDispatch).toHaveBeenCalledWith({
       type: "set",
-      appData: mockedAppData2,
+      state: mockedAppState2,
     });
   });
 
@@ -172,8 +172,8 @@ describe("usePuckHistory", () => {
     const record = (history) => histories.push(history);
 
     _recordHistory({
-      snapshot: mockedAppDataArray1,
-      newSnapshot: mockedAppDataArray2,
+      snapshot: mockedAppStateArray1,
+      newSnapshot: mockedAppStateArray2,
       dispatch: mockDispatch,
       record,
     });
@@ -183,7 +183,7 @@ describe("usePuckHistory", () => {
 
     expect(mockDispatch).toHaveBeenCalledWith({
       type: "set",
-      appData: mockedAppDataArray1,
+      state: mockedAppStateArray1,
     });
   });
 
@@ -192,8 +192,8 @@ describe("usePuckHistory", () => {
     const record = (history) => histories.push(history);
 
     _recordHistory({
-      snapshot: mockedAppDataArray1,
-      newSnapshot: mockedAppDataArray2,
+      snapshot: mockedAppStateArray1,
+      newSnapshot: mockedAppStateArray2,
       dispatch: mockDispatch,
       record,
     });
@@ -202,7 +202,7 @@ describe("usePuckHistory", () => {
 
     expect(mockDispatch).toHaveBeenCalledWith({
       type: "set",
-      appData: mockedAppDataArray2,
+      state: mockedAppStateArray2,
     });
   });
 });

--- a/packages/core/lib/flush-zones.ts
+++ b/packages/core/lib/flush-zones.ts
@@ -1,28 +1,28 @@
-import type { AppData } from "../types/Config";
+import type { AppState } from "../types/Config";
 import { addToZoneCache } from "../reducer/data";
 
 /**
  * Flush out all zones and let them re-register using the zone cache
  *
- * @param appData initial app state
- * @returns appData with zones removed from data
+ * @param appState initial app state
+ * @returns appState with zones removed from data
  */
-export const flushZones = (appData: AppData): AppData => {
-  const containsZones = typeof appData.data.zones !== "undefined";
+export const flushZones = (appState: AppState): AppState => {
+  const containsZones = typeof appState.data.zones !== "undefined";
 
   if (containsZones) {
-    Object.keys(appData.data.zones || {}).forEach((zone) => {
-      addToZoneCache(zone, appData.data.zones![zone]);
+    Object.keys(appState.data.zones || {}).forEach((zone) => {
+      addToZoneCache(zone, appState.data.zones![zone]);
     });
 
     return {
-      ...appData,
+      ...appState,
       data: {
-        ...appData.data,
+        ...appState.data,
         zones: {},
       },
     };
   }
 
-  return appData;
+  return appState;
 };

--- a/packages/core/lib/use-breadcrumbs.ts
+++ b/packages/core/lib/use-breadcrumbs.ts
@@ -79,7 +79,7 @@ export const convertPathDataToBreadcrumbs = (
 
 export const useBreadcrumbs = (renderCount?: number) => {
   const {
-    appData: { data },
+    state: { data },
     selectedItem,
   } = useAppContext();
   const dzContext = useContext(dropZoneContext);

--- a/packages/core/lib/use-puck-history.ts
+++ b/packages/core/lib/use-puck-history.ts
@@ -1,4 +1,4 @@
-import type { AppData } from "../types/Config";
+import type { AppState } from "../types/Config";
 import { useEffect } from "react";
 import { PuckAction } from "../reducer";
 import { useActionHistory } from "./use-action-history";
@@ -9,25 +9,35 @@ import { useDebouncedCallback, useDebounce } from "use-debounce";
 const DEBOUNCE_TIME = 250;
 export const RECORD_DIFF = "RECORD_DIFF";
 export const historyEmitter = EventEmitter();
-export const recordDiff = (newAppData: AppData) =>
-  historyEmitter.emit(RECORD_DIFF, newAppData);
+export const recordDiff = (newAppState: AppState) =>
+  historyEmitter.emit(RECORD_DIFF, newAppState);
 
-export const _recordHistory = ({ snapshot, newSnapshot, record, dispatch }) => {
+export const _recordHistory = ({
+  snapshot,
+  newSnapshot,
+  record,
+  dispatch,
+}: {
+  snapshot: Partial<AppState>;
+  newSnapshot: Partial<AppState>;
+  record: (params: any) => void;
+  dispatch: (action: PuckAction) => void;
+}) => {
   record({
     forward: () => {
-      dispatch({ type: "set", appData: newSnapshot });
+      dispatch({ type: "set", state: newSnapshot });
     },
     rewind: () => {
-      dispatch({ type: "set", appData: snapshot });
+      dispatch({ type: "set", state: snapshot });
     },
   });
 };
 
 export function usePuckHistory({
-  appData,
+  appState,
   dispatch,
 }: {
-  appData: AppData;
+  appState: AppState;
   dispatch: (action: PuckAction) => void;
 }) {
   const { canForward, canRewind, rewind, forward, record } = useActionHistory();
@@ -36,12 +46,12 @@ export function usePuckHistory({
   useHotkeys("meta+shift+z", forward, { preventDefault: true });
   useHotkeys("meta+y", forward, { preventDefault: true });
 
-  const [snapshot] = useDebounce(appData, DEBOUNCE_TIME);
+  const [snapshot] = useDebounce(appState, DEBOUNCE_TIME);
 
-  const handleRecordDiff = useDebouncedCallback((newAppData: AppData) => {
+  const handleRecordDiff = useDebouncedCallback((newAppState: AppState) => {
     return _recordHistory({
       snapshot,
-      newSnapshot: newAppData,
+      newSnapshot: newAppState,
       record,
       dispatch,
     });

--- a/packages/core/reducer/__tests__/data.spec.tsx
+++ b/packages/core/reducer/__tests__/data.spec.tsx
@@ -10,10 +10,11 @@ import {
   UnregisterZoneAction,
   createReducer,
 } from "../../reducer";
-import { AppData, AppState, Config, Data } from "../../types/Config";
+import { AppState, Config, Data, UiState } from "../../types/Config";
 import { rootDroppableId } from "../../lib/root-droppable-id";
 
 import { generateId } from "../../lib/generate-id";
+import { defaultAppState } from "../../components/Puck/context";
 
 jest.mock("../../lib/generate-id");
 
@@ -26,10 +27,7 @@ type Props = {
 };
 const defaultData: Data = { root: { title: "" }, content: [], zones: {} };
 
-const defaultState: AppState = {
-  leftSideBarVisible: true,
-  arrayState: {},
-};
+const defaultUi: UiState = defaultAppState.ui;
 
 describe("Data reducer", () => {
   const config: Config<Props> = {
@@ -45,7 +43,7 @@ describe("Data reducer", () => {
 
   describe("insert action", () => {
     it("should insert into rootDroppableId", () => {
-      const state: AppData = { state: defaultState, data: { ...defaultData } };
+      const state: AppState = { ui: defaultUi, data: { ...defaultData } };
 
       const action: InsertAction = {
         type: "insert",
@@ -60,7 +58,7 @@ describe("Data reducer", () => {
     });
 
     it("should insert into a different zone", () => {
-      const state: AppData = { state: defaultState, data: { ...defaultData } };
+      const state: AppState = { ui: defaultUi, data: { ...defaultData } };
       const action: InsertAction = {
         type: "insert",
         componentType: "Comp",
@@ -80,8 +78,8 @@ describe("Data reducer", () => {
 
   describe("reorder action", () => {
     it("should reorder within rootDroppableId", () => {
-      const state: AppData = {
-        state: defaultState,
+      const state: AppState = {
+        ui: defaultUi,
         data: {
           ...defaultData,
           content: [
@@ -103,8 +101,8 @@ describe("Data reducer", () => {
     });
 
     it("should reorder within a different zone", () => {
-      const state: AppData = {
-        state: defaultState,
+      const state: AppState = {
+        ui: defaultUi,
         data: {
           ...defaultData,
           zones: {
@@ -130,8 +128,8 @@ describe("Data reducer", () => {
 
   describe("duplicate action", () => {
     it("should duplicate in content", () => {
-      const state: AppData = {
-        state: defaultState,
+      const state: AppState = {
+        ui: defaultUi,
         data: {
           ...defaultData,
           content: [
@@ -155,8 +153,8 @@ describe("Data reducer", () => {
     });
 
     it("should duplicate in a different zone", () => {
-      const state: AppData = {
-        state: defaultState,
+      const state: AppState = {
+        ui: defaultUi,
         data: {
           ...defaultData,
           zones: {
@@ -188,8 +186,8 @@ describe("Data reducer", () => {
 
       mockedGenerateId.mockImplementation(() => `mockId-${counter++}`);
 
-      const state: AppData = {
-        state: defaultState,
+      const state: AppState = {
+        ui: defaultUi,
         data: {
           ...defaultData,
           zones: {
@@ -266,8 +264,8 @@ describe("Data reducer", () => {
 
   describe("move action", () => {
     it("should move from rootDroppableId to another zone", () => {
-      const state: AppData = {
-        state: defaultState,
+      const state: AppState = {
+        ui: defaultUi,
         data: {
           ...defaultData,
           content: [{ type: "Comp", props: { id: "1" } }],
@@ -288,8 +286,8 @@ describe("Data reducer", () => {
     });
 
     it("should move from a zone to rootDroppableId", () => {
-      const state: AppData = {
-        state: defaultState,
+      const state: AppState = {
+        ui: defaultUi,
         data: {
           ...defaultData,
           content: [{ type: "Comp", props: { id: "1" } }],
@@ -310,8 +308,8 @@ describe("Data reducer", () => {
     });
 
     it("should move between two zones", () => {
-      const state: AppData = {
-        state: defaultState,
+      const state: AppState = {
+        ui: defaultUi,
         data: {
           ...defaultData,
           content: [],
@@ -339,8 +337,8 @@ describe("Data reducer", () => {
     const replacement = { type: "Comp", props: { id: "3" } };
 
     it("should replace in content", () => {
-      const state: AppData = {
-        state: defaultState,
+      const state: AppState = {
+        ui: defaultUi,
         data: {
           ...defaultData,
           content: [{ type: "Comp", props: { id: "1" } }],
@@ -359,8 +357,8 @@ describe("Data reducer", () => {
     });
 
     it("should replace in a zone", () => {
-      const state: AppData = {
-        state: defaultState,
+      const state: AppState = {
+        ui: defaultUi,
         data: {
           ...defaultData,
           zones: { zone1: [{ type: "Comp", props: { id: "1" } }] },
@@ -381,8 +379,8 @@ describe("Data reducer", () => {
 
   describe("remove action", () => {
     it("should remove from content", () => {
-      const state: AppData = {
-        state: defaultState,
+      const state: AppState = {
+        ui: defaultUi,
         data: {
           ...defaultData,
           content: [{ type: "Comp", props: { id: "1" } }],
@@ -399,8 +397,8 @@ describe("Data reducer", () => {
     });
 
     it("should remove from a zone", () => {
-      const state: AppData = {
-        state: defaultState,
+      const state: AppState = {
+        ui: defaultUi,
         data: {
           ...defaultData,
           zones: { zone1: [{ type: "Comp", props: { id: "1" } }] },
@@ -421,8 +419,8 @@ describe("Data reducer", () => {
 
       mockedGenerateId.mockImplementation(() => `mockId-${counter++}`);
 
-      const state: AppData = {
-        state: defaultState,
+      const state: AppState = {
+        ui: defaultUi,
         data: {
           ...defaultData,
           zones: {
@@ -466,8 +464,8 @@ describe("Data reducer", () => {
 
   describe("unregisterZone action", () => {
     it("should unregister a zone", () => {
-      const state: AppData = {
-        state: defaultState,
+      const state: AppState = {
+        ui: defaultUi,
         data: {
           ...defaultData,
           zones: { zone1: [{ type: "Comp", props: { id: "1" } }] },
@@ -486,8 +484,8 @@ describe("Data reducer", () => {
 
   describe("registerZone action", () => {
     it("should register a zone that's been previously unregistered", () => {
-      const state: AppData = {
-        state: defaultState,
+      const state: AppState = {
+        ui: defaultUi,
         data: {
           ...defaultData,
           zones: { zone1: [{ type: "Comp", props: { id: "1" } }] },
@@ -514,7 +512,7 @@ describe("Data reducer", () => {
 
   describe("set action", () => {
     it("should set new data", () => {
-      const state: AppData = { state: defaultState, data: { ...defaultData } };
+      const state: AppState = { ui: defaultUi, data: { ...defaultData } };
       const newData: Data = {
         ...defaultData,
         root: { title: "Hello, world" },

--- a/packages/core/reducer/__tests__/state.spec.tsx
+++ b/packages/core/reducer/__tests__/state.spec.tsx
@@ -1,16 +1,11 @@
+import { defaultAppState } from "../../components/Puck/context";
 import { SetStateAction, createReducer } from "../../reducer";
-import { AppData, AppState, Config, Data } from "../../types/Config";
+import { AppState, Config, Data, UiState } from "../../types/Config";
 
 type Props = {
   Comp: {
     prop: string;
   };
-};
-const defaultData: Data = { root: { title: "" }, content: [], zones: {} };
-
-const defaultState: AppState = {
-  leftSideBarVisible: true,
-  arrayState: {},
 };
 
 describe("State reducer", () => {
@@ -25,17 +20,17 @@ describe("State reducer", () => {
 
   const reducer = createReducer({ config });
 
-  describe("setState action", () => {
+  describe("setUi action", () => {
     it("should insert data into the state", () => {
-      const state: AppData = { state: defaultState, data: defaultData };
+      const state: AppState = defaultAppState;
 
       const action: SetStateAction = {
-        type: "setState",
-        state: { leftSideBarVisible: false },
+        type: "setUi",
+        ui: { leftSideBarVisible: false },
       };
 
       const newState = reducer(state, action);
-      expect(newState.state.leftSideBarVisible).toEqual(false);
+      expect(newState.ui.leftSideBarVisible).toEqual(false);
     });
   });
 });

--- a/packages/core/reducer/actions.tsx
+++ b/packages/core/reducer/actions.tsx
@@ -1,4 +1,4 @@
-import { AppData, AppState, Data } from "../types/Config";
+import { AppState, Data, UiState } from "../types/Config";
 
 export type InsertAction = {
   type: "insert";
@@ -42,8 +42,8 @@ export type RemoveAction = {
 };
 
 export type SetStateAction = {
-  type: "setState";
-  state: Partial<AppState>;
+  type: "setUi";
+  ui: Partial<UiState>;
 };
 
 export type SetDataAction = {
@@ -53,7 +53,7 @@ export type SetDataAction = {
 
 export type SetAction = {
   type: "set";
-  appData: Partial<AppData>;
+  state: Partial<AppState>;
 };
 
 export type RegisterZoneAction = {

--- a/packages/core/reducer/index.ts
+++ b/packages/core/reducer/index.ts
@@ -1,5 +1,5 @@
 import { Reducer } from "react";
-import { AppData, Config } from "../types/Config";
+import { AppState, Config } from "../types/Config";
 import { recordDiff } from "../lib/use-puck-history";
 import { reduceData } from "./data";
 import { PuckAction } from "./actions";
@@ -10,11 +10,11 @@ export * from "./data";
 
 export type ActionType = "insert" | "reorder";
 
-export type StateReducer = Reducer<AppData, PuckAction>;
+export type StateReducer = Reducer<AppState, PuckAction>;
 
 const storeInterceptor = (reducer: StateReducer) => {
-  return (appData: AppData, action: PuckAction) => {
-    const newAppData = reducer(appData, action);
+  return (state: AppState, action: PuckAction) => {
+    const newAppState = reducer(state, action);
 
     const isValidType = ![
       "registerZone",
@@ -29,21 +29,21 @@ const storeInterceptor = (reducer: StateReducer) => {
         ? action.recordHistory
         : isValidType
     ) {
-      recordDiff(newAppData);
+      recordDiff(newAppState);
     }
 
-    return newAppData;
+    return newAppState;
   };
 };
 
 export const createReducer = ({ config }: { config: Config }): StateReducer =>
-  storeInterceptor((appData, action) => {
-    const data = reduceData(appData.data, action, config);
-    const state = reduceState(appData.state, action);
+  storeInterceptor((state, action) => {
+    const data = reduceData(state.data, action, config);
+    const ui = reduceState(state.ui, action);
 
     if (action.type === "set") {
-      return { ...appData, ...action.appData };
+      return { ...state, ...action.state };
     }
 
-    return { data, state: state };
+    return { data, ui };
   });

--- a/packages/core/reducer/state.ts
+++ b/packages/core/reducer/state.ts
@@ -1,13 +1,13 @@
-import { AppState } from "../types/Config";
+import { UiState } from "../types/Config";
 import { PuckAction } from "./actions";
 
-export const reduceState = (state: AppState, action: PuckAction) => {
-  if (action.type === "setState") {
+export const reduceState = (ui: UiState, action: PuckAction) => {
+  if (action.type === "setUi") {
     return {
-      ...state,
-      ...action.state,
+      ...ui,
+      ...action.ui,
     };
   }
 
-  return state;
+  return ui;
 };

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -122,10 +122,10 @@ export type ItemWithId = {
 
 export type ArrayState = { items: ItemWithId[]; openId: string };
 
-export type AppState = {
+export type UiState = {
   leftSideBarVisible: boolean;
   itemSelector?: ItemSelector | null;
   arrayState: Record<string, ArrayState | undefined>;
 };
 
-export type AppData = { data: Data; state: AppState };
+export type AppState = { data: Data; ui: UiState };


### PR DESCRIPTION
Implements some renames following #153 

* appData -> state _because it's all state really_
* appData.state -> state.ui _because this is UI state only_
* appData.data -> state.data
* `setState` helper -> `setUi`
* `setState` action -> `setUi`

## Data model

### Before

```json
{
  "data": {}
  "state": {
    "leftSideBarVisible": false
  }
}
```

### After

```json
{
  "data": {}
  "ui": {
    "leftSideBarVisible": false
  }
}
```


##  setState Action

### Before

```tsx
dispatch({ type: "setState", state: {} });
```

### After

```tsx
dispatch({ type: "setUi", ui: {} });
```

## set Action

### Before

```tsx
dispatch({ type: "set", appData: {} });
```

### After

```tsx
dispatch({ type: "set", state: {} });
```


