### PR TITLE
Better adaptors, part 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,18 +423,13 @@ The `Config` object describes which components Puck should render, how they shou
     - **title** (`Field`): Title of the content, typically used for the page title.
     - **[fieldName]** (`Field`): User defined fields, used to describe the input data stored in the `root` key.
   - **render** (`Component`): Render a React component at the root of your component tree. Useful for defining context providers.
+  - **resolveData** (`async (data: ComponentData) => ComponentData` [optional]): Function to dynamically change props before rendering the root.
 - **components** (`object`): Definitions for each of the components you want to show in the visual editor
   - **[componentName]** (`object`)
     - **fields** (`Field`): The Field objects describing the input data stored against this component.
     - **render** (`Component`): Render function for your React component. Receives props as defined in fields.
     - **defaultProps** (`object` [optional]): Default props to pass to your component. Will show in fields.
-    - **resolveData** (`async (props: object) => object` [optional]): Function to dynamically change props before rendering the component.
-      - Args
-        - **props** (`object`): the current props for your component stored in the Puck data
-      - Response
-        - **props** (`object`): the resolved props for your component. Will not be stored in the Puck data
-        - **readOnly** (`object`): an object describing which fields on the component are currently read-only
-          - **[prop]** (`boolean`): boolean describing whether or not the prop field is read-only
+    - **resolveData** (`async (data: ComponentData) => ComponentData` [optional]): Function to dynamically change props before rendering the component.
 - **categories** (`object`): Component categories for rendering in the side bar or restricting in DropZones
   - **[categoryName]** (`object`)
     - **components** (`sting[]`, [optional]): Array containing the names of components in this category
@@ -526,9 +521,9 @@ The `Data` object stores the puck page data.
 
 - **root** (`ComponentData`): The component data for the root of your configuration.
   - **props** (object): Extends `ComponentData.props`, with some additional props
-    - **title** (string, optional): Title of the content, typically used for the page title
+    - **title** (`string`, [optional]): Title of the content, typically used for the page title
 - **content** (`ComponentData[]`): Component data for the main content
-- **zones** (`object`, optional): Component data for all DropZones
+- **zones** (`object`, [optional]): Component data for all DropZones
   **[zoneCompound]** (`ComponentData[]`): Component data for a specific DropZone `zone` within a component instance
 
 ### `ComponentData`

--- a/README.md
+++ b/README.md
@@ -277,9 +277,9 @@ When the user interacts with this adaptor, they'll be presented with a list of i
 
 Dynamic prop resolution allows developers to resolve props for components without saving the data to the Puck data model.
 
-### resolveProps()
+### resolveData()
 
-`resolveProps` is defined in the component config, and allows the developer to make asynchronous calls to change the props after they've been set by Puck.
+`resolveData` is defined in the component config, and allows the developer to make asynchronous calls to change the props after they've been set by Puck.
 
 #### Args
 
@@ -309,7 +309,7 @@ const config = {
           type: "text",
         },
       },
