### PR TITLE
chore: don't store history if no diff

### DIFF
--- a/packages/core/components/Puck/context.tsx
+++ b/packages/core/components/Puck/context.tsx
@@ -8,6 +8,7 @@ export const defaultAppState: AppState = {
   ui: {
     leftSideBarVisible: true,
     arrayState: {},
+    itemSelector: null,
   },
 };
 

--- a/packages/core/lib/use-puck-history.ts
+++ b/packages/core/lib/use-puck-history.ts
@@ -23,6 +23,8 @@ export const _recordHistory = ({
   record: (params: any) => void;
   dispatch: (action: PuckAction) => void;
 }) => {
+  if (JSON.stringify(snapshot) === JSON.stringify(newSnapshot)) return;
+
   record({
     forward: () => {
       dispatch({ type: "set", state: newSnapshot });

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -124,7 +124,7 @@ export type ArrayState = { items: ItemWithId[]; openId: string };
 
 export type UiState = {
   leftSideBarVisible: boolean;
-  itemSelector?: ItemSelector | null;
+  itemSelector: ItemSelector | null;
   arrayState: Record<string, ArrayState | undefined>;
 };
 


### PR DESCRIPTION
#154 resulted in history being stored unexpectedly, such as when the user clicks an empty page.

This does a dumb JSON diff to ensure the object has changed before storing the history. This is likely not that efficient, but will need to be improved when we reintroduced diffed history.