### PR TITLE
Introduce dynamic props via resolveProps API

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,7 @@ External fields can be used to load content from an external content repository,
 - **adaptor** (`Adaptor`): Content adaptor responsible for fetching data to show in the table
   - **name** (`string`): The human-readable name of the adaptor
   - **fetchList** (`(adaptorParams: object) => object`): Fetch a list of content and return an array
+  - **mapProp** (`(selectedItem: object) => object`): Map the selected item into another shape
 - **adaptorParams** (`object`): Paramaters passed to the adaptor
 
 ### Custom Fields

--- a/README.md
+++ b/README.md
@@ -454,17 +454,57 @@ The `Config` object describes which components Puck should render, how they shou
 
 A `Field` represents a user input field shown in the Puck interface.
 
-- **type** (`text` | `textarea` | `number` | `select` | `radio` | `external` | `array` | `custom`): The input type to render
+### All Fields
+
 - **label** (`text` [optional]): A label for the input. Will use the key if not provided.
-- **arrayFields** (`object`): Object describing sub-fields for items in an `array` input
-  - **[fieldName]** (`Field`): The Field objects describing the input data for each item
-- **getItemSummary** (`(object, number) => string` [optional]): Function to get the name of each item when using the `array` or `external` field types
-- **defaultItemProps** (`object` [optional]): Default props to pass to each new item added, when using a `array` field type
-- **options** (`object[]`): array of items to render for select or radio inputs
+
+### Text Fields
+
+- **type** (`"text"`)
+
+### Textarea Fields
+
+- **type** (`"textarea"`)
+
+### Number Fields
+
+- **type** (`"number"`)
+
+### Select Fields
+
+- **type** (`"select"`)
+- **options** (`object[]`): array of items to render
   - **label** (`string`)
   - **value** (`string` | `number` | `boolean`)
-- **adaptor** (`Adaptor`): Content adaptor if using the `external` input type
+
+### Radio Fields
+
+- **type** (`"radio"`)
+- **options** (`object[]`): array of items to render
+  - **label** (`string`)
+  - **value** (`string` | `number` | `boolean`)
+
+### Array Fields
+
+- **type** (`"array"`)
+- **arrayFields** (`object`): Object describing sub-fields for each item
+  - **[fieldName]** (`Field`): The Field objects describing the input data for each item
+  - **getItemSummary** (`(object, number) => string` [optional]): Function to get the label of each item
+- **defaultItemProps** (`object` [optional]): Default props to pass to each new item added, when using a `array` field type
+
+### External Fields
+
+External fields can be used to load content from an external content repository, like Strapi.js, using an `Adaptor`.
+
+- **type** (`"external"`)
+- **adaptor** (`Adaptor`): Content adaptor responsible for fetching data to show in the table
+  - **name** (`string`): The human-readable name of the adaptor
+  - **fetchList** (`(adaptorParams: object) => object`): Fetch a list of content and return an array
 - **adaptorParams** (`object`): Paramaters passed to the adaptor
+
+### Custom Fields
+
+- **type** (`"custom"`)
 - **render** (`Component`): Render a custom field. Receives the props:
   - **field** (`Field`): Field configuration
   - **name** (`string`): Name of the field
@@ -498,13 +538,6 @@ The `Data` object stores the puck page data.
   - **type** (string): Component name
   - **props** (object):
     - **[prop]** (string): User defined data from component fields
-
-### `Adaptor`
-
-An `Adaptor` can be used to load content from an external content repository, like Strapi.js.
-
-- **name** (`string`): The human-readable name of the adaptor
-- **fetchList** (`(adaptorParams: object) => object`): Fetch a list of content and return an array
 
 ### `Plugin`
 

--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ External fields can be used to load content from an external content repository,
 - **type** (`"external"`)
 - **adaptor** (`Adaptor`): Content adaptor responsible for fetching data to show in the table
   - **name** (`string`): The human-readable name of the adaptor
-  - **fetchList** (`(adaptorParams: object) => object`): Fetch a list of content and return an array
+  - **fetchList** (`(adaptorParams: object) => object`): Fetch content from a third-party API and return an array
   - **mapProp** (`(selectedItem: object) => object`): Map the selected item into another shape
 - **adaptorParams** (`object`): Paramaters passed to the adaptor
 

