### PR TITLE
feat: reload externals when the modal is opened

### DIFF
--- a/packages/core/components/ExternalInput/index.tsx
+++ b/packages/core/components/ExternalInput/index.tsx
@@ -42,7 +42,7 @@ export const ExternalInput = ({
         }
       }
     })();
-  }, [field.adaptor, field.adaptorParams]);
+  }, [field.adaptor, field.adaptorParams, isOpen]);
 
   if (!field.adaptor) {
     return <div>Incorrectly configured</div>;


### PR DESCRIPTION
Currently, a full reload is requred to refresh the items in the `ExternaInput` item list. I would like to access the most up-to-date version of this data, whenever I open the modal