### PR TITLE
Fix root resolver with new root data API

### DIFF
--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -510,7 +510,7 @@ export function Puck({
                           <Page
                             dispatch={dispatch}
                             state={appState}
-                            {...data.root}
+                            {...rootProps}
                           >
                             <DropZone zone={rootDroppableId} />
                           </Page>
@@ -546,7 +546,7 @@ export function Puck({
                               if (selectedItem) {
                                 currentProps = selectedItem.props;
                               } else {
-                                currentProps = data.root;
+                                currentProps = rootProps;
                               }
 
                               const newProps = {
@@ -578,12 +578,12 @@ export function Puck({
                                   if (config.root?.resolveData) {
                                     resolveData({
                                       ...data,
-                                      root: { props: { newProps } },
+                                      root: { props: newProps },
                                     });
                                   } else {
                                     dispatch({
                                       type: "setData",
-                                      data: { root: { props: { newProps } } },
+                                      data: { root: { props: newProps } },
                                     });
                                   }
                                 } else {

--- a/recipes/next/database.json
+++ b/recipes/next/database.json
@@ -1,1 +1,1 @@
-{"/":{"content":[{"type":"HeadingBlock","props":{"title":"Edit this page by adding /edit to the end of the URL","id":"HeadingBlock-1694032984497"}}],"root":{"title":""}}}
+{"/":{"content":[{"type":"HeadingBlock","props":{"title":"Edit this page by adding /edit to the end of the URL","id":"HeadingBlock-1694032984497"}}],"root":{"props": {"title":""}}}}


### PR DESCRIPTION
The root data API in https://github.com/measuredco/puck/releases/tag/v0.11.0 moved props from `data.root` to `data.root.props`.

This change was implemented as a backwards compatible change. However, the backwards compatibility introduced  two bugs that resulted in the props being recursively spread.