### PR TITLE
fix: stop `zones` getting wiped out if data prop updated

### DIFF
--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -110,7 +110,7 @@ export function Puck({
 }) {
   const [reducer] = useState(() => createReducer({ config }));
 
-  const initialAppState: AppState = {
+  const [initialAppState] = useState<AppState>({
     ...defaultAppState,
     data: initialData,
     ui: {
@@ -134,7 +134,7 @@ export function Puck({
           )
         : {},
     },
-  };
+  });
 
   const [appState, dispatch] = useReducer<StateReducer>(
     reducer,


### PR DESCRIPTION
Updating the `data` prop can confuse Puck, so we should freeze it into state

This use case would result in the `zones` being deleted on mount.

```tsx
  const [puckData, setPuckData] = useState(data);

    return (
      <div>
        <Puck
          config={config}
          data={puckData}
          onChange={(updatedData) => {
            setPuckData(updatedData);
          }}
        />
      </div>
    );
  }
```