### PR TITLE
Expose state and dispatcher via API

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,11 @@ The plugin API follows a React paradigm. Each plugin passed to the Puck editor c
 - `renderRootFields` (`Component`): Render the root fields
 - `renderFields` (`Component`): Render the fields for the currently selected component
 
-Each render function receives the `children` prop, which you must render, and the `data` prop, which can be used to read the data model.
+Each render function receives three props:
+
+- **children** (`ReactNode`): The normal contents of the root or field. You must render this.
+- **state** (`AppState`): The current application state, including data and UI state
+- **dispatch** (`(action: PuckAction) => void`): The Puck dispatcher, used for making data changes or updating the UI. See the [action definitions](https://github.com/measuredco/puck/blob/main/packages/core/reducer/actions.tsx) for a full reference of available mutations.
 
 #### Example
 
@@ -285,9 +289,19 @@ A `Field` represents a user input field shown in the Puck interface.
   - **onChange** (`(value: any) => void`): Callback to change the value
   - **readOnly** (`boolean` | `undefined`): Whether or not the field should be in readOnly mode
 
+### `AppState`
+
+The `AppState` object stores the puck application state.
+
+- **data** (`Data`): The page data currently being rendered
+- **ui** (`object`):
+  - **leftSideBarVisible** (boolean): Whether or not the left side bar is visible
+  - **itemSelector** (object): An object describing which item is selected
+  - **arrayState** (object): An object describing the internal state of array items
+
 ### `Data`
 
-The `Data` object stores the puck state.
+The `Data` object stores the puck page data.
 
 - **root** (`object`):
   - **title** (string): Title of the content, typically used for the page title

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -77,11 +77,11 @@ export function Puck({
   plugins?: Plugin[];
   renderHeader?: (props: {
     children: ReactNode;
-    data: Data;
     dispatch: (action: PuckAction) => void;
+    state: AppState;
   }) => ReactElement;
   renderHeaderActions?: (props: {
-    data: Data;
+    state: AppState;
     dispatch: (action: PuckAction) => void;
   }) => ReactElement;
   headerTitle?: string;
@@ -300,8 +300,8 @@ export function Puck({
                               Publish
                             </Button>
                           ),
-                          data,
                           dispatch,
+                          state: appState,
                         })
                       ) : (
                         <div
@@ -389,7 +389,10 @@ export function Puck({
                               </IconButton>
                             </div>
                             {renderHeaderActions &&
-                              renderHeaderActions({ data, dispatch })}
+                              renderHeaderActions({
+                                state: appState,
+                                dispatch,
+                              })}
                             <Button
                               onClick={() => {
                                 onPublish(data);

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -41,12 +41,12 @@ const defaultPageFields: Record<string, Field> = {
 
 const PluginRenderer = ({
   children,
-  data,
+  state,
   plugins,
   renderMethod,
 }: {
   children: ReactNode;
-  data: Data;
+  state: AppState;
   plugins;
   renderMethod: "renderRoot" | "renderRootFields" | "renderFields";
 }) => {
@@ -54,7 +54,7 @@ const PluginRenderer = ({
     .filter((item) => item[renderMethod])
     .map((item) => item[renderMethod])
     .reduce(
-      (accChildren, Item) => <Item data={data}>{accChildren}</Item>,
+      (accChildren, Item) => <Item state={state}>{accChildren}</Item>,
       children
     );
 };
@@ -125,7 +125,7 @@ export function Puck({
       <PluginRenderer
         plugins={plugins}
         renderMethod="renderRoot"
-        data={pageProps.data}
+        state={pageProps.state}
       >
         {config.root?.render
           ? config.root?.render({ ...pageProps, editMode: true })
@@ -140,7 +140,7 @@ export function Puck({
       <PluginRenderer
         plugins={plugins}
         renderMethod="renderRootFields"
-        data={props.data}
+        state={props.state}
       >
         {props.children}
       </PluginRenderer>
@@ -153,7 +153,7 @@ export function Puck({
       <PluginRenderer
         plugins={plugins}
         renderMethod="renderFields"
-        data={props.data}
+        state={props.state}
       >
         {props.children}
       </PluginRenderer>
@@ -477,7 +477,7 @@ export function Puck({
                             border: "1px solid var(--puck-color-grey-8)",
                           }}
                         >
-                          <Page data={data} {...data.root}>
+                          <Page state={appState} {...data.root}>
                             <DropZone zone={rootDroppableId} />
                           </Page>
                         </div>
@@ -502,7 +502,7 @@ export function Puck({
                         background: "var(--puck-color-white)",
                       }}
                     >
-                      <FieldWrapper data={data}>
+                      <FieldWrapper state={appState}>
                         <SidebarSection
                           noPadding
                           showBreadcrumbs

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -41,11 +41,13 @@ const defaultPageFields: Record<string, Field> = {
 
 const PluginRenderer = ({
   children,
+  dispatch,
   state,
   plugins,
   renderMethod,
 }: {
   children: ReactNode;
+  dispatch: (action: PuckAction) => void;
   state: AppState;
   plugins;
   renderMethod: "renderRoot" | "renderRootFields" | "renderFields";
@@ -54,7 +56,11 @@ const PluginRenderer = ({
     .filter((item) => item[renderMethod])
     .map((item) => item[renderMethod])
     .reduce(
-      (accChildren, Item) => <Item state={state}>{accChildren}</Item>,
+      (accChildren, Item) => (
+        <Item dispatch={dispatch} state={state}>
+          {accChildren}
+        </Item>
+      ),
       children
     );
 };
@@ -125,6 +131,7 @@ export function Puck({
       <PluginRenderer
         plugins={plugins}
         renderMethod="renderRoot"
+        dispatch={pageProps.dispatch}
         state={pageProps.state}
       >
         {config.root?.render
@@ -140,6 +147,7 @@ export function Puck({
       <PluginRenderer
         plugins={plugins}
         renderMethod="renderRootFields"
+        dispatch={props.dispatch}
         state={props.state}
       >
         {props.children}
@@ -153,6 +161,7 @@ export function Puck({
       <PluginRenderer
         plugins={plugins}
         renderMethod="renderFields"
+        dispatch={props.dispatch}
         state={props.state}
       >
         {props.children}
@@ -477,7 +486,11 @@ export function Puck({
                             border: "1px solid var(--puck-color-grey-8)",
                           }}
                         >
-                          <Page state={appState} {...data.root}>
+                          <Page
+                            dispatch={dispatch}
+                            state={appState}
+                            {...data.root}
+                          >
                             <DropZone zone={rootDroppableId} />
                           </Page>
                         </div>
@@ -502,7 +515,7 @@ export function Puck({
                         background: "var(--puck-color-white)",
                       }}
                     >
-                      <FieldWrapper state={appState}>
+                      <FieldWrapper dispatch={dispatch} state={appState}>
                         <SidebarSection
                           noPadding
                           showBreadcrumbs

--- a/packages/core/types/Plugin.ts
+++ b/packages/core/types/Plugin.ts
@@ -1,17 +1,17 @@
 import { ReactElement, ReactNode } from "react";
-import { Data } from "./Config";
+import { AppState } from "./Config";
 
 export type Plugin = {
   renderRootFields?: (props: {
     children: ReactNode;
-    data: Data;
+    state: AppState;
   }) => ReactElement<any>;
   renderRoot?: (props: {
     children: ReactNode;
-    data: Data;
+    state: AppState;
   }) => ReactElement<any>;
   renderFields?: (props: {
     children: ReactNode;
-    data: Data;
+    state: AppState;
   }) => ReactElement<any>;
 };

--- a/packages/core/types/Plugin.ts
+++ b/packages/core/types/Plugin.ts
@@ -1,17 +1,21 @@
 import { ReactElement, ReactNode } from "react";
 import { AppState } from "./Config";
+import { PuckAction } from "../reducer";
 
 export type Plugin = {
   renderRootFields?: (props: {
     children: ReactNode;
+    dispatch: (action: PuckAction) => void;
     state: AppState;
   }) => ReactElement<any>;
   renderRoot?: (props: {
     children: ReactNode;
+    dispatch: (action: PuckAction) => void;
     state: AppState;
   }) => ReactElement<any>;
   renderFields?: (props: {
     children: ReactNode;
+    dispatch: (action: PuckAction) => void;
     state: AppState;
   }) => ReactElement<any>;
 };

--- a/packages/plugin-heading-analyzer/src/HeadingAnalyzer.tsx
+++ b/packages/plugin-heading-analyzer/src/HeadingAnalyzer.tsx
@@ -8,6 +8,7 @@ import { OutlineList } from "@measured/puck/components/OutlineList";
 import { scrollIntoView } from "@measured/puck/lib/scroll-into-view";
 
 import ReactFromJSON from "react-from-json";
+import { PuckAction } from "@measured/puck/reducer";
 
 const dataAttr = "data-puck-heading-analyzer-id";
 
@@ -93,6 +94,7 @@ const HeadingOutlineAnalyer = ({
 }: {
   children: ReactNode;
   state: AppState;
+  dispatch: (action: PuckAction) => void;
 }) => {
   const { data } = state;
   const [hierarchy, setHierarchy] = useState<Block[]>([]);

--- a/packages/plugin-heading-analyzer/src/HeadingAnalyzer.tsx
+++ b/packages/plugin-heading-analyzer/src/HeadingAnalyzer.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, ReactNode, useEffect, useState } from "react";
 
-import { Data } from "@measured/puck";
+import { AppState } from "@measured/puck";
 import { Plugin } from "@measured/puck/types/Plugin";
 import { SidebarSection } from "@measured/puck/components/SidebarSection";
 import { OutlineList } from "@measured/puck/components/OutlineList";
@@ -89,11 +89,12 @@ function buildHierarchy(): Block[] {
 
 const HeadingOutlineAnalyer = ({
   children,
-  data,
+  state,
 }: {
   children: ReactNode;
-  data: Data;
+  state: AppState;
 }) => {
+  const { data } = state;
   const [hierarchy, setHierarchy] = useState<Block[]>([]);
   const [firstRender, setFirstRender] = useState(true);
 


### PR DESCRIPTION
This PR exposes the application `state` (`AppState`) and dispatcher to:

1. The `renderHeader` method
2. The `renderHeaderActions` method
3. All plugins

This enables users to read and mutate both the application state _and_ the data object.

It also removes the `data` parameter from all APIs, as this is accessible under `state.data`. This is a breaking change, but we're below v1 and are not currently highlighting these.

## Example

This example plugin creates a button to toggle the left side-bar:

```jsx
const myPlugin = {
  renderRootFields: ({ children, dispatch, state }) => (
    <div>
      {children}

      <button
        onClick={() => {
          dispatch({
            type: "setUi",
            ui: { leftSideBarVisible: !state.ui.leftSideBarVisible },
          });
        }}
      >
        Toggle side-bar
      </button>
    </div>
  ),
};
```

https://github.com/measuredco/puck/assets/985961/6301222b-00ff-477a-8d2c-70edce207282

---

Closes #152
Closes #18 