### PR TITLE
add explicit rsc and css exports

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,20 @@
   "private": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./rsc": {
+      "import": "./dist/rsc.js",
+      "require": "./dist/rsc.js",
+      "types": "./dist/rsc.d.ts"
+    },
+    "./puck.css": "./dist/index.css",
+    "./dist/index.css": "./dist/index.css"
+  },
   "license": "MIT",
   "scripts": {
     "lint": "eslint \"**/*.ts*\"",


### PR DESCRIPTION
I believe this should be backwards compatible, but would be good to have tested by a few different node versions.