### PR TITLE
feat: add categories API

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,11 @@ The plugin API follows a React paradigm. Each plugin passed to the Puck editor c
 - `renderRoot` (`Component`): Render the root node of the preview content
 - `renderRootFields` (`Component`): Render the root fields
 - `renderFields` (`Component`): Render the fields for the currently selected component
+- `renderComponentList` (`Component`): Render the component list
 
 Each render function receives three props:
 
-- **children** (`ReactNode`): The normal contents of the root or field. You must render this.
+- **children** (`ReactNode`): The normal contents of the root or field. You must render this if provided.
 - **state** (`AppState`): The current application state, including data and UI state
 - **dispatch** (`(action: PuckAction) => void`): The Puck dispatcher, used for making data changes or updating the UI. See the [action definitions](https://github.com/measuredco/puck/blob/main/packages/core/reducer/actions.tsx) for a full reference of available mutations.
 
@@ -241,6 +242,7 @@ The `<Puck>` component renders the Puck editor.
 - **data** (`Data`): Initial data to render
 - **onChange** (`(Data) => void` [optional]): Callback that triggers when the user makes a change
 - **onPublish** (`(Data) => void` [optional]): Callback that triggers when the user hits the "Publish" button
+- **renderComponentList** (`Component` [optional]): Render function for wrapping the component list
 - **renderHeader** (`Component` [optional]): Render function for overriding the Puck header component
 - **renderHeaderActions** (`Component` [optional]): Render function for overriding the Puck header actions. Use a fragment.
 - **headerTitle** (`string` [optional]): Set the title shown in the header title
@@ -313,6 +315,11 @@ The `AppState` object stores the puck application state.
   - **leftSideBarVisible** (boolean): Whether or not the left side bar is visible
   - **itemSelector** (object): An object describing which item is selected
   - **arrayState** (object): An object describing the internal state of array items
+  - **componentList** (object): An object describing the component list. Similar shape to `Config.categories`.
+    - **components** (`sting[]`, [optional]): Array containing the names of components in this category
+    - **title** (`sting`, [optional]): Title of the category
+    - **visible** (`boolean`, [optional]): Whether or not the category is visible in the side bar
+    - **expanded** (`boolean`, [optional]): Whether or not the category is expanded in the side bar
 
 ### `Data`
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,12 @@ The `Config` object describes which components Puck should render, how they shou
     - **fields** (`Field`): The Field objects describing the input data stored against this component.
     - **render** (`Component`): Render function for your React component. Receives props as defined in fields.
     - **defaultProps** (`object` [optional]): Default props to pass to your component. Will show in fields.
+- **categories** (`object`): Component categories for rendering in the side bar or restricting in DropZones
+  - **[categoryName]** (`object`)
+    - **components** (`sting[]`, [optional]): Array containing the names of components in this category
+    - **title** (`sting`, [optional]): Title of the category
+    - **visible** (`boolean`, [optional]): Whether or not the category should be visible in the side bar
+    - **defaultExpanded** (`boolean`, [optional]): Whether or not the category should be expanded in the side bar by default
 
 ### `Field`
 

--- a/apps/demo/app/[...puckPath]/client.tsx
+++ b/apps/demo/app/[...puckPath]/client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Config, Data } from "@measured/puck";
+import { Data } from "@measured/puck/types/Config";
 import { Puck } from "@measured/puck/components/Puck";
 import { Render } from "@measured/puck/components/Render";
 import { useEffect, useState } from "react";
