### PR TITLE
Fix TS module import error

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Render the editor:
 ```jsx
 // Editor.jsx
 import { Puck } from "@measured/puck";
-import "@measured/puck/dist/index.css";
+import "@measured/puck/puck.css";
 
 // Create puck component config
 const config = {
@@ -71,7 +71,7 @@ Render the page:
 ```jsx
 // Page.jsx
 import { Render } from "@measured/puck";
-import "@measured/puck/dist/index.css";
+import "@measured/puck/puck.css";
 
 export function Page() {
   return <Render config={config} data={data} />;
@@ -380,7 +380,7 @@ If you want to use React server components, use ` <Render>` from the `@measured/
 
 ```tsx
 import { Render } from "@measured/puck/rsc";
-import "@measured/puck/dist/index.css";
+import "@measured/puck/puck.css";
 
 export function Page() {
   return <Render config={config} data={data} />;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,13 @@
     "./puck.css": "./dist/index.css",
     "./dist/index.css": "./dist/index.css"
   },
+  "typesVersions": {
+    "*": {
+      "rsc": [
+        "./dist/rsc.js"
+      ]
+    }
+  },
   "license": "MIT",
   "scripts": {
     "lint": "eslint \"**/*.ts*\"",

--- a/recipes/next/app/layout.tsx
+++ b/recipes/next/app/layout.tsx
@@ -1,4 +1,4 @@
-import "@measured/puck/dist/index.css";
+import "@measured/puck/puck.css";
 import "./styles.css";
 
 export default function RootLayout({


### PR DESCRIPTION
#221 introduced explicit exports to allow the user to import the `rsc` and CSS bundles without reaching into `dist`.

However, this introduced this TypeScript issue: https://stackoverflow.com/questions/72193784/why-doesnt-the-exports-field-of-npm-work-in-typescript

Resolved using this answer: https://stackoverflow.com/a/73433177/1703260.

Testing via https://github.com/measuredco/measuredco-site/pull/118.