### PR TITLE
fix: ensure updated root props are passed to root render

### DIFF
--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -510,7 +510,7 @@ export function Puck({
                           <Page
                             dispatch={dispatch}
                             state={appState}
-                            {...data.root}
+                            {...rootProps}
                           >
                             <DropZone zone={rootDroppableId} />
                           </Page>


### PR DESCRIPTION
If the user has migrated to the new data API in [v0.11.0](https://github.com/measuredco/puck/releases/tag/v0.11.0), their root render method would not have received the props (although still accessible via the `state` prop).