--- a/README.md
+++ b/README.md
@@ -340,8 +340,6 @@ An `Adaptor` can be used to load content from an external content repository, li
 - **name** (`string`): The human-readable name of the adaptor
 - **fetchList** (`(adaptorParams: object) => object`): Fetch a list of content and return an array
 
-> NB Using an adaptor on the reserved field name `_data` will spread the resulting data over your object, and lock the overridden fields.
-
 ### `Plugin`
 
 Plugins that can be used to enhance Puck.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # puck
 
+The self-hosted, drag and drop editor for React.
+
 <p align="left">
   <a aria-label="Measured logo" href="https://measured.co">
     <img src="https://img.shields.io/badge/MADE%20BY%20Measured-000000.svg?style=for-the-badge&labelColor=000">
@@ -15,7 +17,7 @@
   </a>
 </p>
 
-The self-hosted, drag and drop editor for React.
+## Features
 
 - 🖱️ **Drag and drop**: Visual editing for your existing React component library
 - 🌐 **Integrations**: Load your content from a 3rd party headless CMS

--- a/apps/demo/app/[...puckPath]/client.tsx
+++ b/apps/demo/app/[...puckPath]/client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Data } from "@measured/puck/types/Config";
+import { Data, resolveData } from "@measured/puck";
 import { Puck } from "@measured/puck/components/Puck";
 import { Render } from "@measured/puck/components/Render";
 import { useEffect, useState } from "react";
@@ -29,6 +29,16 @@ export function Client({ path, isEdit }: { path: string; isEdit: boolean }) {
       return initialData[path] || undefined;
     }
   });