-      resolveProps: async (props) => {
+      resolveData: async (props) => {
         return {
           props: {
             title: props.text,
@@ -329,7 +329,7 @@ const config = {
 
 ##### Combining with adaptors
 
-A more advanced pattern is to combine the `resolveProps` method with the adaptors to dynamically fetch data when rendering the component.
+A more advanced pattern is to combine the `resolveData` method with the adaptors to dynamically fetch data when rendering the component.
 
 ```tsx
 const myAdaptor = {
@@ -355,7 +355,7 @@ const config = {
           type: "text",
         },
       },
-      resolveProps: async (props) => {
+      resolveData: async (props) => {
         if (!myData.id) {
           return { props, readOnly: { title: false } };
         }
@@ -383,7 +383,7 @@ const config = {
 
 ### resolveAllData()
 
-`resolveAllData` is a utility function exported by Puck to enable the developer to resolve their custom props before rendering their component with `<Render>`. This is ideally done on the server. If you're using `resolveProps`, you _must_ use `resolveAllData` before rendering.
+`resolveAllData` is a utility function exported by Puck to enable the developer to resolve their custom props before rendering their component with `<Render>`. This is ideally done on the server. If you're using `resolveData`, you _must_ use `resolveAllData` before rendering.
 
 ```tsx
 import { resolveAllData } from "@measured/puck";
@@ -436,7 +436,7 @@ The `Config` object describes which components Puck should render, how they shou
     - **fields** (`Field`): The Field objects describing the input data stored against this component.
     - **render** (`Component`): Render function for your React component. Receives props as defined in fields.
     - **defaultProps** (`object` [optional]): Default props to pass to your component. Will show in fields.
-    - **resolveProps** (`async (props: object) => object` [optional]): Function to dynamically change props before rendering the component.
+    - **resolveData** (`async (props: object) => object` [optional]): Function to dynamically change props before rendering the component.
       - Args
         - **props** (`object`): the current props for your component stored in the Puck data
       - Response

--- a/README.md
+++ b/README.md
@@ -383,7 +383,9 @@ const config = {
 
 ### resolveAllData()
 
-`resolveAllData` is a utility function exported by Puck to enable the developer to resolve their custom props before rendering their component with `<Render>`. This is ideally done on the server. If you're using `resolveData`, you _must_ use `resolveAllData` before rendering.
+`resolveAllData` is a utility function exported by Puck to enable the developer to run all their `resolveData` methods before rendering the component with `<Render>`.
+
+If your `resolveData` methods rely on any external APIs, you should run this before rendering your page.
 
 ```tsx
 import { resolveAllData } from "@measured/puck";

--- a/README.md
+++ b/README.md
@@ -279,17 +279,7 @@ Dynamic prop resolution allows developers to resolve props for components withou
 
 ### resolveData()
 
-`resolveData` is defined in the component config, and allows the developer to make asynchronous calls to change the props after they've been set by Puck.
-
-#### Args
-
-- **props** (`object`): the current props for your component stored in the Puck data
-
-#### Response
-
-- **props** (`object`): the resolved props for your component. Will not be stored in the Puck data
-- **readOnly** (`object`): an object describing which fields on the component are currently read-only. Can also make array fields read-only by using a dot-notation accessor, like `array[0].text`.
-  - **[prop]** (`boolean`): boolean describing whether or not the prop field is read-only
+`resolveData` is defined in the component config, and allows the developer to make asynchronous calls to change the [ComponentData](#componentdata) after they've been set by Puck. Receives [ComponentData](#componentdata) and returns [ComponentData](#componentdata).
 
 #### Examples
 
@@ -537,10 +527,17 @@ The `Data` object stores the puck page data.
 - **root** (`object`):
   - **title** (string): Title of the content, typically used for the page title
   - **[prop]** (string): User defined data from `root` fields
-- **content** (`object[]`):
-  - **type** (string): Component name
-  - **props** (object):
-    - **[prop]** (string): User defined data from component fields
+- **content** (`ComponentData[]`): Component data for the main content
+- **zones** (`object`, optional): Component data for all DropZones
+  **[zoneCompound]** (`ComponentData[]`): Component data for a specific DropZone `zone` within a component instance
+
+### `ComponentData`
+
+- **type** (`string`): Component name
+- **props** (`object`):
+  - **[prop]** (`any`): User defined data from component fields
+- **readOnly** (`object`): Object describing which fields on the component are currently read-only. Can use dot-notation for arrays, like `array[1].text` or `array[*].text`.
+  - **[prop]** (`boolean`): boolean describing whether or not the prop field is read-only
 
 ### `Plugin`
 

--- a/README.md
+++ b/README.md
@@ -381,14 +381,14 @@ const config = {
 };
 ```
 
-### resolveData()
+### resolveAllData()
 
-`resolveData` is a utility function exported by Puck to enable the developer to resolve their custom props before rendering their component with `<Render>`. This is ideally done on the server. If you're using `resolveProps`, you _must_ use `resolveData` before rendering.
+`resolveAllData` is a utility function exported by Puck to enable the developer to resolve their custom props before rendering their component with `<Render>`. This is ideally done on the server. If you're using `resolveProps`, you _must_ use `resolveAllData` before rendering.
 
 ```tsx
-import { resolveData } from "@measured/puck";
+import { resolveAllData } from "@measured/puck";
 
-const resolvedData = resolveData(data, config);
+const resolvedData = resolveAllData(data, config);
 ```
 
 ## Reference

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Dynamic prop resolution allows developers to resolve props for components withou
 #### Response
 
 - **props** (`object`): the resolved props for your component. Will not be stored in the Puck data
-- **readOnly** (`object`): an object describing which fields on the component are currently read-only
+- **readOnly** (`object`): an object describing which fields on the component are currently read-only. Can also make array fields read-only by using a dot-notation accessor, like `array[0].text`.
   - **[prop]** (`boolean`): boolean describing whether or not the prop field is read-only
 
 #### Examples

--- a/README.md
+++ b/README.md
@@ -524,9 +524,9 @@ The `AppState` object stores the puck application state.
 
 The `Data` object stores the puck page data.
 
-- **root** (`object`):
-  - **title** (string): Title of the content, typically used for the page title
-  - **[prop]** (string): User defined data from `root` fields
+- **root** (`ComponentData`): The component data for the root of your configuration.
+  - **props** (object): Extends `ComponentData.props`, with some additional props
+    - **title** (string, optional): Title of the content, typically used for the page title
 - **content** (`ComponentData[]`): Component data for the main content
 - **zones** (`object`, optional): Component data for all DropZones
   **[zoneCompound]** (`ComponentData[]`): Component data for a specific DropZone `zone` within a component instance

--- a/apps/demo/app/[...puckPath]/client.tsx
+++ b/apps/demo/app/[...puckPath]/client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Data, resolveData } from "@measured/puck";
+import { Data } from "@measured/puck/types/Config";
+import { resolveData } from "@measured/puck/lib/resolve-data";
 import { Puck } from "@measured/puck/components/Puck";
 import { Render } from "@measured/puck/components/Render";
 import { useEffect, useState } from "react";

--- a/apps/demo/app/[...puckPath]/client.tsx
+++ b/apps/demo/app/[...puckPath]/client.tsx
@@ -43,7 +43,8 @@ export function Client({ path, isEdit }: { path: string; isEdit: boolean }) {
 
   useEffect(() => {
     if (!isEdit) {
-      document.title = data?.root?.title || "";
+      const title = data?.root.props?.title || data.root.title;
+      document.title = title || "";
     }
   }, [data, isEdit]);
 

--- a/apps/demo/app/[...puckPath]/client.tsx
+++ b/apps/demo/app/[...puckPath]/client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Data } from "@measured/puck/types/Config";
-import { resolveData } from "@measured/puck/lib/resolve-data";
+import { resolveAllData } from "@measured/puck/lib/resolve-all-data";
 import { Puck } from "@measured/puck/components/Puck";
 import { Render } from "@measured/puck/components/Render";
 import { useEffect, useState } from "react";
@@ -37,7 +37,7 @@ export function Client({ path, isEdit }: { path: string; isEdit: boolean }) {
 
   useEffect(() => {
     if (data && !isEdit) {
-      resolveData(data, config).then(setResolvedData);
+      resolveAllData(data, config).then(setResolvedData);
     }
   }, [data, isEdit]);
 

--- a/apps/demo/config/blocks/Hero/index.tsx
+++ b/apps/demo/config/blocks/Hero/index.tsx
@@ -85,8 +85,8 @@ export const Hero: ComponentConfig<HeroProps> = {
     padding: "64px",
   },
   /**
-   * The resolveProps method allows us to modify props after the Puck
-   * data has been set.
+   * The resolveData method allows us to modify component data after being
+   * set by the user.
    *
    * It is called after the page data is changed, but before a component
    * is rendered. This allows us to make dynamic changes to the props
@@ -94,7 +94,7 @@ export const Hero: ComponentConfig<HeroProps> = {
    *
    * For example, requesting a third-party API for the latest content.
    */
-  resolveProps: async (props, { changed }) => {
+  resolveData: async ({ props }, { changed }) => {
     if (!props.quote)
       return { props, readOnly: { title: false, description: false } };
 

--- a/apps/demo/config/blocks/Hero/index.tsx
+++ b/apps/demo/config/blocks/Hero/index.tsx
@@ -17,7 +17,12 @@ export type HeroProps = {
   padding: string;
   imageMode?: "inline" | "background";
   imageUrl?: string;
-  buttons: { label: string; href: string; variant?: "primary" | "secondary" }[];
+  buttons: {
+    label: string;
+    href: string;
+    variant?: "primary" | "secondary";
+    more?: { text: string }[];
+  }[];
 };
 
 export const Hero: ComponentConfig<HeroProps> = {

--- a/apps/demo/config/blocks/Hero/index.tsx
+++ b/apps/demo/config/blocks/Hero/index.tsx
@@ -89,9 +89,13 @@ export const Hero: ComponentConfig<HeroProps> = {
    *
    * For example, requesting a third-party API for the latest content.
    */
-  resolveProps: (props) => {
+  resolveProps: (props, { changed }) => {
     if (!props.quote)
       return { props, readOnly: { title: false, description: false } };
+
+    if (!changed.quote) {
+      return { props };
+    }
 
     return {
       props: {

--- a/apps/demo/config/blocks/Hero/index.tsx
+++ b/apps/demo/config/blocks/Hero/index.tsx
@@ -107,7 +107,6 @@ export const Hero: ComponentConfig<HeroProps> = {
 
     return {
       props: {
-        ...props,
         title: quotes[props.quote.index].author,
         description: quotes[props.quote.index].content,
       },

--- a/apps/demo/config/blocks/Hero/index.tsx
+++ b/apps/demo/config/blocks/Hero/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @next/next/no-img-element */
 import React, { useState } from "react";
-import { ComponentConfig } from "@measured/puck";
+import { ComponentConfig } from "@measured/puck/types/Config";
 import styles from "./styles.module.css";
 import { getClassNameFactory } from "@measured/puck/lib";
 import { Button } from "@measured/puck/components/Button";
@@ -89,7 +89,7 @@ export const Hero: ComponentConfig<HeroProps> = {
    *
    * For example, requesting a third-party API for the latest content.
    */
-  resolveProps: async (props) => {
+  resolveProps: (props) => {
     if (!props.quote)
       return { props, readOnly: { title: false, description: false } };
 

--- a/apps/demo/config/blocks/Hero/index.tsx
+++ b/apps/demo/config/blocks/Hero/index.tsx
@@ -89,13 +89,16 @@ export const Hero: ComponentConfig<HeroProps> = {
    *
    * For example, requesting a third-party API for the latest content.
    */
-  resolveProps: (props, { changed }) => {
+  resolveProps: async (props, { changed }) => {
     if (!props.quote)
       return { props, readOnly: { title: false, description: false } };
 
     if (!changed.quote) {
       return { props };
     }
+
+    // Simulate a delay
+    await new Promise((resolve) => setTimeout(resolve, 500));
 
     return {
       props: {

--- a/apps/demo/config/index.tsx
+++ b/apps/demo/config/index.tsx
@@ -278,7 +278,7 @@ export const initialData: Record<string, Data> = {
         props: { size: "96px", id: "VerticalSpace-1687284290127" },
       },
     ],
-    root: { title: "Puck Example" },
+    root: { props: { title: "Puck Example" } },
     zones: {
       "Columns-2d650a8ceb081a2c04f3a2d17a7703ca6efb0d06:column-0": [
         {
@@ -398,11 +398,11 @@ export const initialData: Record<string, Data> = {
   },
   "/pricing": {
     content: [],
-    root: { title: "Pricing" },
+    root: { props: { title: "Pricing" } },
   },
   "/about": {
     content: [],
-    root: { title: "About Us" },
+    root: { props: { title: "About Us" } },
   },
 };
 

--- a/packages/core/components/Draggable/index.tsx
+++ b/packages/core/components/Draggable/index.tsx
@@ -12,6 +12,7 @@ export const Draggable = ({
   index,
   showShadow,
   disableAnimations = false,
+  isDragDisabled = false,
 }: {
   className?: (
     provided: DraggableProvided,
@@ -25,9 +26,14 @@ export const Draggable = ({
   index: number;
   showShadow?: boolean;
   disableAnimations?: boolean;
+  isDragDisabled?: boolean;
 }) => {
   return (
-    <DndDraggable draggableId={id} index={index}>
+    <DndDraggable
+      draggableId={id}
+      index={index}
+      isDragDisabled={isDragDisabled}
+    >
       {(provided, snapshot) => (
         <>
           <div

--- a/packages/core/components/DraggableComponent/index.tsx
+++ b/packages/core/components/DraggableComponent/index.tsx
@@ -4,6 +4,7 @@ import styles from "./styles.module.css";
 import getClassNameFactory from "../../lib/get-class-name-factory";
 import { Copy, Trash } from "react-feather";
 import { useModifierHeld } from "../../lib/use-modifier-held";
+import { ClipLoader } from "react-spinners";
 
 const getClassName = getClassNameFactory("DraggableComponent", styles);
 
@@ -11,6 +12,7 @@ export const DraggableComponent = ({
   children,
   id,
   index,
+  isLoading = false,
   isSelected = false,
   onClick = () => null,
   onMount = () => null,
@@ -43,6 +45,7 @@ export const DraggableComponent = ({
   debug?: string;
   label?: string;
   isLocked: boolean;
+  isLoading: boolean;
   isDragDisabled?: boolean;
   forceHover?: boolean;
   indicativeHover?: boolean;
@@ -84,6 +87,11 @@ export const DraggableComponent = ({
           onClick={onClick}
         >
           {debug}
+          {isLoading && (
+            <div className={getClassName("loadingOverlay")}>
+              <ClipLoader size={16} color="inherit" />
+            </div>
+          )}
           <div className={getClassName("overlay")}>
             <div className={getClassName("actions")}>
               {label && (

--- a/packages/core/components/DraggableComponent/index.tsx
+++ b/packages/core/components/DraggableComponent/index.tsx
@@ -14,6 +14,8 @@ export const DraggableComponent = ({
   isSelected = false,
   onClick = () => null,
   onMount = () => null,
+  onMouseDown = () => null,
+  onMouseUp = () => null,
   onMouseOver = () => null,
   onMouseOut = () => null,
   onDelete = () => null,
@@ -32,6 +34,8 @@ export const DraggableComponent = ({
   isSelected?: boolean;
   onClick?: (e: SyntheticEvent) => void;
   onMount?: () => void;
+  onMouseDown?: (e: SyntheticEvent) => void;
+  onMouseUp?: (e: SyntheticEvent) => void;
   onMouseOver?: (e: SyntheticEvent) => void;
   onMouseOut?: (e: SyntheticEvent) => void;
   onDelete?: (e: SyntheticEvent) => void;
@@ -75,6 +79,8 @@ export const DraggableComponent = ({
           }}
           onMouseOver={onMouseOver}
           onMouseOut={onMouseOut}
+          onMouseDown={onMouseDown}
+          onMouseUp={onMouseUp}
           onClick={onClick}
         >
           {debug}

--- a/packages/core/components/DraggableComponent/styles.module.css
+++ b/packages/core/components/DraggableComponent/styles.module.css
@@ -35,6 +35,22 @@
   box-sizing: border-box;
 }
 
+.DraggableComponent-loadingOverlay {
+  background: var(--puck-color-white);
+  color: var(--puck-color-grey-2);
+  border-radius: 4px;
+  display: flex;
+  padding: 8px;
+  top: 8px;
+  right: 8px;
+  position: absolute;
+  z-index: 1;
+  pointer-events: all;
+  box-sizing: border-box;
+  opacity: 0.8;
+  z-index: 1;
+}
+
 .DraggableComponent:hover:not(.DraggableComponent--isLocked)
   > .DraggableComponent-overlay {
   display: block;

--- a/packages/core/components/DraggableComponent/styles.module.css
+++ b/packages/core/components/DraggableComponent/styles.module.css
@@ -29,7 +29,7 @@
   width: 100%;
   top: 0;
   position: absolute;
-  z-index: 1;
+  z-index: 0;
   font-family: var(--puck-font-stack);
   pointer-events: none;
   box-sizing: border-box;

--- a/packages/core/components/DropZone/context.tsx
+++ b/packages/core/components/DropZone/context.tsx
@@ -18,7 +18,7 @@ export type PathData = Record<string, { path: string[]; label: string }>;
 export type DropZoneContext = {
   data: Data;
   config: Config;
-  dynamicProps?: Record<string, any>;
+  componentState?: Record<string, any>;
   itemSelector?: ItemSelector | null;
   setItemSelector?: (newIndex: ItemSelector | null) => void;
   dispatch?: (action: PuckAction) => void;

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -26,7 +26,6 @@ function DropZoneEdit({ zone, style }: DropZoneProps) {
   const {
     // These all need setting via context
     data,
-    dynamicProps = {},
     dispatch = () => null,
     config,
     itemSelector,
@@ -175,7 +174,7 @@ function DropZoneEdit({ zone, style }: DropZoneProps) {
 
                 const defaultedProps = {
                   ...config.components[item.type]?.defaultProps,
-                  ...(dynamicProps[item.props.id] || item.props),
+                  ...item.props,
                   editMode: true,
                 };
 
@@ -226,8 +225,7 @@ function DropZoneEdit({ zone, style }: DropZoneProps) {
                           hoveringArea === componentId
                         }
                         isLoading={
-                          appContext.state.ui.componentState[componentId]
-                            ?.loading
+                          appContext.componentState[componentId]?.loading
                         }
                         onMount={() => {
                           ctx.registerPath!({

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, useContext, useEffect } from "react";
+import { CSSProperties, useContext, useEffect, useState } from "react";
 import { DraggableComponent } from "../DraggableComponent";
 import DroppableStrictMode from "../DroppableStrictMode";
 import { getItem } from "../../lib/get-item";
@@ -79,6 +79,8 @@ function DropZoneEdit({ zone, style }: DropZoneProps) {
   // we use the index rather than spread to prevent down-level iteration warnings: https://stackoverflow.com/questions/53441292/why-downleveliteration-is-not-on-by-default
   const [draggedSourceArea] = getZoneId(draggedSourceId);
 
+  const [userWillDrag, setUserWillDrag] = useState(false);
+
   const userIsDragging = !!draggedItem;
   const draggingOverArea = userIsDragging && zoneArea === draggedSourceArea;
   const draggingNewComponent = draggedSourceId?.startsWith("component-list");
@@ -108,7 +110,7 @@ function DropZoneEdit({ zone, style }: DropZoneProps) {
     : isRootZone;
   const hoveringOverZone = hoveringZone === zoneCompound;
 
-  let isEnabled = false;
+  let isEnabled = userWillDrag;
 
   /**
    * We enable zones when:
@@ -233,6 +235,14 @@ function DropZoneEdit({ zone, style }: DropZoneProps) {
                             zone: zoneCompound,
                           });
                           e.stopPropagation();
+                        }}
+                        onMouseDown={(e) => {
+                          e.stopPropagation();
+                          setUserWillDrag(true);
+                        }}
+                        onMouseUp={(e) => {
+                          e.stopPropagation();
+                          setUserWillDrag(false);
                         }}
                         onMouseOver={(e) => {
                           e.stopPropagation();

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -8,6 +8,7 @@ import { getClassNameFactory } from "../../lib";
 import styles from "./styles.module.css";
 import { DropZoneProvider, dropZoneContext } from "./context";
 import { getZoneId } from "../../lib/get-zone-id";
+import { useAppContext } from "../Puck/context";
 
 const getClassName = getClassNameFactory("DropZone", styles);
 
@@ -19,6 +20,7 @@ type DropZoneProps = {
 };
 
 function DropZoneEdit({ zone, style }: DropZoneProps) {
+  const appContext = useAppContext();
   const ctx = useContext(dropZoneContext);
 
   const {
@@ -222,6 +224,10 @@ function DropZoneEdit({ zone, style }: DropZoneProps) {
                           userIsDragging &&
                           containsZone &&
                           hoveringArea === componentId
+                        }
+                        isLoading={
+                          appContext.state.ui.componentState[componentId]
+                            ?.loading
                         }
                         onMount={() => {
                           ctx.registerPath!({

--- a/packages/core/components/DropZone/styles.module.css
+++ b/packages/core/components/DropZone/styles.module.css
@@ -48,7 +48,6 @@
 
 .DropZone-item {
   position: relative;
-  z-index: 0;
 }
 
 .DropZone-hitbox {

--- a/packages/core/components/ExternalInput/index.tsx
+++ b/packages/core/components/ExternalInput/index.tsx
@@ -3,6 +3,7 @@ import styles from "./styles.module.css";
 import getClassNameFactory from "../../lib/get-class-name-factory";
 import { ExternalField } from "../../types/Config";
 import { Link } from "react-feather";
+import { Modal } from "../Modal";
 
 const getClassName = getClassNameFactory("ExternalInput", styles);
 
@@ -88,53 +89,48 @@ export const ExternalInput = ({
           </button>
         )}
       </div>
-      <div className={getClassName("modal")} onClick={() => setOpen(false)}>
-        <div
-          className={getClassName("modalInner")}
-          onClick={(e) => e.stopPropagation()}
-        >
-          <h2 className={getClassName("modalHeading")}>Select content</h2>
+      <Modal onClose={() => setOpen(false)} isOpen={isOpen}>
+        <h2 className={getClassName("modalHeading")}>Select content</h2>
 
-          {data.length ? (
-            <div className={getClassName("modalTableWrapper")}>
-              <table>
-                <thead>
-                  <tr>
-                    {keys.map((key) => (
-                      <th key={key} style={{ textAlign: "left" }}>
-                        {key}
-                      </th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {data.map((item, i) => {
-                    return (
-                      <tr
-                        key={i}
-                        style={{ whiteSpace: "nowrap" }}
-                        onClick={(e) => {
-                          onChange(mapProp(item));
+        {data.length ? (
+          <div className={getClassName("modalTableWrapper")}>
+            <table className={getClassName("table")}>
+              <thead>
+                <tr>
+                  {keys.map((key) => (
+                    <th key={key} style={{ textAlign: "left" }}>
+                      {key}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {data.map((item, i) => {
+                  return (
+                    <tr
+                      key={i}
+                      style={{ whiteSpace: "nowrap" }}
+                      onClick={(e) => {
+                        onChange(mapProp(item));
 
-                          setOpen(false);
+                        setOpen(false);
 
-                          setSelectedData(mapProp(item));
-                        }}
-                      >
-                        {keys.map((key) => (
-                          <td key={key}>{item[key]}</td>
-                        ))}
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-          ) : (
-            <div style={{ padding: 24 }}>No content</div>
-          )}
-        </div>
-      </div>
+                        setSelectedData(mapProp(item));
+                      }}
+                    >
+                      {keys.map((key) => (
+                        <td key={key}>{item[key]}</td>
+                      ))}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div style={{ padding: 24 }}>No content</div>
+        )}
+      </Modal>
     </div>
   );
 };

--- a/packages/core/components/ExternalInput/index.tsx
+++ b/packages/core/components/ExternalInput/index.tsx
@@ -2,7 +2,7 @@ import { useMemo, useEffect, useState } from "react";
 import styles from "./styles.module.css";
 import getClassNameFactory from "../../lib/get-class-name-factory";
 import { ExternalField } from "../../types/Config";
-import { Link } from "react-feather";
+import { Link, Unlock } from "react-feather";
 import { Modal } from "../Modal";
 import { Heading } from "../Heading";
 
@@ -86,7 +86,7 @@ export const ExternalInput = ({
               onChange(null);
             }}
           >
-            Detach
+            <Unlock size={16} />
           </button>
         )}
       </div>

--- a/packages/core/components/ExternalInput/index.tsx
+++ b/packages/core/components/ExternalInput/index.tsx
@@ -4,6 +4,7 @@ import getClassNameFactory from "../../lib/get-class-name-factory";
 import { ExternalField } from "../../types/Config";
 import { Link } from "react-feather";
 import { Modal } from "../Modal";
+import { Heading } from "../Heading";
 
 const getClassName = getClassNameFactory("ExternalInput", styles);
 
@@ -90,7 +91,11 @@ export const ExternalInput = ({
         )}
       </div>
       <Modal onClose={() => setOpen(false)} isOpen={isOpen}>
-        <h2 className={getClassName("modalHeading")}>Select content</h2>
+        <div className={getClassName("masthead")}>
+          <Heading rank={2} size="xxl">
+            Select content
+          </Heading>
+        </div>
 
         {data.length ? (
           <div className={getClassName("modalTableWrapper")}>

--- a/packages/core/components/ExternalInput/styles.module.css
+++ b/packages/core/components/ExternalInput/styles.module.css
@@ -14,7 +14,7 @@
   background-color: white;
   border: 1px solid var(--puck-color-grey-8);
   border-radius: 4px;
-  color: var(--puck-color-grey-2);
+  color: var(--puck-color-azure-4);
   padding: 12px 16px;
   font-weight: 500;
   white-space: nowrap;
@@ -33,6 +33,7 @@
 }
 
 .ExternalInput--hasData .ExternalInput-button {
+  color: var(--puck-color-grey-2);
   display: block;
   border-top-right-radius: 0px;
   border-bottom-right-radius: 0px;

--- a/packages/core/components/ExternalInput/styles.module.css
+++ b/packages/core/components/ExternalInput/styles.module.css
@@ -52,35 +52,6 @@
   margin-left: -1px;
 }
 
-.ExternalInput-modal {
-  background: #00000099;
-  display: none;
-  justify-content: center;
-  align-items: center;
-  position: fixed;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
-  z-index: 1;
-  padding: 64px;
-}
-
-.ExternalInput--modalVisible .ExternalInput-modal {
-  display: flex;
-}
-
-.ExternalInput-modalInner {
-  width: 100%;
-  max-width: 1024px;
-  border-radius: 16px;
-  overflow: hidden;
-  background: white;
-  display: flex;
-  flex-direction: column;
-  max-height: 90vh;
-}
-
 .ExternalInput-modalHeading {
   background-color: white;
   padding: 32px 24px;
@@ -92,18 +63,18 @@
   flex-grow: 1;
 }
 
-.ExternalInput table {
+.ExternalInput-table {
   border-spacing: 0px;
   color: var(--puck-color-neutral-4);
   position: relative;
 }
 
-.ExternalInput thead {
+.ExternalInput-table thead {
   position: sticky;
   top: 0;
 }
 
-.ExternalInput th {
+.ExternalInput-table th {
   border-bottom: 1px solid var(--puck-color-grey-8);
   border-top: 1px solid var(--puck-color-grey-8);
   font-weight: 700;
@@ -111,23 +82,23 @@
   opacity: 0.9;
 }
 
-.ExternalInput td {
+.ExternalInput-table td {
   padding: 16px 24px;
 }
 
-.ExternalInput tr:nth-of-type(n) {
+.ExternalInput-table tr:nth-of-type(n) {
   background-color: white;
 }
 
-.ExternalInput tr:nth-of-type(2n) {
+.ExternalInput-table tr:nth-of-type(2n) {
   background-color: var(--puck-color-grey-10);
 }
 
-.ExternalInput tr td:first-of-type {
+.ExternalInput-table tr td:first-of-type {
   font-weight: 500;
 }
 
-.ExternalInput tbody tr:hover {
+.ExternalInput-table tbody tr:hover {
   background: var(--puck-color-grey-11);
   color: var(--puck-color-azure-4);
   cursor: pointer;
@@ -135,7 +106,7 @@
   margin-left: -5px;
 }
 
-.ExternalInput tbody tr:hover td:first-of-type {
+.ExternalInput-table tbody tr:hover td:first-of-type {
   border-left: 4px solid var(--puck-color-azure-4);
   padding-left: 20px;
 }

--- a/packages/core/components/ExternalInput/styles.module.css
+++ b/packages/core/components/ExternalInput/styles.module.css
@@ -52,7 +52,7 @@
   margin-left: -1px;
 }
 
-.ExternalInput-modalHeading {
+.ExternalInput-masthead {
   background-color: white;
   padding: 32px 24px;
 }

--- a/packages/core/components/ExternalInput/styles.module.css
+++ b/packages/core/components/ExternalInput/styles.module.css
@@ -14,7 +14,7 @@
   background-color: white;
   border: 1px solid var(--puck-color-grey-8);
   border-radius: 4px;
-  color: var(--puck-color-blue);
+  color: var(--puck-color-grey-2);
   padding: 12px 16px;
   font-weight: 500;
   white-space: nowrap;
@@ -27,14 +27,13 @@
 .ExternalInput-button:hover,
 .ExternalInput-detachButton:hover {
   cursor: pointer;
-  background: var(--puck-color-grey-10);
-  border-color: var(--puck-color-neutral-3);
+  background: var(--puck-color-azure-9);
+  color: var(--puck-color-azure-4);
   z-index: 1;
 }
 
 .ExternalInput--hasData .ExternalInput-button {
   display: block;
-  color: var(--puck-color-neutral-4);
   border-top-right-radius: 0px;
   border-bottom-right-radius: 0px;
 }
@@ -43,7 +42,8 @@
   border: 1px solid var(--puck-color-grey-8);
   border-top-right-radius: 4px;
   border-bottom-right-radius: 4px;
-  background-color: var(--puck-color-neutral-1);
+  background-color: var(--puck-color-grey-11);
+  color: var(--puck-color-grey-4);
   display: flex;
   gap: 8px;
   align-items: center;

--- a/packages/core/components/InputOrGroup/fields/ArrayField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/ArrayField/index.tsx
@@ -1,5 +1,4 @@
 import getClassNameFactory from "../../../../lib/get-class-name-factory";
-import inputStyles from "../../styles.module.css";
 import styles from "./styles.module.css";
 import { List, Plus, Trash } from "react-feather";
 import { FieldLabelInternal, InputOrGroup, type InputProps } from "../..";
@@ -14,7 +13,6 @@ import { DragIcon } from "../../../DragIcon";
 import { ArrayState, ItemWithId } from "../../../../types/Config";
 import { useAppContext } from "../../../Puck/context";
 
-const getClassNameInput = getClassNameFactory("Input", inputStyles);
 const getClassName = getClassNameFactory("ArrayField", styles);
 const getClassNameItem = getClassNameFactory("ArrayFieldItem", styles);
 
@@ -25,6 +23,7 @@ export const ArrayField = ({
   name,
   label,
   readOnly,
+  readOnlyFields = {},
 }: InputProps) => {
   const [arrayFieldId] = useState(generateId("ArrayField"));
 
@@ -177,11 +176,19 @@ export const ArrayField = ({
                                     const subField =
                                       field.arrayFields![fieldName];
 
+                                    const subFieldName = `${name}[${i}].${fieldName}`;
+                                    const zeroIndexSubFieldName =
+                                      subFieldName.replace(/\[\d\]/g, "[0]");
+
                                     return (
                                       <InputOrGroup
-                                        key={`${name}_${i}_${fieldName}`}
-                                        name={`${name}_${i}_${fieldName}`}
+                                        key={subFieldName}
+                                        name={subFieldName}
                                         label={subField.label || fieldName}
+                                        readOnly={
+                                          readOnlyFields[zeroIndexSubFieldName]
+                                        }
+                                        readOnlyFields={readOnlyFields}
                                         field={subField}
                                         value={data[fieldName]}
                                         onChange={(val) =>

--- a/packages/core/components/InputOrGroup/fields/ArrayField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/ArrayField/index.tsx
@@ -177,8 +177,7 @@ export const ArrayField = ({
                                       field.arrayFields![fieldName];
 
                                     const subFieldName = `${name}[${i}].${fieldName}`;
-                                    const zeroIndexSubFieldName =
-                                      subFieldName.replace(/\[\d\]/g, "[0]");
+                                    const wildcardFieldName = `${name}[*].${fieldName}`;
 
                                     return (
                                       <InputOrGroup
@@ -186,7 +185,11 @@ export const ArrayField = ({
                                         name={subFieldName}
                                         label={subField.label || fieldName}
                                         readOnly={
-                                          readOnlyFields[zeroIndexSubFieldName]
+                                          typeof readOnlyFields[
+                                            subFieldName
+                                          ] !== "undefined"
+                                            ? readOnlyFields[subFieldName]
+                                            : readOnlyFields[wildcardFieldName]
                                         }
                                         readOnlyFields={readOnlyFields}
                                         field={subField}

--- a/packages/core/components/InputOrGroup/fields/ArrayField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/ArrayField/index.tsx
@@ -2,7 +2,7 @@ import getClassNameFactory from "../../../../lib/get-class-name-factory";
 import inputStyles from "../../styles.module.css";
 import styles from "./styles.module.css";
 import { List, Plus, Trash } from "react-feather";
-import { InputOrGroup, type InputProps } from "../..";
+import { FieldLabelInternal, InputOrGroup, type InputProps } from "../..";
 import { IconButton } from "../../../IconButton";
 import { reorder, replace } from "../../../../lib";
 import DroppableStrictMode from "../../../DroppableStrictMode";
@@ -69,13 +69,12 @@ export const ArrayField = ({
   }
 
   return (
-    <div className={getClassNameInput()}>
-      <b className={getClassNameInput("label")}>
-        <div className={getClassNameInput("labelIcon")}>
-          <List size={16} />
-        </div>
-        {label || name}
-      </b>
+    <FieldLabelInternal
+      label={label || name}
+      icon={<List size={16} />}
+      el="div"
+      readOnly={readOnly}
+    >
       <DragDropContext
         onDragEnd={(event) => {
           if (event.destination) {
@@ -221,6 +220,6 @@ export const ArrayField = ({
           }}
         </DroppableStrictMode>
       </DragDropContext>
-    </div>
+    </FieldLabelInternal>
   );
 };

--- a/packages/core/components/InputOrGroup/fields/ArrayField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/ArrayField/index.tsx
@@ -24,6 +24,7 @@ export const ArrayField = ({
   value,
   name,
   label,
+  readOnly,
 }: InputProps) => {
   const [arrayFieldId] = useState(generateId("ArrayField"));
 
@@ -89,7 +90,7 @@ export const ArrayField = ({
           }
         }}
       >
-        <DroppableStrictMode droppableId="array">
+        <DroppableStrictMode droppableId="array" isDropDisabled={readOnly}>
           {(provided, snapshot) => {
             return (
               <div
@@ -110,8 +111,10 @@ export const ArrayField = ({
                           getClassNameItem({
                             isExpanded: arrayState.openId === _arrayId,
                             isDragging: snapshot.isDragging,
+                            readOnly,
                           })
                         }
+                        isDragDisabled={readOnly}
                       >
                         {() => (
                           <>
@@ -133,32 +136,34 @@ export const ArrayField = ({
                                 ? field.getItemSummary(data, i)
                                 : `Item #${i}`}
                               <div className={getClassNameItem("rhs")}>
-                                <div className={getClassNameItem("actions")}>
-                                  <div className={getClassNameItem("action")}>
-                                    <IconButton
-                                      onClick={() => {
-                                        const existingValue = [
-                                          ...(value || []),
-                                        ];
-                                        const existingItems = [
-                                          ...(arrayState.items || []),
-                                        ];
+                                {!readOnly && (
+                                  <div className={getClassNameItem("actions")}>
+                                    <div className={getClassNameItem("action")}>
+                                      <IconButton
+                                        onClick={() => {
+                                          const existingValue = [
+                                            ...(value || []),
+                                          ];
+                                          const existingItems = [
+                                            ...(arrayState.items || []),
+                                          ];
 
-                                        existingValue.splice(i, 1);
-                                        existingItems.splice(i, 1);
+                                          existingValue.splice(i, 1);
+                                          existingItems.splice(i, 1);
 
-                                        setArrayState(
-                                          { items: existingItems },
-                                          true
-                                        );
-                                        onChange(existingValue);
-                                      }}
-                                      title="Delete"
-                                    >
-                                      <Trash size={16} />
-                                    </IconButton>
+                                          setArrayState(
+                                            { items: existingItems },
+                                            true
+                                          );
+                                          onChange(existingValue);
+                                        }}
+                                        title="Delete"
+                                      >
+                                        <Trash size={16} />
+                                      </IconButton>
+                                    </div>
                                   </div>
-                                </div>
+                                )}
                                 <div>
                                   <DragIcon />
                                 </div>

--- a/packages/core/components/InputOrGroup/fields/ArrayField/styles.module.css
+++ b/packages/core/components/InputOrGroup/fields/ArrayField/styles.module.css
@@ -81,7 +81,7 @@
   overflow: hidden;
 }
 
-.ArrayFieldItem--readOnly .ArrayFieldItem-summary {
+.ArrayFieldItem--readOnly > .ArrayFieldItem-summary {
   background-color: var(--puck-color-grey-11);
   color: var(--puck-color-grey-5);
 }

--- a/packages/core/components/InputOrGroup/fields/ArrayField/styles.module.css
+++ b/packages/core/components/InputOrGroup/fields/ArrayField/styles.module.css
@@ -81,6 +81,11 @@
   overflow: hidden;
 }
 
+.ArrayFieldItem--readOnly .ArrayFieldItem-summary {
+  background-color: var(--puck-color-grey-11);
+  color: var(--puck-color-grey-5);
+}
+
 .ArrayFieldItem--isExpanded > .ArrayFieldItem-summary {
   font-weight: 600;
 }

--- a/packages/core/components/InputOrGroup/fields/DefaultField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/DefaultField/index.tsx
@@ -1,7 +1,7 @@
 import getClassNameFactory from "../../../../lib/get-class-name-factory";
 import styles from "../../styles.module.css";
 import { Hash, Type } from "react-feather";
-import type { InputProps } from "../..";
+import { FieldLabelInternal, type InputProps } from "../..";
 
 const getClassName = getClassNameFactory("Input", styles);
 
@@ -14,14 +14,16 @@ export const DefaultField = ({
   label,
 }: InputProps) => {
   return (
-    <label className={getClassName({ readOnly })}>
-      <div className={getClassName("label")}>
-        <div className={getClassName("labelIcon")}>
+    <FieldLabelInternal
+      label={label || name}
+      icon={
+        <>
           {field.type === "text" && <Type size={16} />}
           {field.type === "number" && <Hash size={16} />}
-        </div>
-        {label || name}
-      </div>
+        </>
+      }
+      readOnly={readOnly}
+    >
       <input
         className={getClassName("input")}
         autoComplete="off"
@@ -37,6 +39,6 @@ export const DefaultField = ({
         }}
         readOnly={readOnly}
       />
-    </label>
+    </FieldLabelInternal>
   );
 };

--- a/packages/core/components/InputOrGroup/fields/ExternalField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/ExternalField/index.tsx
@@ -1,6 +1,6 @@
 import getClassNameFactory from "../../../../lib/get-class-name-factory";
 import styles from "../../styles.module.css";
-import type { InputProps } from "../..";
+import { FieldLabelInternal, type InputProps } from "../..";
 import { ExternalInput } from "../../../ExternalInput";
 import { Link } from "react-feather";
 
@@ -18,15 +18,12 @@ export const ExternalField = ({
   }
 
   return (
-    <div className={getClassName()}>
-      <div className={getClassName("label")}>
-        <div className={getClassName("labelIcon")}>
-          <Link size={16} />
-        </div>
-
-        {label || name}
-      </div>
+    <FieldLabelInternal
+      label={label || name}
+      icon={<Link size={16} />}
+      el="div"
+    >
       <ExternalInput field={field} onChange={onChange} value={value} />
-    </div>
+    </FieldLabelInternal>
   );
 };

--- a/packages/core/components/InputOrGroup/fields/ExternalField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/ExternalField/index.tsx
@@ -4,8 +4,6 @@ import { FieldLabelInternal, type InputProps } from "../..";
 import { ExternalInput } from "../../../ExternalInput";
 import { Link } from "react-feather";
 
-const getClassName = getClassNameFactory("Input", styles);
-
 export const ExternalField = ({
   field,
   onChange,

--- a/packages/core/components/InputOrGroup/fields/ExternalField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/ExternalField/index.tsx
@@ -1,5 +1,3 @@
-import getClassNameFactory from "../../../../lib/get-class-name-factory";
-import styles from "../../styles.module.css";
 import { FieldLabelInternal, type InputProps } from "../..";
 import { ExternalInput } from "../../../ExternalInput";
 import { Link } from "react-feather";

--- a/packages/core/components/InputOrGroup/fields/RadioField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/RadioField/index.tsx
@@ -1,7 +1,7 @@
 import getClassNameFactory from "../../../../lib/get-class-name-factory";
 import styles from "../../styles.module.css";
 import { CheckCircle } from "react-feather";
-import type { InputProps } from "../..";
+import { FieldLabelInternal, type InputProps } from "../..";
 
 const getClassName = getClassNameFactory("Input", styles);
 
@@ -17,47 +17,43 @@ export const RadioField = ({
   }
 
   return (
-    <div className={getClassName({ readOnly })}>
-      <div className={getClassName("radioGroup")}>
-        <div className={getClassName("label")}>
-          <div className={getClassName("labelIcon")}>
-            <CheckCircle size={16} />
-          </div>
-          {field.label || name}
-        </div>
+    <FieldLabelInternal
+      icon={<CheckCircle size={16} />}
+      label={field.label || name}
+      readOnly={readOnly}
+      el="div"
+    >
+      <div className={getClassName("radioGroupItems")}>
+        {field.options.map((option) => (
+          <label
+            key={option.label + option.value}
+            className={getClassName("radio")}
+          >
+            <input
+              type="radio"
+              className={getClassName("radioInput")}
+              value={option.value as string | number}
+              name={name}
+              onChange={(e) => {
+                if (
+                  e.currentTarget.value === "true" ||
+                  e.currentTarget.value === "false"
+                ) {
+                  onChange(JSON.parse(e.currentTarget.value));
+                  return;
+                }
 
-        <div className={getClassName("radioGroupItems")}>
-          {field.options.map((option) => (
-            <label
-              key={option.label + option.value}
-              className={getClassName("radio")}
-            >
-              <input
-                type="radio"
-                className={getClassName("radioInput")}
-                value={option.value as string | number}
-                name={name}
-                onChange={(e) => {
-                  if (
-                    e.currentTarget.value === "true" ||
-                    e.currentTarget.value === "false"
-                  ) {
-                    onChange(JSON.parse(e.currentTarget.value));
-                    return;
-                  }
-
-                  onChange(e.currentTarget.value);
-                }}
-                disabled={readOnly}
-                defaultChecked={value === option.value}
-              />
-              <div className={getClassName("radioInner")}>
-                {option.label || option.value}
-              </div>
-            </label>
-          ))}
-        </div>
+                onChange(e.currentTarget.value);
+              }}
+              disabled={readOnly}
+              defaultChecked={value === option.value}
+            />
+            <div className={getClassName("radioInner")}>
+              {option.label || option.value}
+            </div>
+          </label>
+        ))}
       </div>
-    </div>
+    </FieldLabelInternal>
   );
 };

--- a/packages/core/components/InputOrGroup/fields/RadioField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/RadioField/index.tsx
@@ -17,7 +17,7 @@ export const RadioField = ({
   }
 
   return (
-    <div className={getClassName()}>
+    <div className={getClassName({ readOnly })}>
       <div className={getClassName("radioGroup")}>
         <div className={getClassName("label")}>
           <div className={getClassName("labelIcon")}>
@@ -48,7 +48,7 @@ export const RadioField = ({
 
                   onChange(e.currentTarget.value);
                 }}
-                readOnly={readOnly}
+                disabled={readOnly}
                 defaultChecked={value === option.value}
               />
               <div className={getClassName("radioInner")}>

--- a/packages/core/components/InputOrGroup/fields/SelectField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/SelectField/index.tsx
@@ -11,13 +11,14 @@ export const SelectField = ({
   label,
   value,
   name,
+  readOnly,
 }: InputProps) => {
   if (field.type !== "select" || !field.options) {
     return null;
   }
 
   return (
-    <label className={getClassName()}>
+    <label className={getClassName({ readOnly })}>
       <div className={getClassName("label")}>
         <div className={getClassName("labelIcon")}>
           <ChevronDown size={16} />
@@ -26,6 +27,7 @@ export const SelectField = ({
       </div>
       <select
         className={getClassName("input")}
+        disabled={readOnly}
         onChange={(e) => {
           if (
             e.currentTarget.value === "true" ||

--- a/packages/core/components/InputOrGroup/fields/SelectField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/SelectField/index.tsx
@@ -1,7 +1,7 @@
 import getClassNameFactory from "../../../../lib/get-class-name-factory";
 import styles from "../../styles.module.css";
 import { ChevronDown } from "react-feather";
-import type { InputProps } from "../..";
+import { FieldLabelInternal, type InputProps } from "../..";
 
 const getClassName = getClassNameFactory("Input", styles);
 
@@ -18,13 +18,11 @@ export const SelectField = ({
   }
 
   return (
-    <label className={getClassName({ readOnly })}>
-      <div className={getClassName("label")}>
-        <div className={getClassName("labelIcon")}>
-          <ChevronDown size={16} />
-        </div>
-        {label || name}
-      </div>
+    <FieldLabelInternal
+      label={label || name}
+      icon={<ChevronDown size={16} />}
+      readOnly={readOnly}
+    >
       <select
         className={getClassName("input")}
         disabled={readOnly}
@@ -49,6 +47,6 @@ export const SelectField = ({
           />
         ))}
       </select>
-    </label>
+    </FieldLabelInternal>
   );
 };

--- a/packages/core/components/InputOrGroup/fields/TextareaField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/TextareaField/index.tsx
@@ -1,7 +1,7 @@
 import getClassNameFactory from "../../../../lib/get-class-name-factory";
 import styles from "../../styles.module.css";
 import { Type } from "react-feather";
-import type { InputProps } from "../..";
+import { FieldLabelInternal, type InputProps } from "../..";
 
 const getClassName = getClassNameFactory("Input", styles);
 
@@ -13,13 +13,11 @@ export const TextareaField = ({
   label,
 }: InputProps) => {
   return (
-    <label className={getClassName({ readOnly })}>
-      <div className={getClassName("label")}>
-        <div className={getClassName("labelIcon")}>
-          <Type size={16} />
-        </div>
-        {label || name}
-      </div>
+    <FieldLabelInternal
+      label={label || name}
+      icon={<Type size={16} />}
+      readOnly={readOnly}
+    >
       <textarea
         className={getClassName("input")}
         autoComplete="off"
@@ -29,6 +27,6 @@ export const TextareaField = ({
         readOnly={readOnly}
         rows={5}
       />
-    </label>
+    </FieldLabelInternal>
   );
 };

--- a/packages/core/components/InputOrGroup/index.tsx
+++ b/packages/core/components/InputOrGroup/index.tsx
@@ -18,19 +18,53 @@ export const FieldLabel = ({
   children,
   icon,
   label,
+  el = "label",
+  readOnly,
+  className,
 }: {
   children?: ReactNode;
   icon?: ReactNode;
   label: string;
+  el?: "label" | "div";
+  readOnly?: boolean;
+  className?: string;
 }) => {
+  const El = el;
   return (
-    <label>
+    <El className={className}>
       <div className={getClassName("label")}>
         {icon ? <div className={getClassName("labelIcon")}>{icon}</div> : <></>}
         {label}
       </div>
       {children}
-    </label>
+    </El>
+  );
+};
+
+export const FieldLabelInternal = ({
+  children,
+  icon,
+  label,
+  el = "label",
+  readOnly,
+}: {
+  children?: ReactNode;
+  icon?: ReactNode;
+  label: string;
+  el?: "label" | "div";
+  readOnly?: boolean;
+}) => {
+  const El = el;
+  return (
+    <FieldLabel
+      label={label}
+      icon={icon}
+      className={getClassName({ readOnly })}
+      readOnly={readOnly}
+      el={el}
+    >
+      {children}
+    </FieldLabel>
   );
 };
 

--- a/packages/core/components/InputOrGroup/index.tsx
+++ b/packages/core/components/InputOrGroup/index.tsx
@@ -11,6 +11,7 @@ import {
   DefaultField,
   TextareaField,
 } from "./fields";
+import { Lock } from "react-feather";
 
 const getClassName = getClassNameFactory("Input", styles);
 
@@ -35,6 +36,12 @@ export const FieldLabel = ({
       <div className={getClassName("label")}>
         {icon ? <div className={getClassName("labelIcon")}>{icon}</div> : <></>}
         {label}
+
+        {readOnly && (
+          <div className={getClassName("disabledIcon")} title="Read-only">
+            <Lock size="12" />
+          </div>
+        )}
       </div>
       {children}
     </El>

--- a/packages/core/components/InputOrGroup/index.tsx
+++ b/packages/core/components/InputOrGroup/index.tsx
@@ -82,6 +82,7 @@ export type InputProps = {
   label?: string;
   onChange: (value: any) => void;
   readOnly?: boolean;
+  readOnlyFields?: Record<string, boolean | undefined>;
 };
 
 export const InputOrGroup = (props: InputProps) => {

--- a/packages/core/components/InputOrGroup/styles.module.css
+++ b/packages/core/components/InputOrGroup/styles.module.css
@@ -57,9 +57,12 @@
   background-color: white;
 }
 
-.Input--readOnly .Input-input {
-  background-color: var(--puck-color-grey-10);
+.Input--readOnly .Input-input,
+.Input--readOnly select.Input-input {
+  background-color: var(--puck-color-grey-11);
   border-color: var(--puck-color-grey-8);
+  color: var(--puck-color-grey-5);
+  opacity: 1;
 }
 
 .Input-input:hover {
@@ -84,6 +87,7 @@
 }
 
 .Input-radioInner {
+  background-color: white;
   color: var(--puck-color-grey-4);
   font-size: var(--puck-font-size-xxxs);
   padding: 8px 12px;
@@ -95,10 +99,24 @@
   cursor: pointer;
 }
 
+.Input--readOnly .Input-radioGroupItems {
+  border-color: var(--puck-color-grey-8);
+}
+
+.Input--readOnly .Input-radioInner {
+  background-color: var(--puck-color-grey-11);
+  color: var(--puck-color-grey-5);
+}
+
 .Input-radio .Input-radioInput:checked ~ .Input-radioInner {
   background-color: var(--puck-color-azure-9);
-  color: var(--puck-color-grey-2);
+  color: var(--puck-color-grey-1);
   font-weight: 500;
+}
+
+.Input--readOnly .Input-radioInput:checked ~ .Input-radioInner {
+  background-color: var(--puck-color-azure-9);
+  color: var(--puck-color-grey-4);
 }
 
 .Input-radio .Input-radioInput {

--- a/packages/core/components/InputOrGroup/styles.module.css
+++ b/packages/core/components/InputOrGroup/styles.module.css
@@ -57,8 +57,8 @@
   background-color: white;
 }
 
-.Input--readOnly .Input-input,
-.Input--readOnly select.Input-input {
+.Input--readOnly > .Input-input,
+.Input--readOnly > select.Input-input {
   background-color: var(--puck-color-grey-11);
   border-color: var(--puck-color-grey-8);
   color: var(--puck-color-grey-5);

--- a/packages/core/components/InputOrGroup/styles.module.css
+++ b/packages/core/components/InputOrGroup/styles.module.css
@@ -34,6 +34,12 @@
 .Input-labelIcon {
   color: var(--puck-color-grey-6);
   margin-right: 4px;
+  padding-left: 4px;
+}
+
+.Input-disabledIcon {
+  color: var(--puck-color-grey-4);
+  margin-left: auto;
 }
 
 .Input-input {

--- a/packages/core/components/Modal/index.tsx
+++ b/packages/core/components/Modal/index.tsx
@@ -1,0 +1,34 @@
+import { ReactNode } from "react";
+import getClassNameFactory from "../../lib/get-class-name-factory";
+import styles from "./styles.module.css";
+import { createPortal } from "react-dom";
+
+const getClassName = getClassNameFactory("Modal", styles);
+
+export const Modal = ({
+  children,
+  onClose,
+  isOpen,
+}: {
+  children: ReactNode;
+  onClose: () => void;
+  isOpen: boolean;
+}) => {
+  const rootEl = document.getElementById("puck-portal-root");
+
+  if (!rootEl) {
+    return <div />;
+  }
+
+  return createPortal(
+    <div className={getClassName({ isOpen })} onClick={onClose}>
+      <div
+        className={getClassName("inner")}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>,
+    rootEl
+  );
+};

--- a/packages/core/components/Modal/styles.module.css
+++ b/packages/core/components/Modal/styles.module.css
@@ -1,0 +1,28 @@
+.Modal {
+  background: #00000099;
+  display: none;
+  justify-content: center;
+  align-items: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  z-index: 1;
+  padding: 64px;
+}
+
+.Modal--isOpen {
+  display: flex;
+}
+
+.Modal-inner {
+  width: 100%;
+  max-width: 1024px;
+  border-radius: 16px;
+  overflow: hidden;
+  background: white;
+  display: flex;
+  flex-direction: column;
+  max-height: 90vh;
+}

--- a/packages/core/components/Puck/context.tsx
+++ b/packages/core/components/Puck/context.tsx
@@ -10,6 +10,7 @@ export const defaultAppState: AppState = {
     arrayState: {},
     itemSelector: null,
     componentList: {},
+    componentState: {},
   },
 };
 

--- a/packages/core/components/Puck/context.tsx
+++ b/packages/core/components/Puck/context.tsx
@@ -10,7 +10,6 @@ export const defaultAppState: AppState = {
     arrayState: {},
     itemSelector: null,
     componentList: {},
-    componentState: {},
   },
 };
 
@@ -18,12 +17,14 @@ type AppContext = {
   state: AppState;
   dispatch: (action: PuckAction) => void;
   config: Config;
+  componentState: Record<string, { loading: true }>;
 };
 
 export const appContext = createContext<AppContext>({
   state: defaultAppState,
   dispatch: () => null,
   config: { components: {} },
+  componentState: {},
 });
 
 export const AppProvider = appContext.Provider;

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -170,7 +170,7 @@ export function Puck({
     ).then((dynamicContent) => {
       const newDynamicProps = dynamicContent.reduce<Record<string, any>>(
         (acc, item) => {
-          return { ...acc, [item.props.id]: item.props };
+          return { ...acc, [item.props.id]: item };
         },
         {}
       );
@@ -657,9 +657,6 @@ export function Puck({
                                 currentProps = data.root;
                               }
 
-                              const { readOnly, ..._meta } =
-                                currentProps._meta || {};
-
                               const newProps = {
                                 ...currentProps,
                                 [fieldName]: value,
@@ -686,8 +683,8 @@ export function Puck({
                             };
 
                             if (selectedItem && itemSelector) {
-                              const { readOnly = {} } =
-                                selectedItem.props._meta || {};
+                              const { readOnly = {} } = selectedItem || {};
+
                               return (
                                 <InputOrGroup
                                   key={`${selectedItem.props.id}_${fieldName}`}
@@ -701,7 +698,7 @@ export function Puck({
                                 />
                               );
                             } else {
-                              const { readOnly = {} } = data.root._meta || {};
+                              const { readOnly = {} } = data.root || {};
 
                               return (
                                 <InputOrGroup

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -141,6 +141,25 @@ export function Puck({
 
   const { data, ui } = appState;
 
+  const setComponentState = useCallback(
+    (id: string, newComponentState: AppState["ui"]["componentState"][0]) => {
+      dispatch({
+        type: "setUi",
+        ui: {
+          ...ui,
+          componentState: {
+            ...ui.componentState,
+            [id]: {
+              ...ui.componentState[id],
+              ...newComponentState,
+            },
+          },
+        },
+      });
+    },
+    [ui]
+  );
+
   useEffect(() => {
     // Flatten zones
     const flatContent = Object.keys(data.zones || {}).reduce(
@@ -148,7 +167,16 @@ export function Puck({
       data.content
     );
 
-    resolveAllProps(flatContent, config).then((dynamicContent) => {
+    resolveAllProps(
+      flatContent,
+      config,
+      (item) => {
+        setComponentState(item.props.id, { loading: true });
+      },
+      (item) => {
+        setComponentState(item.props.id, { loading: false });
+      }
+    ).then((dynamicContent) => {
       const newDynamicProps = dynamicContent.reduce<Record<string, any>>(
         (acc, item) => {
           return { ...acc, [item.props.id]: item.props };
@@ -608,6 +636,10 @@ export function Puck({
                           noPadding
                           showBreadcrumbs
                           title={selectedItem ? selectedItem.type : "Page"}
+                          isLoading={
+                            selectedItem &&
+                            ui.componentState[selectedItem?.props.id]?.loading
+                          }
                         >
                           {Object.keys(fields).map((fieldName) => {
                             const field = fields[fieldName];

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -72,7 +72,7 @@ const PluginRenderer = ({
 
 export function Puck({
   config,
-  data: initialData = { content: [], root: { title: "" } },
+  data: initialData = { content: [], root: { props: { title: "" } } },
   onChange,
   onPublish,
   plugins = [],
@@ -253,6 +253,18 @@ export function Puck({
 
   const componentList = useComponentList(config, appState.ui);
 
+  // DEPRECATED
+  const rootProps = data.root.props || data.root;
+
+  // DEPRECATED
+  useEffect(() => {
+    if (Object.keys(data.root).length > 0 && !data.root.props) {
+      console.error(
+        "Warning: Defining props on `root` is deprecated. Please use `root.props`. This will be a breaking change in a future release "
+      );
+    }
+  }, []);
+
   return (
     <div className="puck">
       <AppProvider
@@ -416,7 +428,7 @@ export function Puck({
                             }}
                           >
                             <Heading rank={2} size="xs">
-                              {headerTitle || data.root.title || "Page"}
+                              {headerTitle || rootProps.title || "Page"}
                               {headerPath && (
                                 <small
                                   style={{ fontWeight: 400, marginLeft: 4 }}
@@ -624,10 +636,18 @@ export function Puck({
 
                                 resolveData();
                               } else {
-                                dispatch({
-                                  type: "setData",
-                                  data: { root: newProps },
-                                });
+                                if (data.root.props) {
+                                  dispatch({
+                                    type: "setData",
+                                    data: { root: { props: { newProps } } },
+                                  });
+                                } else {
+                                  // DEPRECATED
+                                  dispatch({
+                                    type: "setData",
+                                    data: { root: newProps },
+                                  });
+                                }
 
                                 resolveData();
                               }
@@ -659,7 +679,7 @@ export function Puck({
                                   label={field.label}
                                   readOnly={readOnly[fieldName]}
                                   readOnlyFields={readOnly}
-                                  value={data.root[fieldName]}
+                                  value={rootProps[fieldName]}
                                   onChange={onChange}
                                 />
                               );

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -12,7 +12,6 @@ import { DragDropContext, DragStart, DragUpdate } from "react-beautiful-dnd";
 import type { AppState, Config, Data, Field } from "../../types/Config";
 import { InputOrGroup } from "../InputOrGroup";
 import { ComponentList } from "../ComponentList";
-import { filter } from "../../lib";
 import { Button } from "../Button";
 
 import { Plugin } from "../../types/Plugin";
@@ -686,6 +685,7 @@ export function Puck({
           </DropZoneProvider>
         </DragDropContext>
       </AppProvider>
+      <div id="puck-portal-root" />
     </div>
   );
 }

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -604,8 +604,9 @@ export function Puck({
                           showBreadcrumbs
                           title={selectedItem ? selectedItem.type : "Page"}
                           isLoading={
-                            selectedItem &&
-                            componentState[selectedItem?.props.id]?.loading
+                            selectedItem
+                              ? componentState[selectedItem?.props.id]?.loading
+                              : componentState["puck-root"]?.loading
                           }
                         >
                           {Object.keys(fields).map((fieldName) => {

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -634,7 +634,7 @@ export function Puck({
                             };
 
                             if (selectedItem && itemSelector) {
-                              const { readOnly = {} } = selectedItem || {};
+                              const { readOnly = {} } = selectedItem;
 
                               return (
                                 <InputOrGroup
@@ -649,7 +649,7 @@ export function Puck({
                                 />
                               );
                             } else {
-                              const { readOnly = {} } = data.root || {};
+                              const { readOnly = {} } = data.root;
 
                               return (
                                 <InputOrGroup

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -655,6 +655,7 @@ export function Puck({
                                   name={fieldName}
                                   label={field.label}
                                   readOnly={readOnly[fieldName]}
+                                  readOnlyFields={readOnly}
                                   value={selectedItem.props[fieldName]}
                                   onChange={onChange}
                                 />
@@ -669,6 +670,7 @@ export function Puck({
                                   name={fieldName}
                                   label={field.label}
                                   readOnly={readOnly[fieldName]}
+                                  readOnlyFields={readOnly}
                                   value={data.root[fieldName]}
                                   onChange={onChange}
                                 />

--- a/packages/core/components/Render/index.tsx
+++ b/packages/core/components/Render/index.tsx
@@ -5,10 +5,20 @@ import { Config, Data } from "../../types/Config";
 import { DropZone, DropZoneProvider } from "../DropZone";
 
 export function Render({ config, data }: { config: Config; data: Data }) {
-  if (config.root) {
+  // DEPRECATED
+  const rootProps = data.root.props || data.root;
+
+  const title = rootProps.title || "";
+
+  if (config.root?.render) {
     return (
       <DropZoneProvider value={{ data, config, mode: "render" }}>
-        <config.root.render {...data.root} editMode={false} id={"puck-root"}>
+        <config.root.render
+          {...rootProps}
+          title={title}
+          editMode={false}
+          id={"puck-root"}
+        >
           <DropZone zone={rootDroppableId} />
         </config.root.render>
       </DropZoneProvider>

--- a/packages/core/components/SidebarSection/index.tsx
+++ b/packages/core/components/SidebarSection/index.tsx
@@ -5,6 +5,7 @@ import { Heading } from "../Heading";
 import { ChevronRight } from "react-feather";
 import { useBreadcrumbs } from "../../lib/use-breadcrumbs";
 import { useAppContext } from "../Puck/context";
+import { ClipLoader } from "react-spinners";
 
 const getClassName = getClassNameFactory("SidebarSection", styles);
 
@@ -14,12 +15,14 @@ export const SidebarSection = ({
   background,
   showBreadcrumbs,
   noPadding,
+  isLoading,
 }: {
   children: ReactNode;
   title: ReactNode;
   background?: string;
   showBreadcrumbs?: boolean;
   noPadding?: boolean;
+  isLoading?: boolean | null;
 }) => {
   const { setUi } = useAppContext();
   const breadcrumbs = useBreadcrumbs(1);
@@ -49,6 +52,11 @@ export const SidebarSection = ({
         </div>
       </div>
       <div className={getClassName("content")}>{children}</div>
+      {isLoading && (
+        <div className={getClassName("loadingOverlay")}>
+          <ClipLoader />
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/core/components/SidebarSection/styles.module.css
+++ b/packages/core/components/SidebarSection/styles.module.css
@@ -56,3 +56,18 @@
 .SidebarSection-heading {
   padding-right: 16px;
 }
+
+.SidebarSection-loadingOverlay {
+  background: white;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  width: 100%;
+  top: 0;
+  position: absolute;
+  z-index: 1;
+  pointer-events: all;
+  box-sizing: border-box;
+  opacity: 0.8;
+}

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -7,6 +7,6 @@ export * from "./components/IconButton";
 export * from "./components/Puck";
 export * from "./components/Render";
 
-export * from "./lib/resolve-data";
+export * from "./lib/resolve-all-data";
 
 export { FieldLabel } from "./components/InputOrGroup";

--- a/packages/core/lib/__tests__/resolve-all-data.spec.tsx
+++ b/packages/core/lib/__tests__/resolve-all-data.spec.tsx
@@ -22,7 +22,7 @@ const config: Config = {
   components: {
     ComponentWithResolveProps: {
       defaultProps: { prop: "example" },
-      resolveProps: async (props) => {
+      resolveData: async ({ props }) => {
         return {
           props: { ...props, prop: "Resolved" },
           readOnly: { prop: true },

--- a/packages/core/lib/__tests__/resolve-all-data.spec.tsx
+++ b/packages/core/lib/__tests__/resolve-all-data.spec.tsx
@@ -1,5 +1,5 @@
 import { Config, Data } from "../../types/Config";
-import { resolveData } from "../resolve-data";
+import { resolveAllData } from "../resolve-all-data";
 
 const item1 = {
   type: "ComponentWithResolveProps",
@@ -39,7 +39,7 @@ const config: Config = {
 
 describe("resolve-data", () => {
   it("should resolve the data for all components in the data", async () => {
-    expect(await resolveData(data, config)).toMatchInlineSnapshot(`
+    expect(await resolveAllData(data, config)).toMatchInlineSnapshot(`
       {
         "content": [
           {

--- a/packages/core/lib/__tests__/resolve-data.spec.tsx
+++ b/packages/core/lib/__tests__/resolve-data.spec.tsx
@@ -44,13 +44,11 @@ describe("resolve-data", () => {
         "content": [
           {
             "props": {
-              "_meta": {
-                "readOnly": {
-                  "prop": true,
-                },
-              },
               "id": "MyComponent-1",
               "prop": "Resolved",
+            },
+            "readOnly": {
+              "prop": true,
             },
             "type": "ComponentWithResolveProps",
           },

--- a/packages/core/lib/__tests__/use-breadcrumbs.spec.tsx
+++ b/packages/core/lib/__tests__/use-breadcrumbs.spec.tsx
@@ -17,7 +17,7 @@ const data: Data = {
 
 const config: Config = {
   components: {
-    Comp: {
+    MyComponent: {
       defaultProps: { prop: "example" },
       render: () => <div />,
     },

--- a/packages/core/lib/__tests__/use-puck-history.spec.tsx
+++ b/packages/core/lib/__tests__/use-puck-history.spec.tsx
@@ -77,6 +77,7 @@ const mockedAppStateArray1: AppState = {
     },
     itemSelector: { index: 0, zone: "default-zone" },
     componentList: {},
+    componentState: {},
   },
 };
 
@@ -120,6 +121,7 @@ const mockedAppStateArray2: AppState = {
     },
     itemSelector: { index: 0, zone: "default-zone" },
     componentList: {},
+    componentState: {},
   },
 };
 

--- a/packages/core/lib/__tests__/use-puck-history.spec.tsx
+++ b/packages/core/lib/__tests__/use-puck-history.spec.tsx
@@ -77,7 +77,6 @@ const mockedAppStateArray1: AppState = {
     },
     itemSelector: { index: 0, zone: "default-zone" },
     componentList: {},
-    componentState: {},
   },
 };
 
@@ -121,7 +120,6 @@ const mockedAppStateArray2: AppState = {
     },
     itemSelector: { index: 0, zone: "default-zone" },
     componentList: {},
-    componentState: {},
   },
 };
 

--- a/packages/core/lib/__tests__/use-resolved-data.spec.tsx
+++ b/packages/core/lib/__tests__/use-resolved-data.spec.tsx
@@ -1,0 +1,197 @@
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { Config, Data } from "../../types/Config";
+import { useResolvedData } from "../use-resolved-data";
+import { SetDataAction } from "../../reducer";
+import { cache } from "../resolve-all-props";
+
+const item1 = { type: "MyComponent", props: { id: "MyComponent-1" } };
+const item2 = { type: "MyComponent", props: { id: "MyComponent-2" } };
+const item3 = { type: "MyComponent", props: { id: "MyComponent-3" } };
+
+const data: Data = {
+  root: { title: "" },
+  content: [item1],
+  zones: {
+    "MyComponent-1:zone": [item2],
+    "MyComponent-2:zone": [item3],
+  },
+};
+
+const config: Config = {
+  components: {
+    MyComponent: {
+      defaultProps: { prop: "example" },
+      resolveProps: (props) => {
+        return {
+          props: {
+            ...props,
+            prop: "Hello, world",
+          },
+          readOnly: {
+            prop: true,
+          },
+        };
+      },
+      render: () => <div />,
+    },
+  },
+};
+
+describe("use-resolved-data", () => {
+  describe("resolveData method", () => {
+    afterEach(() => {
+      cleanup();
+
+      cache.lastChange = {};
+    });
+
+    it("should call the `setData` action with resolved data", async () => {
+      let dispatchedEvent: SetDataAction = {} as any;
+
+      const renderedHook = renderHook(() =>
+        useResolvedData(data, config, (args) => {
+          dispatchedEvent = args as any;
+        })
+      );
+      const { resolveData } = renderedHook.result.current;
+      await act(async () => {
+        resolveData();
+      });
+
+      expect(dispatchedEvent?.type).toBe("setData");
+
+      if (typeof dispatchedEvent?.data === "function") {
+        expect(dispatchedEvent?.data(data)).toMatchInlineSnapshot(`
+          {
+            "content": [
+              {
+                "props": {
+                  "id": "MyComponent-1",
+                  "prop": "Hello, world",
+                },
+                "readOnly": {
+                  "prop": true,
+                },
+                "type": "MyComponent",
+              },
+            ],
+            "root": {
+              "title": "",
+            },
+            "zones": {
+              "MyComponent-1:zone": [
+                {
+                  "props": {
+                    "id": "MyComponent-2",
+                    "prop": "Hello, world",
+                  },
+                  "readOnly": {
+                    "prop": true,
+                  },
+                  "type": "MyComponent",
+                },
+              ],
+              "MyComponent-2:zone": [
+                {
+                  "props": {
+                    "id": "MyComponent-3",
+                    "prop": "Hello, world",
+                  },
+                  "readOnly": {
+                    "prop": true,
+                  },
+                  "type": "MyComponent",
+                },
+              ],
+            },
+          }
+        `);
+      }
+    });
+
+    it("should NOT call the `setData` action with resolved data, when the data is unchanged", async () => {
+      let dispatchedEvent: SetDataAction = {} as any;
+
+      const renderedHook = renderHook(() =>
+        useResolvedData(
+          data,
+          {
+            ...config,
+            components: {
+              ...config.components,
+              MyComponent: {
+                ...config.components.MyComponent,
+                resolveProps: (props) => ({ props }),
+              },
+            },
+          },
+          (args) => {
+            dispatchedEvent = args as any;
+          }
+        )
+      );
+
+      const { resolveData } = renderedHook.result.current;
+
+      await act(async () => {
+        resolveData();
+      });
+
+      expect(dispatchedEvent).toEqual({});
+    });
+  });
+
+  describe("componentState", () => {
+    it("should state which components are loading", async () => {
+      let dispatchedEvent: SetDataAction = {} as any;
+
+      const renderedHook = renderHook(() =>
+        useResolvedData(
+          data,
+          {
+            ...config,
+            components: {
+              ...config.components,
+              MyComponent: {
+                ...config.components.MyComponent,
+                resolveProps: async (props) => {
+                  await new Promise<void>((resolve) => setTimeout(resolve, 10));
+                  return { props };
+                },
+              },
+            },
+          },
+          (args) => {
+            dispatchedEvent = args as any;
+          }
+        )
+      );
+
+      await act(async () => {
+        renderedHook.result.current.resolveData();
+      });
+
+      expect(renderedHook.result.current.componentState).toMatchInlineSnapshot(`
+        {
+          "MyComponent-1": {
+            "loading": true,
+          },
+          "MyComponent-2": {
+            "loading": true,
+          },
+          "MyComponent-3": {
+            "loading": true,
+          },
+        }
+      `);
+
+      renderedHook.rerender();
+
+      await waitFor(() =>
+        expect(
+          renderedHook.result.current.componentState["MyComponent-1"].loading
+        ).toBe(false)
+      );
+    });
+  });
+});

--- a/packages/core/lib/__tests__/use-resolved-data.spec.tsx
+++ b/packages/core/lib/__tests__/use-resolved-data.spec.tsx
@@ -9,7 +9,7 @@ const item2 = { type: "MyComponent", props: { id: "MyComponent-2" } };
 const item3 = { type: "MyComponent", props: { id: "MyComponent-3" } };
 
 const data: Data = {
-  root: { title: "" },
+  root: { props: { title: "" } },
   content: [item1],
   zones: {
     "MyComponent-1:zone": [item2],
@@ -18,6 +18,15 @@ const data: Data = {
 };
 
 const config: Config = {
+  root: {
+    resolveData: (data) => {
+      return {
+        ...data,
+        props: { title: "Resolved title" },
+        readOnly: { title: true },
+      };
+    },
+  },
   components: {
     MyComponent: {
       defaultProps: { prop: "example" },
@@ -76,7 +85,12 @@ describe("use-resolved-data", () => {
               },
             ],
             "root": {
-              "title": "",
+              "props": {
+                "title": "Resolved title",
+              },
+              "readOnly": {
+                "title": true,
+              },
             },
             "zones": {
               "MyComponent-1:zone": [
@@ -117,6 +131,7 @@ describe("use-resolved-data", () => {
           data,
           {
             ...config,
+            root: {},
             components: {
               ...config.components,
               MyComponent: {

--- a/packages/core/lib/__tests__/use-resolved-data.spec.tsx
+++ b/packages/core/lib/__tests__/use-resolved-data.spec.tsx
@@ -21,7 +21,7 @@ const config: Config = {
   components: {
     MyComponent: {
       defaultProps: { prop: "example" },
-      resolveProps: (props) => {
+      resolveData: ({ props }) => {
         return {
           props: {
             ...props,
@@ -121,7 +121,7 @@ describe("use-resolved-data", () => {
               ...config.components,
               MyComponent: {
                 ...config.components.MyComponent,
-                resolveProps: (props) => ({ props }),
+                resolveData: ({ props }) => ({ props }),
               },
             },
           },
@@ -154,7 +154,7 @@ describe("use-resolved-data", () => {
               ...config.components,
               MyComponent: {
                 ...config.components.MyComponent,
-                resolveProps: async (props) => {
+                resolveData: async ({ props }) => {
                   await new Promise<void>((resolve) => setTimeout(resolve, 10));
                   return { props };
                 },

--- a/packages/core/lib/apply-dynamic-props.ts
+++ b/packages/core/lib/apply-dynamic-props.ts
@@ -1,11 +1,16 @@
-import { Data } from "../types/Config";
+import { ComponentData, Data, RootData } from "../types/Config";
 
 export const applyDynamicProps = (
   data: Data,
-  dynamicProps: Record<string, any>
+  dynamicProps: Record<string, ComponentData>,
+  rootData?: RootData
 ) => {
   return {
     ...data,
+    root: {
+      ...data.root,
+      ...(rootData ? rootData : {}),
+    },
     content: data.content.map((item) => {
       return dynamicProps[item.props.id]
         ? { ...item, ...dynamicProps[item.props.id] }

--- a/packages/core/lib/apply-dynamic-props.ts
+++ b/packages/core/lib/apply-dynamic-props.ts
@@ -8,7 +8,7 @@ export const applyDynamicProps = (
     ...data,
     content: data.content.map((item) => {
       return dynamicProps[item.props.id]
-        ? { ...item, props: dynamicProps[item.props.id] }
+        ? { ...item, ...dynamicProps[item.props.id] }
         : item;
     }),
     zones: Object.keys(data.zones || {}).reduce((acc, zoneKey) => {
@@ -16,7 +16,7 @@ export const applyDynamicProps = (
         ...acc,
         [zoneKey]: data.zones![zoneKey].map((item) => {
           return dynamicProps[item.props.id]
-            ? { ...item, props: dynamicProps[item.props.id] }
+            ? { ...item, ...dynamicProps[item.props.id] }
             : item;
         }),
       };

--- a/packages/core/lib/apply-dynamic-props.ts
+++ b/packages/core/lib/apply-dynamic-props.ts
@@ -1,0 +1,25 @@
+import { Data } from "../types/Config";
+
+export const applyDynamicProps = (
+  data: Data,
+  dynamicProps: Record<string, any>
+) => {
+  return {
+    ...data,
+    content: data.content.map((item) => {
+      return dynamicProps[item.props.id]
+        ? { ...item, props: dynamicProps[item.props.id] }
+        : item;
+    }),
+    zones: Object.keys(data.zones || {}).reduce((acc, zoneKey) => {
+      return {
+        ...acc,
+        [zoneKey]: data.zones![zoneKey].map((item) => {
+          return dynamicProps[item.props.id]
+            ? { ...item, props: dynamicProps[item.props.id] }
+            : item;
+        }),
+      };
+    }, {}),
+  };
+};

--- a/packages/core/lib/get-item.ts
+++ b/packages/core/lib/get-item.ts
@@ -1,4 +1,4 @@
-import { Data, MappedItem } from "../types/Config";
+import { Data } from "../types/Config";
 import { rootDroppableId } from "./root-droppable-id";
 import { setupZone } from "./setup-zone";
 

--- a/packages/core/lib/resolve-all-data.ts
+++ b/packages/core/lib/resolve-all-data.ts
@@ -1,7 +1,7 @@
 import { Config, Data, MappedItem } from "../types/Config";
 import { resolveAllProps } from "./resolve-all-props";
 
-export const resolveData = async (
+export const resolveAllData = async (
   data: Data,
   config: Config,
   onResolveStart?: (item: MappedItem) => void,

--- a/packages/core/lib/resolve-all-data.ts
+++ b/packages/core/lib/resolve-all-data.ts
@@ -1,5 +1,6 @@
 import { Config, Data, MappedItem } from "../types/Config";
 import { resolveAllProps } from "./resolve-all-props";
+import { resolveRootData } from "./resolve-root-data";
 
 export const resolveAllData = async (
   data: Data,
@@ -7,6 +8,8 @@ export const resolveAllData = async (
   onResolveStart?: (item: MappedItem) => void,
   onResolveEnd?: (item: MappedItem) => void
 ) => {
+  const dynamicRoot = await resolveRootData(data, config);
+
   const { zones = {} } = data;
 
   const zoneKeys = Object.keys(zones);
@@ -24,6 +27,7 @@ export const resolveAllData = async (
 
   return {
     ...data,
+    root: dynamicRoot,
     content: await resolveAllProps(
       data.content,
       config,

--- a/packages/core/lib/resolve-all-props.ts
+++ b/packages/core/lib/resolve-all-props.ts
@@ -1,6 +1,6 @@
 import { Config, MappedItem } from "../types/Config";
 
-const lastChangeCache = {};
+export const cache = { lastChange: {} };
 
 export const resolveAllProps = async (
   content: MappedItem[],
@@ -18,8 +18,8 @@ export const resolveAllProps = async (
           {}
         );
 
-        if (lastChangeCache[item.props.id]) {
-          const { item: oldItem, resolved } = lastChangeCache[item.props.id];
+        if (cache.lastChange[item.props.id]) {
+          const { item: oldItem, resolved } = cache.lastChange[item.props.id];
 
           if (oldItem === item) {
             return resolved;
@@ -41,15 +41,20 @@ export const resolveAllProps = async (
 
         const { readOnly: existingReadOnly = {} } = item || {};
 
+        const newReadOnly = { ...existingReadOnly, ...readOnly };
+
         const resolvedItem = {
           ...item,
           props: {
             ...resolvedProps,
           },
-          readOnly: { ...existingReadOnly, ...readOnly },
         };
 
-        lastChangeCache[item.props.id] = {
+        if (Object.keys(newReadOnly).length) {
+          resolvedItem.readOnly = newReadOnly;
+        }
+
+        cache.lastChange[item.props.id] = {
           item,
           resolved: resolvedItem,
         };

--- a/packages/core/lib/resolve-all-props.ts
+++ b/packages/core/lib/resolve-all-props.ts
@@ -12,7 +12,7 @@ export const resolveAllProps = async (
     content.map(async (item) => {
       const configForItem = config.components[item.type];
 
-      if (configForItem.resolveProps) {
+      if (configForItem.resolveData) {
         let changed = Object.keys(item.props).reduce(
           (acc, item) => ({ ...acc, [item]: true }),
           {}
@@ -37,7 +37,7 @@ export const resolveAllProps = async (
         }
 
         const { props: resolvedProps, readOnly = {} } =
-          await configForItem.resolveProps(item.props, { changed });
+          await configForItem.resolveData(item, { changed });
 
         const { readOnly: existingReadOnly = {} } = item || {};
 

--- a/packages/core/lib/resolve-all-props.ts
+++ b/packages/core/lib/resolve-all-props.ts
@@ -11,15 +11,27 @@ export const resolveAllProps = async (
       const configForItem = config.components[item.type];
 
       if (configForItem.resolveProps) {
+        let changed = Object.keys(item.props).reduce(
+          (acc, item) => ({ ...acc, [item]: true }),
+          {}
+        );
+
         if (lastChangeCache[item.props.id]) {
           const { item: oldItem, resolved } = lastChangeCache[item.props.id];
 
           if (oldItem === item) {
             return resolved;
           }
+
+          Object.keys(item.props).forEach((propName) => {
+            if (oldItem.props[propName] === item.props[propName]) {
+              changed[propName] = false;
+            }
+          });
         }
+
         const { props: resolvedProps, readOnly = {} } =
-          await configForItem.resolveProps(item.props);
+          await configForItem.resolveProps(item.props, { changed });
 
         const { _meta: { readOnly: existingReadOnly = {} } = {} } =
           item.props || {};

--- a/packages/core/lib/resolve-all-props.ts
+++ b/packages/core/lib/resolve-all-props.ts
@@ -46,6 +46,7 @@ export const resolveAllProps = async (
         const resolvedItem = {
           ...item,
           props: {
+            ...item.props,
             ...resolvedProps,
           },
         };

--- a/packages/core/lib/resolve-all-props.ts
+++ b/packages/core/lib/resolve-all-props.ts
@@ -39,15 +39,14 @@ export const resolveAllProps = async (
         const { props: resolvedProps, readOnly = {} } =
           await configForItem.resolveProps(item.props, { changed });
 
-        const { _meta: { readOnly: existingReadOnly = {} } = {} } =
-          item.props || {};
+        const { readOnly: existingReadOnly = {} } = item || {};
 
         const resolvedItem = {
           ...item,
           props: {
             ...resolvedProps,
-            _meta: { readOnly: { ...existingReadOnly, ...readOnly } },
           },
+          readOnly: { ...existingReadOnly, ...readOnly },
         };
 
         lastChangeCache[item.props.id] = {

--- a/packages/core/lib/resolve-all-props.ts
+++ b/packages/core/lib/resolve-all-props.ts
@@ -4,7 +4,9 @@ const lastChangeCache = {};
 
 export const resolveAllProps = async (
   content: MappedItem[],
-  config: Config
+  config: Config,
+  onResolveStart?: (item: MappedItem) => void,
+  onResolveEnd?: (item: MappedItem) => void
 ) => {
   return await Promise.all(
     content.map(async (item) => {
@@ -30,6 +32,10 @@ export const resolveAllProps = async (
           });
         }
 
+        if (onResolveStart) {
+          onResolveStart(item);
+        }
+
         const { props: resolvedProps, readOnly = {} } =
           await configForItem.resolveProps(item.props, { changed });
 
@@ -48,6 +54,10 @@ export const resolveAllProps = async (
           item,
           resolved: resolvedItem,
         };
+
+        if (onResolveEnd) {
+          onResolveEnd(resolvedItem);
+        }
 
         return resolvedItem;
       }

--- a/packages/core/lib/resolve-data.ts
+++ b/packages/core/lib/resolve-data.ts
@@ -1,7 +1,12 @@
 import { Config, Data, MappedItem } from "../types/Config";
 import { resolveAllProps } from "./resolve-all-props";
 
-export const resolveData = async (data: Data, config: Config) => {
+export const resolveData = async (
+  data: Data,
+  config: Config,
+  onResolveStart?: (item: MappedItem) => void,
+  onResolveEnd?: (item: MappedItem) => void
+) => {
   const { zones = {} } = data;
 
   const zoneKeys = Object.keys(zones);
@@ -9,12 +14,22 @@ export const resolveData = async (data: Data, config: Config) => {
 
   for (let i = 0; i < zoneKeys.length; i++) {
     const zoneKey = zoneKeys[i];
-    resolvedZones[zoneKey] = await resolveAllProps(zones[zoneKey], config);
+    resolvedZones[zoneKey] = await resolveAllProps(
+      zones[zoneKey],
+      config,
+      onResolveStart,
+      onResolveEnd
+    );
   }
 
   return {
     ...data,
-    content: await resolveAllProps(data.content, config),
+    content: await resolveAllProps(
+      data.content,
+      config,
+      onResolveStart,
+      onResolveEnd
+    ),
     zones: resolvedZones,
   };
 };

--- a/packages/core/lib/resolve-root-data.ts
+++ b/packages/core/lib/resolve-root-data.ts
@@ -1,0 +1,50 @@
+import { Config, Data, RootDataWithProps } from "../types/Config";
+
+export const cache: {
+  lastChange?: { original: RootDataWithProps; resolved: RootDataWithProps };
+} = {};
+
+export const resolveRootData = async (data: Data, config: Config) => {
+  if (config.root?.resolveData && data.root.props) {
+    let changed = Object.keys(data.root.props).reduce(
+      (acc, item) => ({ ...acc, [item]: true }),
+      {}
+    );
+
+    if (cache.lastChange) {
+      const { original, resolved } = cache.lastChange;
+
+      if (original === data.root) {
+        return resolved;
+      }
+
+      Object.keys(data.root.props).forEach((propName) => {
+        if (original.props[propName] === data.root.props![propName]) {
+          changed[propName] = false;
+        }
+      });
+    }
+
+    const rootWithProps = data.root as RootDataWithProps;
+
+    const resolvedRoot = await config.root?.resolveData(rootWithProps, {
+      changed,
+    });
+
+    cache.lastChange = {
+      original: data.root as RootDataWithProps,
+      resolved: resolvedRoot as RootDataWithProps,
+    };
+
+    return {
+      ...data.root,
+      ...resolvedRoot,
+      props: {
+        ...data.root.props,
+        ...resolvedRoot.props,
+      },
+    };
+  }
+
+  return data.root;
+};

--- a/packages/core/lib/use-resolved-data.ts
+++ b/packages/core/lib/use-resolved-data.ts
@@ -38,7 +38,17 @@ export const useResolvedData = (
         }));
       }
     ).then(async (dynamicContent) => {
+      setComponentState((prev) => ({
+        ...prev,
+        "puck-root": { ...prev["puck-root"], loading: true },
+      }));
+
       const dynamicRoot = await resolveRootData(data, config);
+
+      setComponentState((prev) => ({
+        ...prev,
+        "puck-root": { ...prev["puck-root"], loading: false },
+      }));
 
       const newDynamicProps = dynamicContent.reduce<Record<string, any>>(
         (acc, item) => {

--- a/packages/core/lib/use-resolved-data.ts
+++ b/packages/core/lib/use-resolved-data.ts
@@ -19,7 +19,7 @@ export const useResolvedData = (
     // Flatten zones
     const flatContent = Object.keys(data.zones || {})
       .reduce((acc, zone) => [...acc, ...data.zones![zone]], data.content)
-      .filter((item) => !!config.components[item.type].resolveProps);
+      .filter((item) => !!config.components[item.type].resolveData);
 
     resolveAllProps(
       flatContent,

--- a/packages/core/lib/use-resolved-data.ts
+++ b/packages/core/lib/use-resolved-data.ts
@@ -3,6 +3,7 @@ import { Dispatch, useEffect, useState } from "react";
 import { PuckAction } from "../reducer";
 import { resolveAllProps } from "./resolve-all-props";
 import { applyDynamicProps } from "./apply-dynamic-props";
+import { resolveRootData } from "./resolve-root-data";
 
 export const useResolvedData = (
   data: Data,
@@ -36,7 +37,9 @@ export const useResolvedData = (
           [item.props.id]: { ...prev[item.props.id], loading: false },
         }));
       }
-    ).then((dynamicContent) => {
+    ).then(async (dynamicContent) => {
+      const dynamicRoot = await resolveRootData(data, config);
+
       const newDynamicProps = dynamicContent.reduce<Record<string, any>>(
         (acc, item) => {
           return { ...acc, [item.props.id]: item };
@@ -44,7 +47,7 @@ export const useResolvedData = (
         {}
       );
 
-      const processed = applyDynamicProps(data, newDynamicProps);
+      const processed = applyDynamicProps(data, newDynamicProps, dynamicRoot);
 
       const containsChanges =
         JSON.stringify(data) !== JSON.stringify(processed);
@@ -52,7 +55,7 @@ export const useResolvedData = (
       if (containsChanges) {
         dispatch({
           type: "setData",
-          data: (prev) => applyDynamicProps(prev, newDynamicProps),
+          data: (prev) => applyDynamicProps(prev, newDynamicProps, dynamicRoot),
           recordHistory: true,
         });
       }

--- a/packages/core/lib/use-resolved-data.ts
+++ b/packages/core/lib/use-resolved-data.ts
@@ -1,0 +1,72 @@
+import { Config, Data } from "../types/Config";
+import { Dispatch, useEffect, useState } from "react";
+import { PuckAction } from "../reducer";
+import { resolveAllProps } from "./resolve-all-props";
+import { applyDynamicProps } from "./apply-dynamic-props";
+
+export const useResolvedData = (
+  data: Data,
+  config: Config,
+  dispatch: Dispatch<PuckAction>
+) => {
+  const [runResolversKey, setRunResolversKey] = useState(0);
+
+  const [componentState, setComponentState] = useState<
+    Record<string, { loading }>
+  >({});
+
+  const runResolvers = () => {
+    // Flatten zones
+    const flatContent = Object.keys(data.zones || {})
+      .reduce((acc, zone) => [...acc, ...data.zones![zone]], data.content)
+      .filter((item) => !!config.components[item.type].resolveProps);
+
+    resolveAllProps(
+      flatContent,
+      config,
+      (item) => {
+        setComponentState((prev) => ({
+          ...prev,
+          [item.props.id]: { ...prev[item.props.id], loading: true },
+        }));
+      },
+      (item) => {
+        setComponentState((prev) => ({
+          ...prev,
+          [item.props.id]: { ...prev[item.props.id], loading: false },
+        }));
+      }
+    ).then((dynamicContent) => {
+      const newDynamicProps = dynamicContent.reduce<Record<string, any>>(
+        (acc, item) => {
+          return { ...acc, [item.props.id]: item };
+        },
+        {}
+      );
+
+      const processed = applyDynamicProps(data, newDynamicProps);
+
+      const containsChanges =
+        JSON.stringify(data) !== JSON.stringify(processed);
+
+      if (containsChanges) {
+        dispatch({
+          type: "setData",
+          data: (prev) => applyDynamicProps(prev, newDynamicProps),
+          recordHistory: true,
+        });
+      }
+    });
+  };
+
+  useEffect(() => {
+    runResolvers();
+  }, [runResolversKey]);
+
+  return {
+    resolveData: () => {
+      setRunResolversKey((curr) => curr + 1);
+    },
+    componentState,
+  };
+};

--- a/packages/core/reducer/__tests__/state.spec.tsx
+++ b/packages/core/reducer/__tests__/state.spec.tsx
@@ -1,6 +1,6 @@
 import { defaultAppState } from "../../components/Puck/context";
-import { SetStateAction, createReducer } from "../../reducer";
-import { AppState, Config, Data, UiState } from "../../types/Config";
+import { SetUiAction, createReducer } from "../../reducer";
+import { AppState, Config } from "../../types/Config";
 
 type Props = {
   Comp: {
@@ -24,7 +24,7 @@ describe("State reducer", () => {
     it("should insert data into the state", () => {
       const state: AppState = defaultAppState;
 
-      const action: SetStateAction = {
+      const action: SetUiAction = {
         type: "setUi",
         ui: { leftSideBarVisible: false },
       };

--- a/packages/core/reducer/actions.tsx
+++ b/packages/core/reducer/actions.tsx
@@ -41,14 +41,14 @@ export type RemoveAction = {
   zone: string;
 };
 
-export type SetStateAction = {
+export type SetUiAction = {
   type: "setUi";
-  ui: Partial<UiState>;
+  ui: Partial<UiState> | ((previous: UiState) => Partial<UiState>);
 };
 
 export type SetDataAction = {
   type: "setData";
-  data: Partial<Data>;
+  data: Partial<Data> | ((previous: Data) => Partial<Data>);
 };
 
 export type SetAction = {
@@ -75,7 +75,7 @@ export type PuckAction = { recordHistory?: boolean } & (
   | DuplicateAction
   | SetAction
   | SetDataAction
-  | SetStateAction
+  | SetUiAction
   | RegisterZoneAction
   | UnregisterZoneAction
 );

--- a/packages/core/reducer/data.ts
+++ b/packages/core/reducer/data.ts
@@ -259,7 +259,14 @@ export const reduceData = (data: Data, action: PuckAction, config: Config) => {
   }
 
   if (action.type === "setData") {
-    return { ...data, ...action.data };
+    if (typeof action.data === "object") {
+      return {
+        ...data,
+        ...action.data,
+      };
+    }
+
+    return { ...data, ...action.data(data) };
   }
 
   return data;

--- a/packages/core/reducer/index.ts
+++ b/packages/core/reducer/index.ts
@@ -36,7 +36,11 @@ const storeInterceptor = (reducer: StateReducer) => {
   };
 };
 
-export const createReducer = ({ config }: { config: Config }): StateReducer =>
+export const createReducer = ({
+  config,
+}: {
+  config: Config<any>;
+}): StateReducer =>
   storeInterceptor((state, action) => {
     const data = reduceData(state.data, action, config);
     const ui = reduceUi(state.ui, action);

--- a/packages/core/reducer/index.ts
+++ b/packages/core/reducer/index.ts
@@ -3,7 +3,7 @@ import { AppState, Config } from "../types/Config";
 import { recordDiff } from "../lib/use-puck-history";
 import { reduceData } from "./data";
 import { PuckAction } from "./actions";
-import { reduceState } from "./state";
+import { reduceUi } from "./state";
 
 export * from "./actions";
 export * from "./data";
@@ -20,7 +20,7 @@ const storeInterceptor = (reducer: StateReducer) => {
       "registerZone",
       "unregisterZone",
       "setData",
-      "setState",
+      "setUi",
       "set",
     ].includes(action.type);
 
@@ -39,7 +39,7 @@ const storeInterceptor = (reducer: StateReducer) => {
 export const createReducer = ({ config }: { config: Config }): StateReducer =>
   storeInterceptor((state, action) => {
     const data = reduceData(state.data, action, config);
-    const ui = reduceState(state.ui, action);
+    const ui = reduceUi(state.ui, action);
 
     if (action.type === "set") {
       return { ...state, ...action.state };

--- a/packages/core/reducer/state.ts
+++ b/packages/core/reducer/state.ts
@@ -1,11 +1,18 @@
 import { UiState } from "../types/Config";
 import { PuckAction } from "./actions";
 
-export const reduceState = (ui: UiState, action: PuckAction) => {
+export const reduceUi = (ui: UiState, action: PuckAction) => {
   if (action.type === "setUi") {
+    if (typeof action.ui === "object") {
+      return {
+        ...ui,
+        ...action.ui,
+      };
+    }
+
     return {
       ...ui,
-      ...action.ui,
+      ...action.ui(ui),
     };
   }
 

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -103,18 +103,12 @@ export type ComponentConfig<
   render: (props: WithPuckProps<ComponentProps>) => ReactElement;
   defaultProps?: DefaultProps;
   fields?: Fields<ComponentProps>;
-  resolveProps?: (
-    props: WithPuckProps<ComponentProps>,
+  resolveData?: (
+    data: ComponentData<ComponentProps>,
     params: { changed: Partial<Record<keyof ComponentProps, boolean>> }
   ) =>
-    | Promise<{
-        props: WithPuckProps<ComponentProps>;
-        readOnly?: Partial<Record<keyof ComponentProps, boolean>>;
-      }>
-    | {
-        props: WithPuckProps<ComponentProps>;
-        readOnly?: Partial<Record<keyof ComponentProps, boolean>>;
-      };
+    | Promise<Partial<ComponentData<ComponentProps>>>
+    | Partial<ComponentData<ComponentProps>>;
 };
 
 type Category<ComponentName> = {
@@ -133,9 +127,9 @@ export type Config<
     other?: Category<Props>;
   };
   components: {
-    [ComponentName in keyof Props]: ComponentConfig<
-      Props[ComponentName],
-      Props[ComponentName]
+    [ComponentName in keyof Props]: Omit<
+      ComponentConfig<Props[ComponentName], Props[ComponentName]>,
+      "type"
     >;
   };
   root?: ComponentConfig<

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -106,7 +106,10 @@ export type ComponentConfig<
   render: (props: WithPuckProps<ComponentProps>) => ReactElement;
   defaultProps?: DefaultProps;
   fields?: Fields<ComponentProps>;
-  resolveProps?: (props: WithPuckProps<ComponentProps>) =>
+  resolveProps?: (
+    props: WithPuckProps<ComponentProps>,
+    params: { changed: Partial<Record<keyof ComponentProps, boolean>> }
+  ) =>
     | Promise<{
         props: WithPuckProps<ComponentProps>;
         readOnly?: Partial<Record<keyof ComponentProps, boolean>>;

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -188,6 +188,7 @@ export type UiState = {
       expanded?: boolean;
     }
   >;
+  componentState: Record<string, { loading: boolean }>;
 };
 
 export type AppState = { data: Data; ui: UiState };

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -107,8 +107,8 @@ export type ComponentConfig<
     data: ComponentData<ComponentProps>,
     params: { changed: Partial<Record<keyof ComponentProps, boolean>> }
   ) =>
-    | Promise<Partial<ComponentData<ComponentProps>>>
-    | Partial<ComponentData<ComponentProps>>;
+    | Promise<Partial<ComponentDataWithOptionalProps<ComponentProps>>>
+    | Partial<ComponentDataWithOptionalProps<ComponentProps>>;
 };
 
 type Category<ComponentName> = {
@@ -142,10 +142,14 @@ export type ComponentData<
   Props extends { [key: string]: any } = { [key: string]: any }
 > = {
   type: keyof Props;
-  props: WithPuckProps<{
-    [key: string]: any;
-  }>;
+  props: WithPuckProps<Props>;
   readOnly?: Partial<Record<keyof Props, boolean>>;
+};
+
+type ComponentDataWithOptionalProps<
+  Props extends { [key: string]: any } = { [key: string]: any }
+> = Omit<ComponentData, "props"> & {
+  props: Partial<WithPuckProps<Props>>;
 };
 
 // Backwards compatability

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -75,11 +75,13 @@ export type Field<
   | CustomField;
 
 export type DefaultRootProps = {
-  children: ReactNode;
-  title: string;
-  editMode: boolean;
+  title?: string;
   [key: string]: any;
 };
+
+export type DefaultRootRenderProps = {
+  editMode: boolean;
+} & DefaultRootProps;
 
 export type DefaultComponentProps = { [key: string]: any; editMode?: boolean };
 
@@ -98,13 +100,14 @@ export type Content<
 
 export type ComponentConfig<
   ComponentProps extends DefaultComponentProps = DefaultComponentProps,
-  DefaultProps = ComponentProps
+  DefaultProps = ComponentProps,
+  DataShape = ComponentData<ComponentProps>
 > = {
   render: (props: WithPuckProps<ComponentProps>) => ReactElement;
   defaultProps?: DefaultProps;
   fields?: Fields<ComponentProps>;
   resolveData?: (
-    data: ComponentData<ComponentProps>,
+    data: DataShape,
     params: { changed: Partial<Record<keyof ComponentProps, boolean>> }
   ) =>
     | Promise<Partial<ComponentDataWithOptionalProps<ComponentProps>>>
@@ -132,19 +135,43 @@ export type Config<
       "type"
     >;
   };
-  root?: ComponentConfig<
-    RootProps & { children: ReactNode },
-    Partial<RootProps & { children: ReactNode }>
+  root?: Partial<
+    ComponentConfig<
+      RootProps & { children: ReactNode },
+      Partial<RootProps & { children: ReactNode }>,
+      RootDataWithProps<RootProps>
+    >
   >;
 };
 
-export type ComponentData<
+export type BaseData<
   Props extends { [key: string]: any } = { [key: string]: any }
+> = {
+  readOnly?: Partial<Record<keyof Props, boolean>>;
+};
+
+export type ComponentData<
+  Props extends DefaultComponentProps = DefaultComponentProps
 > = {
   type: keyof Props;
   props: WithPuckProps<Props>;
-  readOnly?: Partial<Record<keyof Props, boolean>>;
+} & BaseData<Props>;
+
+export type RootDataWithProps<
+  Props extends DefaultRootProps = DefaultRootProps
+> = {
+  props: Props;
 };
+
+// DEPRECATED
+export type RootDataWithoutProps<
+  Props extends DefaultRootProps = DefaultRootProps
+> = Props;
+
+export type RootData<Props extends DefaultRootProps = DefaultRootProps> =
+  BaseData<Props> &
+    Partial<RootDataWithProps<Props>> &
+    Partial<RootDataWithoutProps<Props>>; // DEPRECATED
 
 type ComponentDataWithOptionalProps<
   Props extends { [key: string]: any } = { [key: string]: any }
@@ -156,15 +183,12 @@ type ComponentDataWithOptionalProps<
 export type MappedItem = ComponentData;
 
 export type Data<
-  Props extends { [key: string]: any } = { [key: string]: any },
-  RootProps extends { title: string; [key: string]: any } = {
-    title: string;
-    [key: string]: any;
-  }
+  Props extends DefaultComponentProps = DefaultComponentProps,
+  RootProps extends DefaultRootProps = DefaultRootProps
 > = {
-  root: RootProps;
-  content: Content<Props>;
-  zones?: Record<string, Content<Props>>;
+  root: RootData<RootProps>;
+  content: Content<WithPuckProps<Props>>;
+  zones?: Record<string, Content<WithPuckProps<Props>>>;
 };
 
 export type ItemWithId = {

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -14,9 +14,6 @@ export type Adaptor<
 
 type WithPuckProps<Props> = Props & {
   id: string;
-  _meta?: {
-    readOnly: Partial<Record<keyof Props, boolean>>;
-  };
 };
 
 export type BaseField = {
@@ -97,7 +94,7 @@ export type Fields<
 
 export type Content<
   Props extends { [key: string]: any } = { [key: string]: any }
-> = MappedItem<Props>[];
+> = ComponentData<Props>[];
 
 export type ComponentConfig<
   ComponentProps extends DefaultComponentProps = DefaultComponentProps,
@@ -147,14 +144,18 @@ export type Config<
   >;
 };
 
-export type MappedItem<
+export type ComponentData<
   Props extends { [key: string]: any } = { [key: string]: any }
 > = {
   type: keyof Props;
   props: WithPuckProps<{
     [key: string]: any;
   }>;
+  readOnly?: Partial<Record<keyof Props, boolean>>;
 };
+
+// Backwards compatability
+export type MappedItem = ComponentData;
 
 export type Data<
   Props extends { [key: string]: any } = { [key: string]: any },

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -188,7 +188,6 @@ export type UiState = {
       expanded?: boolean;
     }
   >;
-  componentState: Record<string, { loading: boolean }>;
 };
 
 export type AppState = { data: Data; ui: UiState };

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -106,10 +106,15 @@ export type ComponentConfig<
   render: (props: WithPuckProps<ComponentProps>) => ReactElement;
   defaultProps?: DefaultProps;
   fields?: Fields<ComponentProps>;
-  resolveProps?: (props: WithPuckProps<ComponentProps>) => Promise<{
-    props: WithPuckProps<ComponentProps>;
-    readOnly?: Partial<Record<keyof ComponentProps, boolean>>;
-  }>;
+  resolveProps?: (props: WithPuckProps<ComponentProps>) =>
+    | Promise<{
+        props: WithPuckProps<ComponentProps>;
+        readOnly?: Partial<Record<keyof ComponentProps, boolean>>;
+      }>
+    | {
+        props: WithPuckProps<ComponentProps>;
+        readOnly?: Partial<Record<keyof ComponentProps, boolean>>;
+      };
 };
 
 type Category<ComponentName> = {


### PR DESCRIPTION
This PR makes various changes to adaptors. Part 3 coming soon with UI improvements.

No breaking changes as everything is either unreleased, or backwards compatible.

1. Rename the `resolveData` lib to `resolveAllData` to prevent clash with 2.
2. Rename `resolveProps` to `resolveData`, and tweak the API
3. Persist the data that `resolveData` produces
4. Move props from `root` to `root.props`*
5. Add `resolveData` support to **root**.
6. Add loading states when `resolveData` is processing
9. Moves the modal outside of the root to prevent z-index clashes
10. Adds readOnly functionality to all field types, and improve UI
11. Prevent flickering when item is dragged in root DropZone

*Backwards compatible, but will require future breaking change.