### PR TITLE
Improve responsive behaviour

### DIFF
--- a/apps/demo/config/blocks/Card/styles.module.css
+++ b/apps/demo/config/blocks/Card/styles.module.css
@@ -12,6 +12,7 @@
   background: white;
   box-shadow: rgba(140, 152, 164, 0.25) 0px 3px 6px 0px;
   border-radius: 8px;
+  flex: 1;
   max-width: 100%;
   margin-left: unset;
   margin-right: unset;

--- a/apps/demo/config/blocks/Columns/index.tsx
+++ b/apps/demo/config/blocks/Columns/index.tsx
@@ -63,6 +63,8 @@ export const Columns: ComponentConfig<ColumnsProps> = {
             <div
               key={idx}
               style={{
+                display: "flex",
+                flexDirection: "column",
                 gridColumn:
                   span && distribution === "manual"
                     ? `span ${Math.max(Math.min(span, 12), 1)}`

--- a/apps/demo/config/blocks/Stats/styles.module.css
+++ b/apps/demo/config/blocks/Stats/styles.module.css
@@ -10,13 +10,22 @@
   grid-gap: 72px;
   align-items: center;
   justify-content: space-between;
-  padding: 64px;
+  margin: 0 auto;
+  max-width: 768px;
+  padding: 64px 16px;
 }
 
 @media (min-width: 768px) {
   .Stats-items {
+    padding: 64px 24px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .Stats-items {
     grid-template-columns: 1fr 1fr;
-    padding: 128px;
+    padding: 128px 24px;
+    max-width: 100%;
   }
 }
 

--- a/apps/demo/config/components/Header/index.tsx
+++ b/apps/demo/config/components/Header/index.tsx
@@ -1,0 +1,39 @@
+import { getClassNameFactory } from "@/core/lib";
+
+import styles from "./styles.module.css";
+
+const getClassName = getClassNameFactory("Header", styles);
+
+const NavItem = ({ label, href }: { label: string; href: string }) => {
+  const navPath = window.location.pathname.replace("/edit", "") || "/";
+
+  const isActive = navPath === (href.replace("/edit", "") || "/");
+
+  return (
+    <a
+      href={href || "/"}
+      style={{
+        textDecoration: "none",
+        color: isActive
+          ? "var(--puck-color-grey-1)"
+          : "var(--puck-color-grey-5)",
+        fontWeight: isActive ? "600" : "400",
+      }}
+    >
+      {label}
+    </a>
+  );
+};
+
+const Header = ({ editMode }) => (
+  <header className={getClassName()}>
+    <div className={getClassName("logo")}>LOGO</div>
+    <nav className={getClassName("items")}>
+      <NavItem label="Home" href={`${editMode ? "/edit" : ""}`} />
+      <NavItem label="Pricing" href={`/pricing${editMode ? "/edit" : ""}`} />
+      <NavItem label="About" href={`/about${editMode ? "/edit" : ""}`} />
+    </nav>
+  </header>
+);
+
+export { Header };

--- a/apps/demo/config/components/Header/styles.module.css
+++ b/apps/demo/config/components/Header/styles.module.css
@@ -1,0 +1,33 @@
+.Header {
+  align-items: center;
+  display: flex;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 1280px;
+  padding: 24px 16px;
+}
+
+@media (min-width: 768px) {
+  .Header {
+    padding: 24px;
+  }
+}
+
+.Header-logo {
+  font-size: 24px;
+  font-weight: 800;
+  letter-spacing: 1.4;
+  opacity: 0.8;
+}
+
+.Header-items {
+  display: flex;
+  gap: 24px;
+  margin-left: auto;
+}
+
+@media (min-width: 1024px) {
+  .Header-items  {
+    gap: 32px;
+  }
+}

--- a/apps/demo/config/components/Section/styles.module.css
+++ b/apps/demo/config/components/Section/styles.module.css
@@ -1,6 +1,13 @@
 .Section:not(.Section .Section) {
-  padding-left: 24px;
-  padding-right: 24px;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+@media (min-width: 768px) {
+  .Section:not(.Section .Section) {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
 }
 
 .Section:not(.Section .Section) .Section-inner {

--- a/apps/demo/config/root.tsx
+++ b/apps/demo/config/root.tsx
@@ -2,67 +2,17 @@ import { ReactNode } from "react";
 
 import { DefaultRootProps } from "@/core";
 import { Footer } from "./components/Footer";
+import { Header } from "./components/Header";
 
 export type RootProps = {
   children: ReactNode;
   title: string;
 } & DefaultRootProps;
 
-const NavItem = ({ label, href }: { label: string; href: string }) => {
-  const navPath = window.location.pathname.replace("/edit", "") || "/";
-
-  const isActive = navPath === (href.replace("/edit", "") || "/");
-
-  return (
-    <a
-      href={href || "/"}
-      style={{
-        textDecoration: "none",
-        color: isActive
-          ? "var(--puck-color-grey-1)"
-          : "var(--puck-color-grey-5)",
-        fontWeight: isActive ? "600" : "400",
-      }}
-    >
-      {label}
-    </a>
-  );
-};
-
 function Root({ children, editMode }: RootProps) {
   return (
     <>
-      <header>
-        <div
-          style={{
-            display: "flex",
-            maxWidth: 1280,
-            marginLeft: "auto",
-            marginRight: "auto",
-            padding: 24,
-            alignItems: "center",
-          }}
-        >
-          <div
-            style={{
-              fontSize: 24,
-              letterSpacing: 1.4,
-              fontWeight: 800,
-              opacity: 0.8,
-            }}
-          >
-            LOGO
-          </div>
-          <nav style={{ display: "flex", marginLeft: "auto", gap: 32 }}>
-            <NavItem label="Home" href={`${editMode ? "/edit" : ""}`} />
-            <NavItem
-              label="Pricing"
-              href={`/pricing${editMode ? "/edit" : ""}`}
-            />
-            <NavItem label="About" href={`/about${editMode ? "/edit" : ""}`} />
-          </nav>
-        </div>
-      </header>
+      <Header editMode={editMode} />
       {children}
       <Footer>
         <Footer.List title="Section">

--- a/packages/core/components/Button/Button.module.css
+++ b/packages/core/components/Button/Button.module.css
@@ -8,6 +8,7 @@
   align-items: center;
   gap: 8px;
   letter-spacing: 0.05ch;
+  font-family: var(--puck-font-family);
   font-size: 14px;
   font-weight: 500;
   text-align: center;

--- a/packages/core/components/ComponentList/index.tsx
+++ b/packages/core/components/ComponentList/index.tsx
@@ -31,7 +31,7 @@ const ComponentListItem = ({
       >
         {() => (
           <>
-            {component}
+            <div className={getClassNameItem("name")}>{component}</div>
             <div className={getClassNameItem("icon")}>
               <DragIcon />
             </div>

--- a/packages/core/components/ComponentList/styles.module.css
+++ b/packages/core/components/ComponentList/styles.module.css
@@ -53,13 +53,14 @@
   font-size: var(--puck-font-size-xxs);
   justify-content: space-between;
   align-items: center;
-  gap: 12px;
   cursor: grab;
   margin-bottom: 12px;
 }
 
-.ComponentListItemIcon {
-  color: var(--puck-color-grey-4);
+.ComponentListItem-name {
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .ComponentList:not(.ComponentList--isDraggingFrom)

--- a/packages/core/components/InputOrGroup/fields/ArrayField/styles.module.css
+++ b/packages/core/components/InputOrGroup/fields/ArrayField/styles.module.css
@@ -73,10 +73,11 @@
   color: var(--puck-color-grey-3);
   display: flex;
   align-items: center;
+  gap: 2px;
   justify-content: space-between;
   font-size: var(--puck-font-size-xxs);
   list-style: none;
-  padding: 12px 16px;
+  padding: 12px 15px;
   position: relative;
   overflow: hidden;
 }
@@ -114,18 +115,18 @@
   border: none;
   border-top: 1px solid var(--puck-color-grey-8);
   margin: 0;
-  padding: 16px;
+  padding: 16px 15px;
 }
 
 .ArrayFieldItem-rhs {
   display: flex;
-  gap: 8px;
+  gap: 4px;
   align-items: center;
 }
 
 .ArrayFieldItem-actions {
   display: flex;
-  gap: 8px;
+  gap: 4px;
   opacity: 0;
 }
 

--- a/packages/core/components/InputOrGroup/styles.module.css
+++ b/packages/core/components/InputOrGroup/styles.module.css
@@ -48,7 +48,7 @@
   border-color: var(--puck-color-grey-8);
   border-radius: 4px;
   font-family: inherit;
-  padding: 12px 16px;
+  padding: 12px 15px;
   width: 100%;
 }
 

--- a/packages/core/components/LayerTree/index.tsx
+++ b/packages/core/components/LayerTree/index.tsx
@@ -128,7 +128,7 @@ export const LayerTree = ({
                         <Grid size="16" />
                       )}
                     </div>
-                    {item.type}
+                    <div className={getClassNameLayer("name")}>{item.type}</div>
                   </div>
                 </div>
               </div>

--- a/packages/core/components/LayerTree/styles.module.css
+++ b/packages/core/components/LayerTree/styles.module.css
@@ -27,13 +27,13 @@
 }
 
 .Layer-inner {
-  padding-left: 20px;
-  padding-right: 8px;
-  border-radius: 3px;
+  padding-left: 12px;
+  padding-right: 4px;
+  border-radius: 4px;
 }
 
 .Layer--containsZone > .Layer-inner {
-  padding-left: 8px;
+  padding-left: 0;
 }
 
 .Layer-clickable {
@@ -69,7 +69,7 @@
 
 .Layer-zones {
   display: none;
-  margin-left: 20px;
+  margin-left: 12px;
 }
 
 .Layer--isSelected > .Layer-zones,
@@ -78,7 +78,7 @@
 }
 
 .Layer-zones > .LayerTree {
-  margin-left: 16px;
+  margin-left: 12px;
 }
 
 .Layer-title,
@@ -87,6 +87,13 @@
   gap: 8px;
   align-items: center;
   margin: 8px 4px;
+  overflow-x: hidden;
+}
+
+.Layer-name {
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .Layer-icon {

--- a/packages/core/components/OutlineList/styles.module.css
+++ b/packages/core/components/OutlineList/styles.module.css
@@ -2,7 +2,6 @@
   color: var(--puck-color-grey-2);
   font-family: var(--puck-font-stack);
   margin: 0;
-  margin-left: 16px;
   padding-left: 16px;
   position: relative;
   list-style: none;
@@ -39,5 +38,5 @@
 }
 
 .OutlineListItem > .OutlineList {
-  margin: 8px;
+  margin: 8px 0;
 }

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -33,10 +33,14 @@ import { LayerTree } from "../LayerTree";
 import { findZonesForArea } from "../../lib/find-zones-for-area";
 import { areaContainsZones } from "../../lib/area-contains-zones";
 import { flushZones } from "../../lib/flush-zones";
+import getClassNameFactory from "../../lib/get-class-name-factory";
 import { usePuckHistory } from "../../lib/use-puck-history";
 import { AppProvider, defaultAppState } from "./context";
 import { useComponentList } from "../../lib/use-component-list";
 import { useResolvedData } from "../../lib/use-resolved-data";
+import styles from "./styles.module.css";
+
+const getClassName = getClassNameFactory("Puck", styles);
 
 const Field = () => {};
 
@@ -270,7 +274,7 @@ export function Puck({
   }, []);
 
   return (
-    <div className="puck">
+    <div>
       <AppProvider
         value={{ state: appState, dispatch, config, componentState }}
       >
@@ -354,31 +358,8 @@ export function Puck({
             <dropZoneContext.Consumer>
               {(ctx) => {
                 return (
-                  <div
-                    style={{
-                      display: "grid",
-                      gridTemplateAreas:
-                        '"header header header" "left editor right"',
-                      gridTemplateColumns: `${
-                        leftSideBarVisible ? "288px" : "0px"
-                      } auto 288px`,
-                      gridTemplateRows: "min-content auto",
-                      height: "100vh",
-                      position: "fixed",
-                      top: 0,
-                      bottom: 0,
-                      left: 0,
-                      right: 0,
-                    }}
-                  >
-                    <header
-                      style={{
-                        gridArea: "header",
-                        color: "var(--puck-color-black)",
-                        background: "var(--puck-color-white)",
-                        borderBottom: "1px solid var(--puck-color-grey-8)",
-                      }}
-                    >
+                  <div className={getClassName({ leftSideBarVisible })}>
+                    <header className={getClassName("header")}>
                       {renderHeader ? (
                         renderHeader({
                           children: (
@@ -395,21 +376,8 @@ export function Puck({
                           state: appState,
                         })
                       ) : (
-                        <div
-                          style={{
-                            display: "grid",
-                            padding: 16,
-                            gridTemplateAreas: '"left middle right"',
-                            gridTemplateColumns: "344px auto 344px",
-                            gridTemplateRows: "auto",
-                          }}
-                        >
-                          <div
-                            style={{
-                              display: "flex",
-                              gap: 16,
-                            }}
-                          >
+                        <div className={getClassName("headerInner")}>
+                          <div className={getClassName("headerToggle")}>
                             <IconButton
                               onClick={() =>
                                 dispatch({
@@ -424,31 +392,20 @@ export function Puck({
                               <Sidebar />
                             </IconButton>
                           </div>
-                          <div
-                            style={{
-                              display: "flex",
-                              justifyContent: "center",
-                              alignItems: "center",
-                            }}
-                          >
+                          <div className={getClassName("headerTitle")}>
                             <Heading rank={2} size="xs">
                               {headerTitle || rootProps.title || "Page"}
                               {headerPath && (
-                                <small
-                                  style={{ fontWeight: 400, marginLeft: 4 }}
-                                >
-                                  <code>{headerPath}</code>
-                                </small>
+                                <>
+                                  {" "}
+                                  <code className={getClassName("headerPath")}>
+                                    {headerPath}
+                                  </code>
+                                </>
                               )}
                             </Heading>
                           </div>
-                          <div
-                            style={{
-                              display: "flex",
-                              gap: 16,
-                              justifyContent: "flex-end",
-                            }}
-                          >
+                          <div className={getClassName("headerTools")}>
                             <div style={{ display: "flex" }}>
                               <IconButton
                                 title="undo"
@@ -479,33 +436,28 @@ export function Puck({
                                 />
                               </IconButton>
                             </div>
-                            {renderHeaderActions &&
-                              renderHeaderActions({
-                                state: appState,
-                                dispatch,
-                              })}
-                            <Button
-                              onClick={() => {
-                                onPublish(data);
-                              }}
-                              icon={<Globe size="14px" />}
-                            >
-                              Publish
-                            </Button>
+                            <div>
+                              {renderHeaderActions &&
+                                renderHeaderActions({
+                                  state: appState,
+                                  dispatch,
+                                })}
+                            </div>
+                            <div>
+                              <Button
+                                onClick={() => {
+                                  onPublish(data);
+                                }}
+                                icon={<Globe size="14px" />}
+                              >
+                                Publish
+                              </Button>
+                            </div>
                           </div>
                         </div>
                       )}
                     </header>
-                    <div
-                      style={{
-                        gridArea: "left",
-                        background: "var(--puck-color-grey-11)",
-                        borderRight: "1px solid var(--puck-color-grey-8)",
-                        overflowY: "auto",
-                        display: "flex",
-                        flexDirection: "column",
-                      }}
-                    >
+                    <div className={getClassName("leftSideBar")}>
                       <SidebarSection title="Components">
                         <ComponentListWrapper>
                           {componentList ? (
@@ -549,30 +501,12 @@ export function Puck({
                       </SidebarSection>
                     </div>
                     <div
-                      style={{
-                        overflowY: "auto",
-                        gridArea: "editor",
-                        position: "relative",
-                        display: "flex",
-                        flexDirection: "column",
-                      }}
+                      className={getClassName("frame")}
                       onClick={() => setItemSelector(null)}
                       id="puck-frame"
                     >
-                      <div
-                        className="puck-root"
-                        style={{
-                          boxShadow:
-                            "0px 0px 0px 32px var(--puck-color-grey-10)",
-                          margin: 32,
-                          zoom: 0.75,
-                        }}
-                      >
-                        <div
-                          style={{
-                            border: "1px solid var(--puck-color-grey-8)",
-                          }}
-                        >
+                      <div className={getClassName("root")}>
+                        <div className={getClassName("page")}>
                           <Page
                             dispatch={dispatch}
                             state={appState}
@@ -591,17 +525,7 @@ export function Puck({
                         }}
                       ></div>
                     </div>
-                    <div
-                      style={{
-                        borderLeft: "1px solid var(--puck-color-grey-8)",
-                        overflowY: "auto",
-                        gridArea: "right",
-                        fontFamily: "var(--puck-font-stack)",
-                        display: "flex",
-                        flexDirection: "column",
-                        background: "var(--puck-color-white)",
-                      }}
-                    >
+                    <div className={getClassName("rightSideBar")}>
                       <FieldWrapper dispatch={dispatch} state={appState}>
                         <SidebarSection
                           noPadding

--- a/packages/core/components/Puck/styles.module.css
+++ b/packages/core/components/Puck/styles.module.css
@@ -1,0 +1,151 @@
+/*
+ * Puck's responsive layout uses minimum viewport widths slightly _below_ common
+ * framework/device breakpoints, and ensures that the width of the resulting
+ * Puck page preview (zoomed at 75%) is slightly _above_ common framework/device
+ * breakpoints. This can help alleviate some of the pain when editing responsive
+ * pages in a preview area that is narrower than the reported viewport width.
+ *
+ * Viewport | Puck page @ zoom 0.75
+ * --------------------------------
+ * 638px    | 321px
+ * 766px    | 321px
+ * 990px    | 604px
+ * 1022px   | 646px
+ * 1198px   | 801px
+ * 1398px   | 1025px
+ * 1598px   | 1212px
+ */
+
+ .Puck {
+  --puck-frame-width: minmax(266px, auto);
+  --puck-side-bar-width: minmax(186px, 250px);
+  --puck-space-px: 16px;
+  bottom: 0;
+  display: grid;
+  grid-template-areas: "header header header" "left editor right";
+  grid-template-columns: 0 var(--puck-frame-width) var(--puck-side-bar-width);
+  grid-template-rows: min-content auto;
+  height: 100vh;
+  left: 0;
+  overflow-x: auto;
+  position: fixed;
+  right: 0;
+  top: 0;
+}
+
+.Puck--leftSideBarVisible {
+  grid-template-columns:
+    var(--puck-side-bar-width) var(--puck-frame-width)
+    var(--puck-side-bar-width);
+}
+
+@media (min-width: 766px) {
+  .Puck {
+    --puck-frame-width: auto;
+  }
+}
+
+@media (min-width: 990px) {
+  .Puck {
+    --puck-side-bar-width: 256px;
+  }
+}
+
+@media (min-width: 1198px) {
+  .Puck {
+    --puck-side-bar-width: 274px;
+  }
+}
+
+@media (min-width: 1398px) {
+  .Puck {
+    --puck-side-bar-width: 290px;
+  }
+}
+
+@media (min-width: 1598px) {
+  .Puck {
+    --puck-side-bar-width: 320px;
+  }
+}
+
+.Puck-header {
+  background: var(--puck-color-white);
+  border-bottom: 1px solid var(--puck-color-grey-8);
+  color: var(--puck-color-black);
+  grid-area: header;
+}
+
+.Puck-headerInner {
+  align-items: start;
+  display: grid;
+  gap: var(--puck-space-px);
+  grid-template-areas: "left middle right";
+  grid-template-columns: 1fr auto 1fr;
+  grid-template-rows: auto;
+  padding: var(--puck-space-px);
+}
+
+.Puck-headerToggle {
+  padding-top: 2px;
+}
+
+.Puck-headerTitle {
+  align-self: center;
+}
+
+.Puck-headerPath {
+  font-family: var(--puck-font-family-monospaced);
+  font-size: var(--puck-font-size-xxs);
+  font-weight: normal;
+  word-break: break-all;
+}
+
+.Puck-headerTools {
+  display: flex;
+  gap: 16px;
+  justify-content: flex-end;
+}
+
+.Puck-leftSideBar {
+  background: var(--puck-color-grey-11);
+  border-right: 1px solid var(--puck-color-grey-8);
+  display: flex;
+  flex-direction: column;
+  grid-area: left;
+  overflow-y: auto;
+}
+
+.Puck-frame {
+  display: flex;
+  flex-direction: column;
+  grid-area: editor;
+  overflow-y: auto;
+  position: relative;
+}
+
+.Puck-root {
+  box-shadow: 0 0 0 calc(var(--puck-space-px) * 2) var(--puck-color-grey-10);
+  margin: var(--puck-space-px);
+  zoom: 0.75;
+}
+
+@media (min-width: 1198px) {
+  .Puck-root {
+    margin: calc(var(--puck-space-px) * 2);
+  }
+}
+
+.Puck-page {
+  border: 1px solid var(--puck-color-grey-8);
+}
+
+.Puck-rightSideBar {
+  background: var(--puck-color-white);
+  border-left: 1px solid var(--puck-color-grey-8);
+  display: flex;
+  flex-direction: column;
+  font-family: var(--puck-font-stack);
+  grid-area: right;
+  overflow-y: auto;
+}

--- a/packages/core/components/SidebarSection/styles.module.css
+++ b/packages/core/components/SidebarSection/styles.module.css
@@ -25,6 +25,10 @@
   padding: 0px;
 }
 
+.SidebarSection--noPadding .SidebarSection-content:last-child {
+  padding-bottom: 4px;
+}
+
 .SidebarSection:last-of-type .SidebarSection-content {
   border-bottom: none;
   flex-grow: 1;

--- a/packages/core/styles/typography.css
+++ b/packages/core/styles/typography.css
@@ -92,7 +92,6 @@
     Segoe UI Symbol;
 
   /* Values */
-  --puck-font-family-monospaced: "Menlo", "Monaco", "Liberation Mono",
-    "Consolas", "Courier New", monospace;
+  --puck-font-family-monospaced: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
   --puck-font-family-proportional: var(--puck-font-stack), sans-serif;
 }

--- a/packages/plugin-heading-analyzer/src/HeadingAnalyzer.tsx
+++ b/packages/plugin-heading-analyzer/src/HeadingAnalyzer.tsx
@@ -16,7 +16,7 @@ const getOutline = ({
   addDataAttr = false,
 }: { addDataAttr?: boolean } = {}) => {
   const headings = window.document
-    .querySelector(".puck-root")!
+    .querySelector("#puck-frame")!
     .querySelectorAll("h1,h2,h3,h4,h5,h6");
 
   const _outline: { rank: number; text: string; analyzeId: string }[] = [];


### PR DESCRIPTION
Closes #225 

First pass of responsive improvements

* Editor supports viewport widths down to `638px` without breaking
* Pragmatic widths for the editor page preview (helps alleviate some of the pain when editing responsive pages in a preview area narrower than the reported viewport width)
* Tightens up spacing in editor sidebars to maximise available space for longer names
* Ensures long strings can always be handled (defensive CSS)
* Prevents form zoom in iOS
* Adds some missing responsive behaviour to the demo app

For follow up work, suggest we make more granular issues, I can this handle as I go, for example

* Add a toggle for the right-hand sidebar
* Support viewports below `638px` wide

### Before

<img width="640" alt="Screenshot 2023-11-16 at 12 33 17" src="https://github.com/measuredco/puck/assets/98794/8f861b4f-c23e-42d0-8f37-90bf42ab298f">

### After

<img width="640" alt="Screenshot 2023-11-16 at 12 33 40" src="https://github.com/measuredco/puck/assets/98794/f5f78c08-4e8f-4d1d-842e-425d64e84c82">