+
+  // Normally this would happen on the server, but we can't
+  // do that because we're using local storage as a database
+  const [resolvedData, setResolvedData] = useState(data);
+
+  useEffect(() => {
+    if (data && !isEdit) {
+      resolveData(data, config).then(setResolvedData);
+    }
+  }, [data, isEdit]);
 
   useEffect(() => {
     if (!isEdit) {
@@ -60,7 +70,7 @@ export function Client({ path, isEdit }: { path: string; isEdit: boolean }) {
   }
 
   if (data) {
-    return <Render config={config} data={data} />;
+    return <Render config={config} data={resolvedData} />;
   }
 
   return (

--- a/apps/demo/config/blocks/Hero/index.tsx
+++ b/apps/demo/config/blocks/Hero/index.tsx
@@ -10,7 +10,7 @@ import { quotes } from "./quotes";
 const getClassName = getClassNameFactory("Hero", styles);
 
 export type HeroProps = {
-  quote?: { index: number };
+  quote?: { index: number; label: string };
   title: string;
   description: string;
   align?: string;
@@ -20,23 +20,23 @@ export type HeroProps = {
   buttons: { label: string; href: string; variant?: "primary" | "secondary" }[];
 };
 
-// TODO add resolveValue prop so the fetch can return different data to the adaptor
-const quotesAdaptor = {
-  name: "Quotes API",
-  fetchList: async (): Promise<Partial<HeroProps>[]> =>
-    quotes.map((quote, idx) => ({
-      index: idx,
-      title: quote.author,
-      description: quote.content,
-    })),
-};
-
 export const Hero: ComponentConfig<HeroProps> = {
   fields: {
     quote: {
       type: "external",
-      adaptor: quotesAdaptor,
-      getItemSummary: (item: Partial<HeroProps>) => item.description,
+      adaptor: {
+        name: "Quotes API",
+        fetchList: async () =>
+          quotes.map((quote, idx) => ({
+            index: idx,
+            title: quote.author,
+            description: quote.content,
+          })),
+        mapProp: (result) => {
+          return { index: result.index, label: result.description };
+        },
+      },
+      getItemSummary: (item) => item.label,
     },
     title: { type: "text" },
     description: { type: "textarea" },

--- a/apps/demo/config/blocks/Hero/quotes.ts
+++ b/apps/demo/config/blocks/Hero/quotes.ts
@@ -20,11 +20,6 @@ export const quotes = [
   },
   {
     content:
-      "A diplomat is a man who always remembers a woman's birthday but never remembers her age.",
-    author: "Robert Frost",
-  },
-  {
-    content:
       "As I grow older, I pay less attention to what men say. I just watch what they do.",
     author: "Andrew Carnegie",
   },
@@ -47,10 +42,5 @@ export const quotes = [
     content:
       "Nobody grows old merely by living a number of years. We grow old by deserting our ideals. Years may wrinkle the skin, but to give up enthusiasm wrinkles the soul.",
     author: "Samuel Ullman",
-  },
-  {
-    content:
-      "An archaeologist is the best husband a woman can have. The older she gets the more interested he is in her.",
-    author: "Agatha Christie",
   },
 ];

--- a/packages/core/components/DropZone/context.tsx
+++ b/packages/core/components/DropZone/context.tsx
@@ -5,7 +5,7 @@ import {
   useCallback,
   useState,
 } from "react";
-import { Config, Data, MappedItem } from "../../types/Config";
+import { Config, Data } from "../../types/Config";
 import { DragStart, DragUpdate } from "react-beautiful-dnd";
 import { ItemSelector, getItem } from "../../lib/get-item";
 import { PuckAction } from "../../reducer";

--- a/packages/core/components/DropZone/context.tsx
+++ b/packages/core/components/DropZone/context.tsx
@@ -5,7 +5,7 @@ import {
   useCallback,
   useState,
 } from "react";
-import { Config, Data } from "../../types/Config";
+import { Config, Data, MappedItem } from "../../types/Config";
 import { DragStart, DragUpdate } from "react-beautiful-dnd";
 import { ItemSelector, getItem } from "../../lib/get-item";
 import { PuckAction } from "../../reducer";
@@ -18,6 +18,7 @@ export type PathData = Record<string, { path: string[]; label: string }>;
 export type DropZoneContext = {
   data: Data;
   config: Config;
+  dynamicProps?: Record<string, any>;
   itemSelector?: ItemSelector | null;
   setItemSelector?: (newIndex: ItemSelector | null) => void;
   dispatch?: (action: PuckAction) => void;

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -24,6 +24,7 @@ function DropZoneEdit({ zone, style }: DropZoneProps) {
   const {
     // These all need setting via context
     data,
+    dynamicProps = {},
     dispatch = () => null,
     config,
     itemSelector,
@@ -170,7 +171,7 @@ function DropZoneEdit({ zone, style }: DropZoneProps) {
 
                 const defaultedProps = {
                   ...config.components[item.type]?.defaultProps,
-                  ...item.props,
+                  ...(dynamicProps[item.props.id] || item.props),
                   editMode: true,
                 };
 

--- a/packages/core/components/ExternalInput/index.tsx
+++ b/packages/core/components/ExternalInput/index.tsx
@@ -15,6 +15,8 @@ export const ExternalInput = ({
   onChange: (value: any) => void;
   value: any;
 }) => {
+  const { mapProp = (val) => val } = field.adaptor || {};
+
   const [data, setData] = useState<Record<string, any>[]>([]);
   const [isOpen, setOpen] = useState(false);
   const [selectedData, setSelectedData] = useState(value);
@@ -112,11 +114,11 @@ export const ExternalInput = ({
                         key={i}
                         style={{ whiteSpace: "nowrap" }}
                         onClick={(e) => {
-                          onChange(item);
+                          onChange(mapProp(item));
 
                           setOpen(false);
 
-                          setSelectedData(item);
+                          setSelectedData(mapProp(item));
                         }}
                       >
                         {keys.map((key) => (

--- a/packages/core/components/ExternalInput/index.tsx
+++ b/packages/core/components/ExternalInput/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useEffect, useState } from "react";
 import styles from "./styles.module.css";
 import getClassNameFactory from "../../lib/get-class-name-factory";
-import { Field } from "../../types/Config";
+import { ExternalField } from "../../types/Config";
 import { Link } from "react-feather";
 
 const getClassName = getClassNameFactory("ExternalInput", styles);
@@ -11,7 +11,7 @@ export const ExternalInput = ({
   onChange,
   value = null,
 }: {
-  field: Field;
+  field: ExternalField;
   onChange: (value: any) => void;
   value: any;
 }) => {

--- a/packages/core/components/InputOrGroup/fields/ArrayField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/ArrayField/index.tsx
@@ -63,7 +63,7 @@ export const ArrayField = ({
     setArrayState({ items: newItems });
   }, [value]);
 
-  if (!field.arrayFields) {
+  if (field.type !== "array" || !field.arrayFields) {
     return null;
   }
 

--- a/packages/core/components/InputOrGroup/fields/ExternalField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/ExternalField/index.tsx
@@ -2,13 +2,13 @@ import getClassNameFactory from "../../../../lib/get-class-name-factory";
 import styles from "../../styles.module.css";
 import type { InputProps } from "../..";
 import { ExternalInput } from "../../../ExternalInput";
+import { Link } from "react-feather";
 
 const getClassName = getClassNameFactory("Input", styles);
 
 export const ExternalField = ({
   field,
   onChange,
-  readOnly,
   value,
   name,
   label,
@@ -18,9 +18,13 @@ export const ExternalField = ({
   }
 
   return (
-    <div className={getClassName("")}>
+    <div className={getClassName()}>
       <div className={getClassName("label")}>
-        {name === "_data" ? "External content" : label || name}
+        <div className={getClassName("labelIcon")}>
+          <Link size={16} />
+        </div>
+
+        {name === "_data" ? label || "External content" : label || name}
       </div>
       <ExternalInput field={field} onChange={onChange} value={value} />
     </div>

--- a/packages/core/components/InputOrGroup/fields/ExternalField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/ExternalField/index.tsx
@@ -24,7 +24,7 @@ export const ExternalField = ({
           <Link size={16} />
         </div>
 
-        {name === "_data" ? label || "External content" : label || name}
+        {label || name}
       </div>
       <ExternalInput field={field} onChange={onChange} value={value} />
     </div>

--- a/packages/core/components/InputOrGroup/fields/ExternalField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/ExternalField/index.tsx
@@ -13,7 +13,7 @@ export const ExternalField = ({
   name,
   label,
 }: InputProps) => {
-  if (!field.adaptor) {
+  if (field.type !== "external" || !field.adaptor) {
     return null;
   }
 

--- a/packages/core/components/InputOrGroup/fields/RadioField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/RadioField/index.tsx
@@ -12,7 +12,7 @@ export const RadioField = ({
   value,
   name,
 }: InputProps) => {
-  if (!field.options) {
+  if (field.type !== "radio" || !field.options) {
     return null;
   }
 

--- a/packages/core/components/InputOrGroup/fields/SelectField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/SelectField/index.tsx
@@ -12,7 +12,7 @@ export const SelectField = ({
   value,
   name,
 }: InputProps) => {
-  if (!field.options) {
+  if (field.type !== "select" || !field.options) {
     return null;
   }
 

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -615,7 +615,6 @@ export function Puck({
 
                             const onChange = (value: any) => {
                               let currentProps;
-                              let newProps;
 
                               if (selectedItem) {
                                 currentProps = selectedItem.props;
@@ -626,36 +625,10 @@ export function Puck({
                               const { readOnly, ..._meta } =
                                 currentProps._meta || {};
 
-                              if (fieldName === "_data") {
-                                // Reset the link if value is falsey
-                                if (!value) {
-                                  newProps = {
-                                    ...currentProps,
-                                    _data: undefined,
-                                    _meta: _meta,
-                                  };
-                                } else {
-                                  const changedFields = filter(
-                                    // filter out anything not supported by this component
-                                    value,
-                                    Object.keys(fields)
-                                  );
-
-                                  newProps = {
-                                    ...currentProps,
-                                    ...changedFields,
-                                    _data: value, // TODO perf - this is duplicative and will make payload larger
-                                    _meta: {
-                                      locked: Object.keys(changedFields),
-                                    },
-                                  };
-                                }
-                              } else {
-                                newProps = {
-                                  ...currentProps,
-                                  [fieldName]: value,
-                                };
-                              }
+                              const newProps = {
+                                ...currentProps,
+                                [fieldName]: value,
+                              };
 
                               if (itemSelector) {
                                 dispatch({

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -7,4 +7,6 @@ export * from "./components/IconButton";
 export * from "./components/Puck";
 export * from "./components/Render";
 
+export * from "./lib/resolve-data";
+
 export { FieldLabel } from "./components/InputOrGroup";

--- a/packages/core/lib/__tests__/resolve-data.spec.tsx
+++ b/packages/core/lib/__tests__/resolve-data.spec.tsx
@@ -1,0 +1,75 @@
+import { Config, Data } from "../../types/Config";
+import { resolveData } from "../resolve-data";
+
+const item1 = {
+  type: "ComponentWithResolveProps",
+  props: { id: "MyComponent-1", prop: "Original" },
+};
+const item2 = {
+  type: "ComponentWithoutResolveProps",
+  props: { id: "MyComponent-2", prop: "Original" },
+};
+
+const data: Data = {
+  root: { title: "" },
+  content: [item1],
+  zones: {
+    "MyComponent-1:zone": [item2],
+  },
+};
+
+const config: Config = {
+  components: {
+    ComponentWithResolveProps: {
+      defaultProps: { prop: "example" },
+      resolveProps: async (props) => {
+        return {
+          props: { ...props, prop: "Resolved" },
+          readOnly: { prop: true },
+        };
+      },
+      render: () => <div />,
+    },
+    ComponentWithoutResolveProps: {
+      defaultProps: { prop: "example" },
+      render: () => <div />,
+    },
+  },
+};
+
+describe("resolve-data", () => {
+  it("should resolve the data for all components in the data", async () => {
+    expect(await resolveData(data, config)).toMatchInlineSnapshot(`
+      {
+        "content": [
+          {
+            "props": {
+              "_meta": {
+                "readOnly": {
+                  "prop": true,
+                },
+              },
+              "id": "MyComponent-1",
+              "prop": "Resolved",
+            },
+            "type": "ComponentWithResolveProps",
+          },
+        ],
+        "root": {
+          "title": "",
+        },
+        "zones": {
+          "MyComponent-1:zone": [
+            {
+              "props": {
+                "id": "MyComponent-2",
+                "prop": "Original",
+              },
+              "type": "ComponentWithoutResolveProps",
+            },
+          ],
+        },
+      }
+    `);
+  });
+});

--- a/packages/core/lib/get-item.ts
+++ b/packages/core/lib/get-item.ts
@@ -1,4 +1,4 @@
-import { Data } from "../types/Config";
+import { Data, MappedItem } from "../types/Config";
 import { rootDroppableId } from "./root-droppable-id";
 import { setupZone } from "./setup-zone";
 
@@ -9,11 +9,18 @@ export type ItemSelector = {
 
 export const getItem = (
   selector: ItemSelector,
-  data: Data
+  data: Data,
+  dynamicProps: Record<string, any> = {}
 ): Data["content"][0] | undefined => {
   if (!selector.zone || selector.zone === rootDroppableId) {
-    return data.content[selector.index];
+    const item = data.content[selector.index];
+
+    return { ...item, props: dynamicProps[item.props.id] || item.props };
   }
 
-  return setupZone(data, selector.zone).zones[selector.zone][selector.index];
+  const item = setupZone(data, selector.zone).zones[selector.zone][
+    selector.index
+  ];
+
+  return { ...item, props: dynamicProps[item.props.id] || item.props };
 };

--- a/packages/core/lib/resolve-all-props.ts
+++ b/packages/core/lib/resolve-all-props.ts
@@ -1,0 +1,30 @@
+import { Config, MappedItem } from "../types/Config";
+
+export const resolveAllProps = async (
+  content: MappedItem[],
+  config: Config
+) => {
+  return await Promise.all(
+    content.map(async (item) => {
+      const configForItem = config.components[item.type];
+
+      if (configForItem.resolveProps) {
+        const { props: resolvedProps, readOnly = {} } =
+          await configForItem.resolveProps(item.props);
+
+        const { _meta: { readOnly: existingReadOnly = {} } = {} } =
+          item.props || {};
+
+        return {
+          ...item,
+          props: {
+            ...resolvedProps,
+            _meta: { readOnly: { ...existingReadOnly, ...readOnly } },
+          },
+        };
+      }
+
+      return item;
+    })
+  );
+};

--- a/packages/core/lib/resolve-data.ts
+++ b/packages/core/lib/resolve-data.ts
@@ -1,0 +1,20 @@
+import { Config, Data, MappedItem } from "../types/Config";
+import { resolveAllProps } from "./resolve-all-props";
+
+export const resolveData = async (data: Data, config: Config) => {
+  const { zones = {} } = data;
+
+  const zoneKeys = Object.keys(zones);
+  const resolvedZones: Record<string, MappedItem[]> = {};
+
+  for (let i = 0; i < zoneKeys.length; i++) {
+    const zoneKey = zoneKeys[i];
+    resolvedZones[zoneKey] = await resolveAllProps(zones[zoneKey], config);
+  }
+
+  return {
+    ...data,
+    content: await resolveAllProps(data.content, config),
+    zones: resolvedZones,
+  };
+};

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -16,38 +16,63 @@ type WithPuckProps<Props> = Props & {
   };
 };
 
-export type Field<
-  Props extends { [key: string]: any } = { [key: string]: any }
-> = {
-  type:
-    | "text"
-    | "textarea"
-    | "number"
-    | "select"
-    | "array"
-    | "external"
-    | "radio"
-    | "custom";
+export type BaseField = {
   label?: string;
-  adaptor?: Adaptor;
-  adaptorParams?: object;
-  arrayFields?: {
-    [SubPropName in keyof Props]: Field<Props[SubPropName][0]>;
-  };
-  getItemSummary?: (item: Props, index?: number) => string;
-  defaultItemProps?: Props;
-  render?: (props: {
-    field: Field;
-    name: string;
-    value: any;
-    onChange: (value: any) => void;
-    readOnly?: boolean;
-  }) => ReactElement;
-  options?: {
+};
+
+export type TextField = BaseField & {
+  type: "text" | "number" | "textarea";
+};
+
+export type SelectField = BaseField & {
+  type: "select" | "radio";
+  options: {
     label: string;
     value: string | number | boolean;
   }[];
 };
+
+export type ArrayField<
+  Props extends { [key: string]: any } = { [key: string]: any }
+> = BaseField & {
+  type: "array";
+  arrayFields: {
+    [SubPropName in keyof Props[0]]: Field<Props[0][SubPropName]>;
+  };
+  defaultItemProps?: Props[0];
+  getItemSummary?: (item: Props[0], index?: number) => string;
+};
+
+export type ExternalField<
+  Props extends { [key: string]: any } = { [key: string]: any }
+> = BaseField & {
+  type: "external";
+  adaptor: Adaptor;
+  adaptorParams?: object;
+  getItemSummary: (item: Props, index?: number) => string;
+};
+
+export type CustomField<
+  Props extends { [key: string]: any } = { [key: string]: any }
+> = BaseField & {
+  type: "custom";
+  render: (props: {
+    field: CustomField;
+    name: string;
+    value: any;
+    onChange: (value: Props) => void;
+    readOnly?: boolean;
+  }) => ReactElement;
+};
+
+export type Field<
+  Props extends { [key: string]: any } = { [key: string]: any }
+> =
+  | TextField
+  | SelectField
+  | ArrayField<Props>
+  | ExternalField<Props>
+  | CustomField;
 
 export type DefaultRootProps = {
   children: ReactNode;
@@ -64,7 +89,7 @@ export type Fields<
   [PropName in keyof Omit<
     Required<ComponentProps>,
     "children" | "editMode"
-  >]: Field<ComponentProps[PropName][0]>;
+  >]: Field<ComponentProps[PropName]>;
 };
 
 export type Content<

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -2,11 +2,14 @@ import { ReactElement } from "react";
 import { ReactNode } from "react";
 import { ItemSelector } from "../lib/get-item";
 
-export type Adaptor<AdaptorParams = {}> = {
+export type Adaptor<
+  AdaptorParams = {},
+  TableShape extends Record<string, any> = {},
+  PropShape = TableShape
+> = {
   name: string;
-  fetchList: (
-    adaptorParams?: AdaptorParams
-  ) => Promise<Record<string, any>[] | null>;
+  fetchList: (adaptorParams?: AdaptorParams) => Promise<TableShape[] | null>;
+  mapProp?: (value: TableShape) => PropShape;
 };
 
 type WithPuckProps<Props> = Props & {
@@ -47,7 +50,7 @@ export type ExternalField<
   Props extends { [key: string]: any } = { [key: string]: any }
 > = BaseField & {
   type: "external";
-  adaptor: Adaptor;
+  adaptor: Adaptor<any, any, Props>;
   adaptorParams?: object;
   getItemSummary: (item: Props, index?: number) => string;
 };

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -14,7 +14,7 @@ export type Adaptor<
 
 type WithPuckProps<Props> = Props & {
   id: string;
-  _meta: {
+  _meta?: {
     readOnly: Partial<Record<keyof Props, boolean>>;
   };
 };

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -9,8 +9,11 @@ export type Adaptor<AdaptorParams = {}> = {
   ) => Promise<Record<string, any>[] | null>;
 };
 
-type WithId<T> = T & {
+type WithPuckProps<Props> = Props & {
   id: string;
+  _meta: {
+    readOnly: Partial<Record<keyof Props, boolean>>;
+  };
 };
 
 export type Field<
@@ -72,9 +75,13 @@ export type ComponentConfig<
   ComponentProps extends DefaultComponentProps = DefaultComponentProps,
   DefaultProps = ComponentProps
 > = {
-  render: (props: WithId<ComponentProps>) => ReactElement;
+  render: (props: WithPuckProps<ComponentProps>) => ReactElement;
   defaultProps?: DefaultProps;
   fields?: Fields<ComponentProps>;
+  resolveProps?: (props: WithPuckProps<ComponentProps>) => Promise<{
+    props: WithPuckProps<ComponentProps>;
+    readOnly?: Partial<Record<keyof ComponentProps, boolean>>;
+  }>;
 };
 
 type Category<ComponentName> = {
@@ -108,7 +115,7 @@ export type MappedItem<
   Props extends { [key: string]: any } = { [key: string]: any }
 > = {
   type: keyof Props;
-  props: WithId<{
+  props: WithPuckProps<{
     [key: string]: any;
   }>;
 };


### PR DESCRIPTION
This PR that introduces new APIs for expanding the capability of adaptors

* The `resolveProp` config API allows users to modify props dynamically without writing them to the Puck data model on a per-component basis.
* The `resolveData` util function allows users to apply their dynamic props on the server or client before rendering their page with the `<Render>` component
* The `mapProp` adaptor API to enable the user to return change the shape of the data returned by the adaptor before applying it as a prop

Additionally:
* It removes the `_data` API for adaptors in favour of `resolveProp`. This is a breaking change.
* It makes the types stricter for Fields (considered a Fix).

## resolveProps Usage

The Hero component in the demo app contains an example

```tsx
const config:Config = {
  HeadingBlock: {
    fields: {
      text: {
        type: "text"
      }
    },
    resolveProps: async (props) => {
      // modify props. May include async operations.
      return { props: { ...props, text: "Hello, world" }, locked: { text: true } }
    },
    render: ({ text }) => {
      return <h1>{text}</h1>
    }
  }
}
```

Pairing it with an adaptor

```tsx
const quotesAdaptor = {
  name: "Quotes API",
  fetchList: async () => {
    const quotesResponse = await fetch("/api/quotes");
    
    return quotesResponse.json();
  }
};

const config:Config = {
  HeadingBlock: {
    fields: {
      quote: {
        type: "external",
        adaptor: quotesAdaptor
      },
      text: {
        type: "text"
      }
    },
    resolveProps: async (props) => {
      if (props.quote?.id) {
        const quote = await fetch(`/api/quotes/${props.quote.id}`);
        
        return { props: { text: quote.json().content }, locked: { text: true } }
      }
      
      return { props, locked: { text: false } };
    },
    render: ({ text }) => {
      return <h1>{text}</h1>
    }
  }
}
```

## resolveData usage

This should be used by the user to resolve data before rendering their <Render> component. It should ideally be used server-side, but can also be used client side in a `useEffect` hook.

```tsx
export const MyRSCPage =  async () => {
  const data = await getPage(); // user's database query
  const resolvedData = await resolveData(data);

  return <Render data={data} />
}
```

## mapProp usage

```tsx
const quotesAdaptor = {
  name: "Quotes API",
  fetchList: async () => {
    const quotesResponse = await fetch("/api/quotes");
    const data =  quotesResponse.json();

    return { id: data.id, title: data };
  },
  // Called _after_ the user selects an item from the adaptor
  mapProp: (prop => ({ id: prop.id }))
};

const config:Config = {
  HeadingBlock: {
    fields: {
      quote: {
        type: "external",
        adaptor: quotesAdaptor
      },
      text: {
        type: "text"
      }
    },
    render: ({ text }) => {
      return <h1>{text}</h1>
    }
  }
}
```

## Tasks

* [x] add tests