### PR TITLE
chore: stop dnd scoll container warning

### DIFF
--- a/packages/core/components/Puck/styles.module.css
+++ b/packages/core/components/Puck/styles.module.css
@@ -16,7 +16,7 @@
  * 1598px   | 1212px
  */
 
- .Puck {
+.Puck {
   --puck-frame-width: minmax(266px, auto);
   --puck-side-bar-width: minmax(186px, 250px);
   --puck-space-px: 16px;
@@ -27,7 +27,6 @@
   grid-template-rows: min-content auto;
   height: 100vh;
   left: 0;
-  overflow-x: auto;
   position: fixed;
   right: 0;
   top: 0;


### PR DESCRIPTION
Having `overflow-x: auto` on a parent of the Droppable causes the following dnd warning whenever dragging an item:

> dnd.esm.js:31 @hello-pangea/dndDroppable: unsupported nested scroll container detected.A Droppable can only have one scroll parent (which can be itself)Nested scroll containers are currently not supported.We hope to support nested scroll containers soon: https://github.com/atlassian/react-beautiful-dnd/issues/131

See https://github.com/atlassian/react-beautiful-dnd/issues/131\#issuecomment-1634398431

Introduced in #225, which has not been released so using `chore`.