### PR TITLE
Further improvements to ArrayField functionality

### DIFF
--- a/apps/docs/components/Preview/index.tsx
+++ b/apps/docs/components/Preview/index.tsx
@@ -5,7 +5,7 @@ export { InputOrGroup } from "@/core/components/InputOrGroup";
 import { ReactNode, useReducer, useState } from "react";
 import "@/core/styles.css";
 import { AppProvider, defaultAppState } from "@/core/components/Puck/context";
-import { PuckAction, createReducer } from "@/core/reducer";
+import { PuckAction, createReducer, replaceAction } from "@/core/reducer";
 import { InputOrGroup } from "@/core/components/InputOrGroup";
 import { AppState, ComponentConfig, Config, Data } from "@/core/types/Config";
 import { rootDroppableId } from "@/core/lib/root-droppable-id";
@@ -36,7 +36,7 @@ const PreviewApp = ({
     data,
   });
 
-  const { componentState } = useResolvedData(data, config, dispatch);
+  const { componentState } = useResolvedData(appState, config, dispatch);
 
   return (
     <AppProvider
@@ -123,7 +123,8 @@ export const ConfigPreview = ({
                   appState.data["content"][0].readOnly &&
                   appState.data["content"][0].readOnly[name]
                 }
-                onChange={async (val) => {
+                id={`example_${name}`}
+                onChange={async (val, ui) => {
                   const { resolveData = (data) => data } = componentConfig;
 
                   const newData = await resolveData(
@@ -138,7 +139,7 @@ export const ConfigPreview = ({
                     { changed: { [name]: true } }
                   );
 
-                  dispatch({
+                  const replacedData = replaceAction(appState.data, {
                     type: "replace",
                     destinationIndex: 0,
                     destinationZone: rootDroppableId,
@@ -152,6 +153,17 @@ export const ConfigPreview = ({
                         ...appState.data["content"][0].readOnly,
                         ...newData.readOnly,
                       },
+                    },
+                  });
+
+                  dispatch({
+                    type: "set",
+                    state: {
+                      ui: {
+                        ...appState.ui,
+                        ...ui,
+                      },
+                      data: replacedData,
                     },
                   });
                 }}

--- a/apps/docs/pages/docs/api-reference/_meta.json
+++ b/apps/docs/pages/docs/api-reference/_meta.json
@@ -1,0 +1,6 @@
+{
+  "components": {},
+  "configuration": {},
+  "functions": {},
+  "plugins": {}
+}

--- a/apps/docs/pages/docs/api-reference/app-state.mdx
+++ b/apps/docs/pages/docs/api-reference/app-state.mdx
@@ -1,6 +1,6 @@
 # `AppState`
 
-> **⚠️ The plugin API is highly experimental and is likely to experience breaking changes.**
+> **⚠️ The application state is unstable and is likely to experience breaking changes.**
 
 The internal state of the [`<Puck>`](/docs/api-reference/components/puck) component.
 

--- a/apps/docs/pages/docs/api-reference/configuration/fields/custom.mdx
+++ b/apps/docs/pages/docs/api-reference/configuration/fields/custom.mdx
@@ -126,13 +126,22 @@ const config = {
 
 #### `params`
 
-| Param             | Example                    | Type     |
-| ----------------- | -------------------------- | -------- |
-| `field`           | `{ type: "custom" }`       | Object   |
-| `id`              | `id`                       | String   |
-| `name`            | `"title"`                  | String   |
-| `onChange(value)` | `onChange("Hello, world")` | Function |
-| `value`           | `"Hello, world"`           | Any      |
+| Param                 | Example                    | Type     |
+| --------------------- | -------------------------- | -------- |
+| `field`               | `{ type: "custom" }`       | Object   |
+| `id`                  | `id`                       | String   |
+| `name`                | `"title"`                  | String   |
+| `onChange(value, ui)` | `onChange("Hello, world")` | Function |
+| `value`               | `"Hello, world"`           | Any      |
+
+##### onChange(value, [ui])
+
+Set the value of the field and optionally update the [Puck UI state](/docs/api-reference/app-state#ui).
+
+| Param   | Example                       | Type                                        | Status   |
+| ------- | ----------------------------- | ------------------------------------------- | -------- |
+| `value` | `"Hello, world"`              | Any                                         | Required |
+| `ui`    | `{leftSideBarVisible: false}` | [UiState](/docs/api-reference/app-state#ui) |          |
 
 ## Further reading
 

--- a/apps/docs/pages/docs/api-reference/configuration/fields/custom.mdx
+++ b/apps/docs/pages/docs/api-reference/configuration/fields/custom.mdx
@@ -129,6 +129,7 @@ const config = {
 | Param             | Example                    | Type     |
 | ----------------- | -------------------------- | -------- |
 | `field`           | `{ type: "custom" }`       | Object   |
+| `id`              | `id`                       | String   |
 | `name`            | `"title"`                  | String   |
 | `onChange(value)` | `onChange("Hello, world")` | Function |
 | `value`           | `"Hello, world"`           | Any      |

--- a/apps/docs/pages/docs/api-reference/plugins.mdx
+++ b/apps/docs/pages/docs/api-reference/plugins.mdx
@@ -17,5 +17,4 @@ export const Example = () => {
 ## Contents
 
 - [Functions](plugins/functions) - A list of the functions available to each plugin.
-- [AppState](plugins/app-state) - The internal state of the `<Puck>` component.
-- [Actions](plugins/actions) - Actions enable you to make changes to the internal [AppState](app-state) via the [`dispatch` method](functions#dispatch).
+- [Actions](plugins/actions) - Actions enable you to make changes to the internal [AppState](/docs/api-reference/app-state) via the [`dispatch` method](functions#dispatch).

--- a/apps/docs/pages/docs/api-reference/plugins/actions.mdx
+++ b/apps/docs/pages/docs/api-reference/plugins/actions.mdx
@@ -2,7 +2,7 @@
 
 > **⚠️ The plugin API is highly experimental and is likely to experience breaking changes.**
 
-Actions enable you to make changes to the internal [AppState](app-state) via the [`dispatch` method](functions#dispatch).
+Actions enable you to make changes to the internal [AppState](/docs/api-reference/app-state) via the [`dispatch` method](functions#dispatch).
 
 This is a partial reference of the most useful actions. A full reference is available in [the codebase](https://github.com/measuredco/puck/blob/main/packages/core/reducer/actions.tsx).
 
@@ -25,12 +25,12 @@ dispatch({ type: "setData", data: {} });
 
 ### `setUi`
 
-Change a value on Puck's [UI state](/docs/api-reference/plugins/app-state/#ui).
+Change a value on Puck's [UI state](/docs/api-reference/app-state/#ui).
 
-| Param  | Example                             | Type                                                 | Status   |
-| ------ | ----------------------------------- | ---------------------------------------------------- | -------- |
-| `type` | `type: "setData"`                   | "setData"                                            | Required |
-| `ui`   | `ui: { leftSideBarVisible: false }` | [UiState](/docs/api-reference/plugins/app-state/#ui) | Required |
+| Param  | Example                             | Type                                         | Status   |
+| ------ | ----------------------------------- | -------------------------------------------- | -------- |
+| `type` | `type: "setData"`                   | "setData"                                    | Required |
+| `ui`   | `ui: { leftSideBarVisible: false }` | [UiState](/docs/api-reference/app-state/#ui) | Required |
 
 #### Example
 

--- a/apps/docs/pages/docs/api-reference/plugins/functions.mdx
+++ b/apps/docs/pages/docs/api-reference/plugins/functions.mdx
@@ -42,7 +42,7 @@ A ReactNode that contains the normal content for this field. You must render thi
 
 The current application state, including data and UI.
 
-See [AppState](app-state).
+See [AppState](/docs/api-reference/app-state).
 
 #### `dispatch(action)`
 

--- a/apps/docs/pages/docs/extending-puck/custom-fields.mdx
+++ b/apps/docs/pages/docs/extending-puck/custom-fields.mdx
@@ -34,7 +34,7 @@ const config = {
 };
 ```
 
-The `onChange` function updates the Puck data payload for the field name, in this case "title".
+The [`onChange` function](/docs/api-reference/configuration/fields/custom#onchangevalue-ui) updates the Puck data payload for the field name, in this case "title".
 
 <ConfigPreview
   label="Example"
@@ -128,6 +128,41 @@ const config = {
   }}
 />
 
+## Updating the UI state
+
+The [`onChange` function](/docs/api-reference/configuration/fields/custom#onchangevalue-ui) can also be used to modify the [Puck UI state](/docs/api-reference/app-state#ui) at the same time as updating the field value:
+
+```tsx copy showLineNumbers {14,15}
+const config = {
+  components: {
+    Example: {
+      fields: {
+        title: {
+          type: "custom",
+          render: ({ name, onChange, value }) => (
+            <input
+              defaultValue={value}
+              name={name}
+              onChange={(e) =>
+                onChange(
+                  e.currentTarget.value,
+                  // Close the left side bar when this field is changed
+                  { leftSideBarVisible: false }
+                )
+              }
+              style={{ border: "1px solid black", padding: 4 }}
+            />
+          ),
+        },
+      },
+      render: ({ title }) => {
+        return <p>{title}</p>;
+      },
+    },
+  },
+};
+```
+
 ## Further reading
 
-- [The `custom` field API reference](/docs/api-reference/configuration/fields/custom):
+- [The `custom` field API reference](/docs/api-reference/configuration/fields/custom)

--- a/packages/core/components/ExternalInput/index.tsx
+++ b/packages/core/components/ExternalInput/index.tsx
@@ -17,11 +17,13 @@ export const ExternalInput = ({
   onChange,
   value = null,
   name,
+  id,
 }: {
   field: ExternalField;
   onChange: (value: any) => void;
   value: any;
   name: string;
+  id: string;
 }) => {
   const { mapProp = (val) => val } = field || {};
 
@@ -61,6 +63,7 @@ export const ExternalInput = ({
         dataSelected: !!value,
         modalVisible: isOpen,
       })}
+      id={id}
     >
       <div className={getClassName("actions")}>
         <button

--- a/packages/core/components/InputOrGroup/fields/DefaultField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/DefaultField/index.tsx
@@ -12,6 +12,7 @@ export const DefaultField = ({
   value,
   name,
   label,
+  id,
 }: InputProps) => {
   return (
     <FieldLabelInternal
@@ -38,6 +39,7 @@ export const DefaultField = ({
           }
         }}
         readOnly={readOnly}
+        id={id}
       />
     </FieldLabelInternal>
   );

--- a/packages/core/components/InputOrGroup/fields/ExternalField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/ExternalField/index.tsx
@@ -13,6 +13,7 @@ export const ExternalField = ({
   value,
   name,
   label,
+  id,
 }: InputProps) => {
   // DEPRECATED
   const validField = field as ExternalFieldType;
@@ -55,6 +56,7 @@ export const ExternalField = ({
         }}
         onChange={onChange}
         value={value}
+        id={id}
       />
     </FieldLabelInternal>
   );

--- a/packages/core/components/InputOrGroup/fields/RadioField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/RadioField/index.tsx
@@ -11,6 +11,7 @@ export const RadioField = ({
   readOnly,
   value,
   name,
+  id,
 }: InputProps) => {
   if (field.type !== "radio" || !field.options) {
     return null;
@@ -23,7 +24,7 @@ export const RadioField = ({
       readOnly={readOnly}
       el="div"
     >
-      <div className={getClassName("radioGroupItems")}>
+      <div className={getClassName("radioGroupItems")} id={id}>
         {field.options.map((option) => (
           <label
             key={option.label + option.value}

--- a/packages/core/components/InputOrGroup/fields/SelectField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/SelectField/index.tsx
@@ -12,6 +12,7 @@ export const SelectField = ({
   value,
   name,
   readOnly,
+  id,
 }: InputProps) => {
   if (field.type !== "select" || !field.options) {
     return null;
@@ -24,6 +25,7 @@ export const SelectField = ({
       readOnly={readOnly}
     >
       <select
+        id={id}
         className={getClassName("input")}
         disabled={readOnly}
         onChange={(e) => {

--- a/packages/core/components/InputOrGroup/fields/TextareaField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/TextareaField/index.tsx
@@ -11,6 +11,7 @@ export const TextareaField = ({
   value,
   name,
   label,
+  id,
 }: InputProps) => {
   return (
     <FieldLabelInternal
@@ -19,6 +20,7 @@ export const TextareaField = ({
       readOnly={readOnly}
     >
       <textarea
+        id={id}
         className={getClassName("input")}
         autoComplete="off"
         name={name}

--- a/packages/core/components/InputOrGroup/index.tsx
+++ b/packages/core/components/InputOrGroup/index.tsx
@@ -62,7 +62,6 @@ export const FieldLabelInternal = ({
   el?: "label" | "div";
   readOnly?: boolean;
 }) => {
-  const El = el;
   return (
     <FieldLabel
       label={label}
@@ -80,6 +79,7 @@ export type InputProps = {
   name: string;
   field: Field<any>;
   value: any;
+  id: string;
   label?: string;
   onChange: (value: any) => void;
   readOnly?: boolean;

--- a/packages/core/components/InputOrGroup/index.tsx
+++ b/packages/core/components/InputOrGroup/index.tsx
@@ -1,5 +1,5 @@
 import getClassNameFactory from "../../lib/get-class-name-factory";
-import { Field } from "../../types/Config";
+import { Field, UiState } from "../../types/Config";
 
 import styles from "./styles.module.css";
 import { ReactNode, useCallback, useEffect, useState } from "react";
@@ -81,7 +81,7 @@ export type InputProps = {
   value: any;
   id: string;
   label?: string;
-  onChange: (value: any) => void;
+  onChange: (value: any, uiState?: Partial<UiState>) => void;
   readOnly?: boolean;
   readOnlyFields?: Record<string, boolean | undefined>;
 };
@@ -92,16 +92,16 @@ export const InputOrGroup = ({ onChange, ...props }: InputProps) => {
   const [localValue, setLocalValue] = useState(value);
 
   const onChangeDb = useDebouncedCallback(
-    (val) => {
-      onChange(val);
+    (val, ui) => {
+      onChange(val, ui);
     },
     50,
     { leading: true }
   );
 
-  const onChangeLocal = useCallback((val) => {
+  const onChangeLocal = useCallback((val: any, ui?: Partial<UiState>) => {
     setLocalValue(val);
-    onChangeDb(val);
+    onChangeDb(val, ui);
   }, []);
 
   useEffect(() => {

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -639,6 +639,7 @@ export function Puck({
                                   key={`${selectedItem.props.id}_${fieldName}`}
                                   field={field}
                                   name={fieldName}
+                                  id={`${selectedItem.props.id}_${fieldName}`}
                                   label={field.label}
                                   readOnly={readOnly[fieldName]}
                                   readOnlyFields={readOnly}
@@ -654,6 +655,7 @@ export function Puck({
                                   key={`page_${fieldName}`}
                                   field={field}
                                   name={fieldName}
+                                  id={`root_${fieldName}`}
                                   label={field.label}
                                   readOnly={readOnly[fieldName]}
                                   readOnlyFields={readOnly}

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,5 +1,7 @@
 import "./styles/global.css";
 
+export type { PuckAction } from "./reducer/actions";
+
 export * from "./types/Config";
 export * from "./components/Button";
 // DEPRECATED

--- a/packages/core/lib/__tests__/use-puck-history.spec.tsx
+++ b/packages/core/lib/__tests__/use-puck-history.spec.tsx
@@ -63,17 +63,14 @@ const mockedAppStateArray1: AppState = {
           {
             _originalIndex: 0,
             _arrayId: "ArrayItem-46a064dbef49e8441afd782b10320b74f27f8bcb",
-            data: { label: "Learn more", href: "#", variant: "primary" },
           },
           {
             _originalIndex: 1,
             _arrayId: "ArrayItem-5d99e3a7721edad0d127c9a6b010a37097dad610",
-            data: { label: "Button", href: "#", variant: "primary" },
           },
           {
             _originalIndex: 2,
             _arrayId: "ArrayItem-222ea8b444fa799a8863eb32d057f3080ec99c65",
-            data: { label: "Button", href: "#", variant: "primary" },
           },
         ],
         openId: "",
@@ -110,17 +107,14 @@ const mockedAppStateArray2: AppState = {
           {
             _originalIndex: 0,
             _arrayId: "ArrayItem-5d99e3a7721edad0d127c9a6b010a37097dad610",
-            data: { label: "Button", href: "#", variant: "primary" },
           },
           {
             _originalIndex: 1,
             _arrayId: "ArrayItem-222ea8b444fa799a8863eb32d057f3080ec99c65",
-            data: { label: "Button", href: "#", variant: "primary" },
           },
           {
             _originalIndex: 2,
             _arrayId: "ArrayItem-46a064dbef49e8441afd782b10320b74f27f8bcb",
-            data: { label: "Learn more", href: "#", variant: "primary" },
           },
         ],
         openId: "",

--- a/packages/core/lib/__tests__/use-resolved-data.spec.tsx
+++ b/packages/core/lib/__tests__/use-resolved-data.spec.tsx
@@ -1,8 +1,9 @@
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
-import { Config, Data } from "../../types/Config";
+import { AppState, Config, Data } from "../../types/Config";
 import { useResolvedData } from "../use-resolved-data";
-import { SetDataAction } from "../../reducer";
+import { SetAction, SetDataAction } from "../../reducer";
 import { cache } from "../resolve-component-data";
+import { defaultAppState } from "../../components/Puck/context";
 
 const item1 = { type: "MyComponent", props: { id: "MyComponent-1" } };
 const item2 = { type: "MyComponent", props: { id: "MyComponent-2" } };
@@ -15,6 +16,11 @@ const data: Data = {
     "MyComponent-1:zone": [item2],
     "MyComponent-2:zone": [item3],
   },
+};
+
+const state: AppState = {
+  data,
+  ui: defaultAppState.ui,
 };
 
 const config: Config = {
@@ -54,19 +60,26 @@ describe("use-resolved-data", () => {
       cache.lastChange = {};
     });
 
-    it("should call the `setData` action with resolved data", async () => {
-      let dispatchedEvents: SetDataAction[] = [];
-      let currentData = data;
+    it("should call the `set` action with resolved data and state", async () => {
+      let dispatchedEvents: SetAction[] = [];
+      let currentState: AppState = state;
 
       const renderedHook = renderHook(() => {
-        return useResolvedData(currentData, config, (args) => {
-          const action = args as SetDataAction;
-          const newData = action.data as any;
+        return useResolvedData(
+          {
+            ...currentState,
+            ui: { ...currentState.ui, leftSideBarVisible: false },
+          },
+          config,
+          (args) => {
+            const action = args as SetAction;
+            const newState = action.state as any;
 
-          dispatchedEvents.push(action);
+            dispatchedEvents.push(action);
 
-          currentData = { ...currentData, ...newData(currentData) };
-        });
+            currentState = { ...currentState, ...newState(currentState) };
+          }
+        );
       });
 
       await act(async () => {
@@ -76,54 +89,62 @@ describe("use-resolved-data", () => {
 
       expect(dispatchedEvents.length).toBe(4); // calls dispatcher for each resolver
 
-      const fn = dispatchedEvents[dispatchedEvents.length - 1].data as any;
-      expect(currentData).toMatchInlineSnapshot(`
+      const fn = dispatchedEvents[dispatchedEvents.length - 1].state as any;
+      expect(currentState).toMatchInlineSnapshot(`
         {
-          "content": [
-            {
+          "data": {
+            "content": [
+              {
+                "props": {
+                  "id": "MyComponent-1",
+                  "prop": "Hello, world",
+                },
+                "readOnly": {
+                  "prop": true,
+                },
+                "type": "MyComponent",
+              },
+            ],
+            "root": {
               "props": {
-                "id": "MyComponent-1",
-                "prop": "Hello, world",
+                "title": "Resolved title",
               },
               "readOnly": {
-                "prop": true,
+                "title": true,
               },
-              "type": "MyComponent",
             },
-          ],
-          "root": {
-            "props": {
-              "title": "Resolved title",
-            },
-            "readOnly": {
-              "title": true,
+            "zones": {
+              "MyComponent-1:zone": [
+                {
+                  "props": {
+                    "id": "MyComponent-2",
+                    "prop": "Hello, world",
+                  },
+                  "readOnly": {
+                    "prop": true,
+                  },
+                  "type": "MyComponent",
+                },
+              ],
+              "MyComponent-2:zone": [
+                {
+                  "props": {
+                    "id": "MyComponent-3",
+                    "prop": "Hello, world",
+                  },
+                  "readOnly": {
+                    "prop": true,
+                  },
+                  "type": "MyComponent",
+                },
+              ],
             },
           },
-          "zones": {
-            "MyComponent-1:zone": [
-              {
-                "props": {
-                  "id": "MyComponent-2",
-                  "prop": "Hello, world",
-                },
-                "readOnly": {
-                  "prop": true,
-                },
-                "type": "MyComponent",
-              },
-            ],
-            "MyComponent-2:zone": [
-              {
-                "props": {
-                  "id": "MyComponent-3",
-                  "prop": "Hello, world",
-                },
-                "readOnly": {
-                  "prop": true,
-                },
-                "type": "MyComponent",
-              },
-            ],
+          "ui": {
+            "arrayState": {},
+            "componentList": {},
+            "itemSelector": null,
+            "leftSideBarVisible": false,
           },
         }
       `);
@@ -134,7 +155,7 @@ describe("use-resolved-data", () => {
 
       const renderedHook = renderHook(() =>
         useResolvedData(
-          data,
+          state,
           {
             ...config,
             root: {},
@@ -168,7 +189,7 @@ describe("use-resolved-data", () => {
 
       const renderedHook = renderHook(() =>
         useResolvedData(
-          data,
+          state,
           {
             ...config,
             components: {

--- a/packages/core/reducer/actions.tsx
+++ b/packages/core/reducer/actions.tsx
@@ -53,7 +53,7 @@ export type SetDataAction = {
 
 export type SetAction = {
   type: "set";
-  state: Partial<AppState>;
+  state: Partial<AppState> | ((previous: AppState) => Partial<AppState>);
 };
 
 export type RegisterZoneAction = {

--- a/packages/core/reducer/index.ts
+++ b/packages/core/reducer/index.ts
@@ -2,7 +2,7 @@ import { Reducer } from "react";
 import { AppState, Config } from "../types/Config";
 import { recordDiff } from "../lib/use-puck-history";
 import { reduceData } from "./data";
-import { PuckAction } from "./actions";
+import { PuckAction, SetAction } from "./actions";
 import { reduceUi } from "./state";
 
 export * from "./actions";
@@ -36,6 +36,17 @@ const storeInterceptor = (reducer: StateReducer) => {
   };
 };
 
+export const setAction = (state: AppState, action: SetAction) => {
+  if (typeof action.state === "object") {
+    return {
+      ...state,
+      ...action.state,
+    };
+  }
+
+  return { ...state, ...action.state(state) };
+};
+
 export const createReducer = ({
   config,
 }: {
@@ -46,7 +57,7 @@ export const createReducer = ({
     const ui = reduceUi(state.ui, action);
 
     if (action.type === "set") {
-      return { ...state, ...action.state };
+      return setAction(state, action);
     }
 
     return { data, ui };

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -213,7 +213,6 @@ export type Data<
 export type ItemWithId = {
   _arrayId: string;
   _originalIndex: number;
-  data: any;
 };
 
 export type ArrayState = { items: ItemWithId[]; openId: string };


### PR DESCRIPTION
This PR makes various changes in order to ensure that ArrayField ordering behaviour is more predictable, respecting undo/redo history.

Changes:

* Introduces a new `id` prop to all fields. This is exposed to the `custom` field type.
* Uses the new `id` prop to deterministically set the ids within the array field, making SSR rendering possible
* Significantly refactors the array field, dispatching changes to the UI state (which contains array field ordering information) at the same time the actual value is updated via changes to the `onChange` method. This keeps the array field changes completely in sync with the value changes, which makes undo/redo recording seamless. I suspect this should make #160 possible again.
* Exposes a second, optional  `ui` prop to the `onChange` method for custom fields, enabling custom fields to change the UI at the same time they set the field value.
* Other refactors to the array field, to make it behave more consistently across both the core editor and docs