@@ -40,7 +40,7 @@ export function Client({ path, isEdit }: { path: string; isEdit: boolean }) {
     return (
       <div>
         <Puck
-          config={config as Config}
+          config={config}
           data={data}
           onPublish={async (data: Data) => {
             localStorage.setItem(key, JSON.stringify(data));
@@ -60,7 +60,7 @@ export function Client({ path, isEdit }: { path: string; isEdit: boolean }) {
   }
 
   if (data) {
-    return <Render config={config as Config} data={data} />;
+    return <Render config={config} data={data} />;
   }
 
   return (

--- a/apps/demo/config/blocks/ButtonGroup/index.tsx
+++ b/apps/demo/config/blocks/ButtonGroup/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @next/next/no-img-element */
 import React from "react";
-import { ComponentConfig } from "@measured/puck";
+import { ComponentConfig } from "@measured/puck/types/Config";
 import styles from "./styles.module.css";
 import { getClassNameFactory } from "@measured/puck/lib";
 import { Button } from "@measured/puck/components/Button";

--- a/apps/demo/config/index.tsx
+++ b/apps/demo/config/index.tsx
@@ -1,4 +1,4 @@
-import { Config, Data } from "@measured/puck";
+import { Config, Data } from "@measured/puck/types/Config";
 import { ButtonGroup, ButtonGroupProps } from "./blocks/ButtonGroup";
 import { Card, CardProps } from "./blocks/Card";
 import { Columns, ColumnsProps } from "./blocks/Columns";
@@ -29,6 +29,18 @@ type Props = {
 export const conf: Config<Props, RootProps> = {
   root: {
     render: Root,
+  },
+  categories: {
+    layout: {
+      components: ["Columns", "Flex", "VerticalSpace"],
+    },
+    typography: {
+      components: ["Heading", "Text"],
+    },
+    interactive: {
+      title: "Actions",
+      components: ["ButtonGroup"],
+    },
   },
   components: {
     ButtonGroup,

--- a/packages/core/components/ComponentList/index.tsx
+++ b/packages/core/components/ComponentList/index.tsx
@@ -14,15 +14,17 @@ const getClassNameItem = getClassNameFactory("ComponentListItem", styles);
 const ComponentListItem = ({
   component,
   index,
+  id,
 }: {
   component: string;
   index: number;
+  id: string;
 }) => {
   return (
     <div className={getClassNameItem()}>
       <Draggable
         key={component}
-        id={component}
+        id={id}
         index={index}
         showShadow
         disableAnimations
@@ -102,6 +104,7 @@ const ComponentList = ({
                       key={componentKey}
                       component={componentKey}
                       index={i}
+                      id={componentKey}
                     />
                   );
                 })}

--- a/packages/core/components/ComponentList/index.tsx
+++ b/packages/core/components/ComponentList/index.tsx
@@ -1,49 +1,110 @@
 import DroppableStrictMode from "../DroppableStrictMode";
-import { Config } from "../../types/Config";
 
 import styles from "./styles.module.css";
 import getClassNameFactory from "../../lib/get-class-name-factory";
 import { Draggable } from "../Draggable";
 import { DragIcon } from "../DragIcon";
+import { ReactNode, useState } from "react";
+import { useAppContext } from "../Puck/context";
+import { ChevronDown, ChevronUp } from "react-feather";
 
 const getClassName = getClassNameFactory("ComponentList", styles);
+const getClassNameItem = getClassNameFactory("ComponentListItem", styles);
 
-export const ComponentList = ({ config }: { config: Config }) => {
+const ComponentListItem = ({
+  component,
+  index,
+}: {
+  component: string;
+  index: number;
+}) => {
   return (
-    <DroppableStrictMode droppableId="component-list" isDropDisabled>
-      {(provided, snapshot) => (
-        <div
-          {...provided.droppableProps}
-          ref={provided.innerRef}
-          className={getClassName({
-            isDraggingFrom: !!snapshot.draggingFromThisWith,
-          })}
-        >
-          {Object.keys(config.components).map((componentKey, i) => {
-            return (
-              <Draggable
-                key={componentKey}
-                id={componentKey}
-                index={i}
-                showShadow
-                disableAnimations
-                className={() => getClassName("item")}
-              >
-                {() => (
-                  <>
-                    {componentKey}
-                    <div className={getClassName("itemIcon")}>
-                      <DragIcon />
-                    </div>
-                  </>
-                )}
-              </Draggable>
-            );
-          })}
-          {/* Use different element so we don't clash with :last-of-type */}
-          <span style={{ display: "none" }}>{provided.placeholder}</span>
-        </div>
-      )}
-    </DroppableStrictMode>
+    <div className={getClassNameItem()}>
+      <Draggable
+        key={component}
+        id={component}
+        index={index}
+        showShadow
+        disableAnimations
+        className={() => getClassNameItem("draggable")}
+      >
+        {() => (
+          <>
+            {component}
+            <div className={getClassNameItem("icon")}>
+              <DragIcon />
+            </div>
+          </>
+        )}
+      </Draggable>
+    </div>
   );
 };
+
+const ComponentList = ({
+  children,
+  title,
+  defaultExpanded = true,
+}: {
+  children?: ReactNode;
+  title?: string;
+  defaultExpanded?: boolean;
+}) => {
+  const { config } = useAppContext();
+
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+
+  return (
+    <div className={getClassName({ isExpanded })}>
+      {title && (
+        <div
+          className={getClassName("title")}
+          onClick={() => setIsExpanded(!isExpanded)}
+          title={
+            isExpanded
+              ? `Collapse${title ? ` ${title}` : ""}`
+              : `Expand${title ? ` ${title}` : ""}`
+          }
+        >
+          <div>{title}</div>
+          <div className={getClassName("titleIcon")}>
+            {isExpanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+          </div>
+        </div>
+      )}
+      <div className={getClassName("content")}>
+        <DroppableStrictMode
+          droppableId={`component-list${title ? `:${title}` : ""}`}
+          isDropDisabled
+        >
+          {(provided, snapshot) => (
+            <div
+              {...provided.droppableProps}
+              ref={provided.innerRef}
+              className={getClassName({
+                isDraggingFrom: !!snapshot.draggingFromThisWith,
+              })}
+            >
+              {children ||
+                Object.keys(config.components).map((componentKey, i) => {
+                  return (
+                    <ComponentListItem
+                      key={componentKey}
+                      component={componentKey}
+                      index={i}
+                    />
+                  );
+                })}
+              {/* Use different element so we don't clash with :last-of-type */}
+              <span style={{ display: "none" }}>{provided.placeholder}</span>
+            </div>
+          )}
+        </DroppableStrictMode>
+      </div>
+    </div>
+  );
+};
+
+ComponentList.Item = ComponentListItem;
+
+export { ComponentList };

--- a/packages/core/components/ComponentList/index.tsx
+++ b/packages/core/components/ComponentList/index.tsx
@@ -4,7 +4,7 @@ import styles from "./styles.module.css";
 import getClassNameFactory from "../../lib/get-class-name-factory";
 import { Draggable } from "../Draggable";
 import { DragIcon } from "../DragIcon";
-import { ReactNode, useState } from "react";
+import { ReactNode } from "react";
 import { useAppContext } from "../Puck/context";
 import { ChevronDown, ChevronUp } from "react-feather";
 
@@ -44,31 +44,41 @@ const ComponentListItem = ({
 const ComponentList = ({
   children,
   title,
-  defaultExpanded = true,
+  id,
 }: {
+  id: string;
   children?: ReactNode;
   title?: string;
-  defaultExpanded?: boolean;
 }) => {
-  const { config } = useAppContext();
+  const { config, state, setUi } = useAppContext();
 
-  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+  const { expanded = true } = state.ui.componentList[id] || {};
 
   return (
-    <div className={getClassName({ isExpanded })}>
+    <div className={getClassName({ isExpanded: expanded })}>
       {title && (
         <div
           className={getClassName("title")}
-          onClick={() => setIsExpanded(!isExpanded)}
+          onClick={() =>
+            setUi({
+              componentList: {
+                ...state.ui.componentList,
+                [id]: {
+                  ...state.ui.componentList[id],
+                  expanded: !expanded,
+                },
+              },
+            })
+          }
           title={
-            isExpanded
+            expanded
               ? `Collapse${title ? ` ${title}` : ""}`
               : `Expand${title ? ` ${title}` : ""}`
           }
         >
           <div>{title}</div>
           <div className={getClassName("titleIcon")}>
-            {isExpanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+            {expanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
           </div>
         </div>
       )}

--- a/packages/core/components/ComponentList/styles.module.css
+++ b/packages/core/components/ComponentList/styles.module.css
@@ -3,7 +3,48 @@
   max-width: 100%;
 }
 
-.ComponentList-item {
+.ComponentList--isExpanded + .ComponentList {
+  margin-top: 12px;
+}
+
+.ComponentList-content {
+  display: none;
+}
+
+.ComponentList--isExpanded > .ComponentList-content {
+  display: block;
+}
+
+.ComponentList-title {
+  color: var(--puck-color-grey-4);
+  display: flex;
+  font-size: var(--puck-font-size-xxxs);
+  list-style: none;
+  padding: 8px;
+  text-transform: uppercase;
+  gap: 4px;
+  border-radius: 4px;
+}
+
+.ComponentList--isExpanded .ComponentList-title {
+  margin-bottom: 4px;
+}
+
+.ComponentList-title:hover {
+  background-color: var(--puck-color-azure-9);
+  color: var(--puck-color-azure-4);
+  cursor: pointer;
+}
+
+.ComponentList-titleIcon {
+  margin-left: auto;
+}
+
+.ComponentListItem:last-of-type .ComponentListItem-draggable {
+  margin-bottom: 0px;
+}
+
+.ComponentListItem-draggable {
   background: white;
   padding: 12px;
   display: flex;
@@ -17,15 +58,12 @@
   margin-bottom: 12px;
 }
 
-.ComponentList-item:last-of-type {
-  margin-bottom: 0px;
-}
-
-.ComponentList-itemIcon {
+.ComponentListItemIcon {
   color: var(--puck-color-grey-4);
 }
 
-.ComponentList:not(.ComponentList--isDraggingFrom) .ComponentList-item:hover {
+.ComponentList:not(.ComponentList--isDraggingFrom)
+  .ComponentListItem-draggable:hover {
   background-color: var(--puck-color-azure-9);
   color: var(--puck-color-azure-4);
 }

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -80,7 +80,7 @@ function DropZoneEdit({ zone, style }: DropZoneProps) {
 
   const userIsDragging = !!draggedItem;
   const draggingOverArea = userIsDragging && zoneArea === draggedSourceArea;
-  const draggingNewComponent = draggedSourceId === "component-list";
+  const draggingNewComponent = draggedSourceId?.startsWith("component-list");
 
   if (
     !ctx?.config ||

--- a/packages/core/components/InputOrGroup/fields/ArrayField/styles.module.css
+++ b/packages/core/components/InputOrGroup/fields/ArrayField/styles.module.css
@@ -97,10 +97,6 @@
   color: var(--puck-color-azure-4);
 }
 
-.ArrayFieldItem-summary::-webkit-details-marker {
-  display: none;
-}
-
 .ArrayFieldItem-body {
   display: none;
 }

--- a/packages/core/components/Puck/context.tsx
+++ b/packages/core/components/Puck/context.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext } from "react";
-import { AppState, UiState } from "../../types/Config";
+import { AppState, Config, UiState } from "../../types/Config";
 import { PuckAction } from "../../reducer";
 import { getItem } from "../../lib/get-item";
 
@@ -15,11 +15,13 @@ export const defaultAppState: AppState = {
 type AppContext = {
   state: AppState;
   dispatch: (action: PuckAction) => void;
+  config: Config;
 };
 
 export const appContext = createContext<AppContext>({
   state: defaultAppState,
   dispatch: () => null,
+  config: { components: {} },
 });
 
 export const AppProvider = appContext.Provider;

--- a/packages/core/components/Puck/context.tsx
+++ b/packages/core/components/Puck/context.tsx
@@ -9,6 +9,7 @@ export const defaultAppState: AppState = {
     leftSideBarVisible: true,
     arrayState: {},
     itemSelector: null,
+    componentList: {},
   },
 };
 

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -272,9 +272,11 @@ export function Puck({
               droppedItem.source.droppableId.startsWith("component-list") &&
               droppedItem.destination
             ) {
+              const [_, componentId] = droppedItem.draggableId.split("::");
+
               dispatch({
                 type: "insert",
-                componentType: droppedItem.draggableId,
+                componentType: componentId || droppedItem.draggableId,
                 destinationIndex: droppedItem.destination!.index,
                 destinationZone: droppedItem.destination.droppableId,
               });

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -32,6 +32,7 @@ import { areaContainsZones } from "../../lib/area-contains-zones";
 import { flushZones } from "../../lib/flush-zones";
 import { usePuckHistory } from "../../lib/use-puck-history";
 import { AppProvider, defaultAppState } from "./context";
+import { useComponentList } from "../../lib/use-component-list";
 
 const Field = () => {};
 
@@ -191,9 +192,11 @@ export function Puck({
     DragStart & Partial<DragUpdate>
   >();
 
+  const componentList = useComponentList(config);
+
   return (
     <div className="puck">
-      <AppProvider value={{ state: appState, dispatch }}>
+      <AppProvider value={{ state: appState, dispatch, config }}>
         <DragDropContext
           onDragUpdate={(update) => {
             setDraggedItem({ ...draggedItem, ...update });
@@ -213,7 +216,7 @@ export function Puck({
 
             // New component
             if (
-              droppedItem.source.droppableId === "component-list" &&
+              droppedItem.source.droppableId.startsWith("component-list") &&
               droppedItem.destination
             ) {
               dispatch({
@@ -425,7 +428,7 @@ export function Puck({
                       }}
                     >
                       <SidebarSection title="Components">
-                        <ComponentList config={config} />
+                        {componentList ? componentList : <ComponentList />}
                       </SidebarSection>
                       <SidebarSection title="Outline">
                         {ctx?.activeZones &&

--- a/packages/core/lib/__tests__/use-puck-history.spec.tsx
+++ b/packages/core/lib/__tests__/use-puck-history.spec.tsx
@@ -76,6 +76,7 @@ const mockedAppStateArray1: AppState = {
       },
     },
     itemSelector: { index: 0, zone: "default-zone" },
+    componentList: {},
   },
 };
 
@@ -118,6 +119,7 @@ const mockedAppStateArray2: AppState = {
       },
     },
     itemSelector: { index: 0, zone: "default-zone" },
+    componentList: {},
   },
 };
 

--- a/packages/core/lib/use-component-list.tsx
+++ b/packages/core/lib/use-component-list.tsx
@@ -6,7 +6,7 @@ export const useComponentList = (config: Config, ui: UiState) => {
   const [componentList, setComponentList] = useState<ReactNode[]>();
 
   useEffect(() => {
-    if (ui.componentList) {
+    if (Object.keys(ui.componentList).length > 0) {
       const matchedComponents: string[] = [];
 
       let _componentList: ReactNode[];
@@ -31,6 +31,7 @@ export const useComponentList = (config: Config, ui: UiState) => {
                     key={componentName}
                     component={componentName as string}
                     index={i}
+                    id={`${categoryKey}::${componentName}`}
                   />
                 );
               })}
@@ -49,13 +50,18 @@ export const useComponentList = (config: Config, ui: UiState) => {
         ui.componentList.other?.visible !== false
       ) {
         _componentList.push(
-          <ComponentList id="other" key="other" title={"Other"}>
+          <ComponentList
+            id="other"
+            key="other"
+            title={ui.componentList.other?.title || "Other"}
+          >
             {remainingComponents.map((componentName, i) => {
               return (
                 <ComponentList.Item
                   key={componentName}
                   component={componentName as string}
                   index={i}
+                  id={`other::${componentName}`}
                 />
               );
             })}

--- a/packages/core/lib/use-component-list.tsx
+++ b/packages/core/lib/use-component-list.tsx
@@ -1,17 +1,17 @@
 import { ReactNode, useEffect, useState } from "react";
-import { Config } from "../types/Config";
+import { Config, UiState } from "../types/Config";
 import { ComponentList } from "../components/ComponentList";
 
-export const useComponentList = (config: Config) => {
+export const useComponentList = (config: Config, ui: UiState) => {
   const [componentList, setComponentList] = useState<ReactNode[]>();
 
   useEffect(() => {
-    if (config.categories) {
+    if (ui.componentList) {
       const matchedComponents: string[] = [];
 
       let _componentList: ReactNode[];
 
-      _componentList = Object.entries(config.categories).map(
+      _componentList = Object.entries(ui.componentList).map(
         ([categoryKey, category]) => {
           if (category.visible === false || !category.components) {
             return null;
@@ -19,9 +19,9 @@ export const useComponentList = (config: Config) => {
 
           return (
             <ComponentList
+              id={categoryKey}
               key={categoryKey}
               title={category.title || categoryKey}
-              defaultExpanded={category.defaultExpanded}
             >
               {category.components.map((componentName, i) => {
                 matchedComponents.push(componentName as string);
@@ -45,15 +45,11 @@ export const useComponentList = (config: Config) => {
 
       if (
         remainingComponents.length > 0 &&
-        !config.categories["other"]?.components &&
-        config.categories["other"]?.visible !== false
+        !ui.componentList.other?.components &&
+        ui.componentList.other?.visible !== false
       ) {
         _componentList.push(
-          <ComponentList
-            key="other"
-            title={"Other"}
-            defaultExpanded={config.categories.other?.defaultExpanded}
-          >
+          <ComponentList id="other" key="other" title={"Other"}>
             {remainingComponents.map((componentName, i) => {
               return (
                 <ComponentList.Item
@@ -69,7 +65,7 @@ export const useComponentList = (config: Config) => {
 
       setComponentList(_componentList);
     }
-  }, [config.categories, config.components]);
+  }, [config.categories, ui.componentList]);
 
   return componentList;
 };

--- a/packages/core/lib/use-component-list.tsx
+++ b/packages/core/lib/use-component-list.tsx
@@ -1,0 +1,75 @@
+import { ReactNode, useEffect, useState } from "react";
+import { Config } from "../types/Config";
+import { ComponentList } from "../components/ComponentList";
+
+export const useComponentList = (config: Config) => {
+  const [componentList, setComponentList] = useState<ReactNode[]>();
+
+  useEffect(() => {
+    if (config.categories) {
+      const matchedComponents: string[] = [];
+
+      let _componentList: ReactNode[];
+
+      _componentList = Object.entries(config.categories).map(
+        ([categoryKey, category]) => {
+          if (category.visible === false || !category.components) {
+            return null;
+          }
+
+          return (
+            <ComponentList
+              key={categoryKey}
+              title={category.title || categoryKey}
+              defaultExpanded={category.defaultExpanded}
+            >
+              {category.components.map((componentName, i) => {
+                matchedComponents.push(componentName as string);
+
+                return (
+                  <ComponentList.Item
+                    key={componentName}
+                    component={componentName as string}
+                    index={i}
+                  />
+                );
+              })}
+            </ComponentList>
+          );
+        }
+      );
+
+      const remainingComponents = Object.keys(config.components).filter(
+        (component) => matchedComponents.indexOf(component) === -1
+      );
+
+      if (
+        remainingComponents.length > 0 &&
+        !config.categories["other"]?.components &&
+        config.categories["other"]?.visible !== false
+      ) {
+        _componentList.push(
+          <ComponentList
+            key="other"
+            title={"Other"}
+            defaultExpanded={config.categories.other?.defaultExpanded}
+          >
+            {remainingComponents.map((componentName, i) => {
+              return (
+                <ComponentList.Item
+                  key={componentName}
+                  component={componentName as string}
+                  index={i}
+                />
+              );
+            })}
+          </ComponentList>
+        );
+      }
+
+      setComponentList(_componentList);
+    }
+  }, [config.categories, config.components]);
+
+  return componentList;
+};

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -136,6 +136,15 @@ export type UiState = {
   leftSideBarVisible: boolean;
   itemSelector: ItemSelector | null;
   arrayState: Record<string, ArrayState | undefined>;
+  componentList: Record<
+    string,
+    {
+      components?: string[];
+      title?: string;
+      visible?: boolean;
+      expanded?: boolean;
+    }
+  >;
 };
 
 export type AppState = { data: Data; ui: UiState };

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -1,7 +1,6 @@
 import { ReactElement } from "react";
 import { ReactNode } from "react";
 import { ItemSelector } from "../lib/get-item";
-import { DragStart, DragUpdate } from "react-beautiful-dnd";
 
 export type Adaptor<AdaptorParams = {}> = {
   name: string;
@@ -78,10 +77,21 @@ export type ComponentConfig<
   fields?: Fields<ComponentProps>;
 };
 
+type Category<ComponentName> = {
+  components?: ComponentName[];
+  title?: string;
+  visible?: boolean;
+  defaultExpanded?: boolean;
+};
+
 export type Config<
   Props extends { [key: string]: any } = { [key: string]: any },
-  RootProps extends DefaultRootProps = DefaultRootProps
+  RootProps extends DefaultRootProps = DefaultRootProps,
+  CategoryName extends string = string
 > = {
+  categories?: Record<CategoryName, Category<keyof Props>> & {
+    other?: Category<Props>;
+  };
   components: {
     [ComponentName in keyof Props]: ComponentConfig<
       Props[ComponentName],


### PR DESCRIPTION
This PR introduces:

* a `categories` API for grouping components
* a `renderComponentList` API for both the user and plugins to enable enhancing of the component list (such as for search)


## `categories` API

`categories` is a new key on `Config`. 

- **[categoryName]** (`object`)
  - **components** (`sting[]`, [optional]): Array containing the names of components in this category
  - **title** (`sting`, [optional]): Title of the category
  - **visible** (`boolean`, [optional]): Whether or not the category should be visible in the side bar
  - **defaultExpanded** (`boolean`, [optional]): Whether or not the category should be expanded in the side bar by default

Example:

```tsx
  categories: {
    layout: {
      components: ["Columns", "Flex", "VerticalSpace"],
    },
    typography: {
      components: ["Heading", "Text"],
    },
    interactive: {
      title: "Actions",
      components: ["ButtonGroup"],
    },
  },
```

This renders a UI like this

<img width="1437" alt="image" src="https://github.com/measuredco/puck/assets/985961/6475fbcd-5906-49e2-832b-fa6f62409ef2">

It's okay for a component to appear in multiple categories.

All remaining components are grouped in a hidden category called `other` (currently undocumented, but worth adding once we deploy the website). By default, the `other` category will show all components that aren't included by other categories, but it can still be configured like any other category.

For example, we might choose to hide it

```tsx
  categories: {
   ...existingCategories
    other: {
      visible: false,
    },
  }
```

<img width="1438" alt="image" src="https://github.com/measuredco/puck/assets/985961/128d7456-6367-485a-b37c-5c9298f9885a">


Or render it collapsed by default

```tsx
  categories: {
   ...existingCategories
    other: {
      defaultExpanded: false,
    },
  }
```

<img width="1440" alt="image" src="https://github.com/measuredco/puck/assets/985961/9a6267e6-8d51-4bf4-8f06-a31844c72dba">

### Why this API was chosen

There was much discussion in #87. This proposal implements option 4 from [this comment](https://github.com/measuredco/puck/issues/87#issuecomment-1768303564). There was some interest in option 1b, and this implementation was originally an exploration of both options. However, option 4 was chosen because:

* It's easier to strictly type than 1b, especially when the user splits the components into separate files (as we do in demo)
* You can reorder components
* All categories considerations are kept in one place

## renderComponentList API

Additionally, the `renderComponentList` API was introduced for both the user _and_ plugins, allowing users to add custom UI to the component list. Since the component list is using application state, users can control the component list by writing to the `componentList` UI state object.

For example, here's a search implementation:

https://github.com/measuredco/puck/assets/985961/6b1151af-9b98-4697-8f6a-52ef35170dd0

<details>
<summary>See code</summary>

```tsx
          renderComponentList={({ children, dispatch, state }) => (
            <>
              <input
                placeholder="Search components"
                onChange={(e) => {
                  if (!prevComponentList) {
                    prevComponentList = { ...state.ui.componentList };
                  }

                  if (!e.currentTarget.value && prevComponentList) {
                    dispatch({
                      type: "setUi",
                      ui: {
                        ...state.ui,
                        componentList: prevComponentList,
                      },
                    });

                    prevComponentList = null;

                    return;
                  }

                  const filteredComponentList = Object.keys(
                    config.components
                  ).filter(
                    (componentName) =>
                      componentName
                        .toLowerCase()
                        .indexOf(e.currentTarget.value.toLowerCase()) > -1
                  );

                  dispatch({
                    type: "setUi",
                    ui: {
                      ...state.ui,
                      componentList: {
                        results: {
                          title: `${filteredComponentList.length} result${
                            filteredComponentList.length === 1 ? "" : "s"
                          }`,
                          components: filteredComponentList,
                        },
                        other: { visible: false },
                      },
                    },
                    recordHistory: false,
                  });
                }}
              ></input>

              {children}
            </>
          )}
```

</details>

> **Note, this is the first render API exposed to both. We might want to also consider exposing `renderHeader` and `renderHeaderActions` to plugins at a later date**.

Closes #87 