### PR TITLE
Add object fields

### DIFF
--- a/apps/demo/app/[...puckPath]/client.tsx
+++ b/apps/demo/app/[...puckPath]/client.tsx
@@ -14,7 +14,7 @@ const isBrowser = typeof window !== "undefined";
 export function Client({ path, isEdit }: { path: string; isEdit: boolean }) {
   // unique b64 key that updates each time we add / remove components
   const componentKey = Buffer.from(
-    Object.keys(config.components).join("-")
+    `${Object.keys(config.components).join("-")}-${JSON.stringify(initialData)}`
   ).toString("base64");
 
   const key = `puck-demo:${componentKey}:${path}`;

--- a/apps/demo/config/blocks/Hero/index.tsx
+++ b/apps/demo/config/blocks/Hero/index.tsx
@@ -15,8 +15,10 @@ export type HeroProps = {
   description: string;
   align?: string;
   padding: string;
-  imageMode?: "inline" | "background";
-  imageUrl?: string;
+  image?: {
+    mode?: "inline" | "background";
+    url?: string;
+  };
   buttons: {
     label: string;
     href: string;
@@ -65,13 +67,18 @@ export const Hero: ComponentConfig<HeroProps> = {
         { label: "center", value: "center" },
       ],
     },
-    imageUrl: { type: "text" },
-    imageMode: {
-      type: "radio",
-      options: [
-        { label: "inline", value: "inline" },
-        { label: "background", value: "background" },
-      ],
+    image: {
+      type: "object",
+      objectFields: {
+        url: { type: "text" },
+        mode: {
+          type: "radio",
+          options: [
+            { label: "inline", value: "inline" },
+            { label: "background", value: "background" },
+          ],
+        },
+      },
     },
     padding: { type: "text" },
   },
@@ -111,15 +118,7 @@ export const Hero: ComponentConfig<HeroProps> = {
       readOnly: { title: true, description: true },
     };
   },
-  render: ({
-    align,
-    title,
-    description,
-    buttons,
-    padding,
-    imageUrl,
-    imageMode,
-  }) => {
+  render: ({ align, title, description, buttons, padding, image }) => {
     // Empty state allows us to test that components support hooks
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [_] = useState(0);
@@ -130,15 +129,15 @@ export const Hero: ComponentConfig<HeroProps> = {
         className={getClassName({
           left: align === "left",
           center: align === "center",
-          hasImageBackground: imageMode === "background",
+          hasImageBackground: image?.mode === "background",
         })}
       >
-        {imageMode === "background" && (
+        {image?.mode === "background" && (
           <>
             <div
               className={getClassName("image")}
               style={{
-                backgroundImage: `url("${imageUrl}")`,
+                backgroundImage: `url("${image?.url}")`,
               }}
             ></div>
 
@@ -164,10 +163,10 @@ export const Hero: ComponentConfig<HeroProps> = {
             </div>
           </div>
 
-          {align !== "center" && imageMode !== "background" && imageUrl && (
+          {align !== "center" && image?.mode !== "background" && image?.url && (
             <div
               style={{
-                backgroundImage: `url('${imageUrl}')`,
+                backgroundImage: `url('${image?.url}')`,
                 backgroundSize: "cover",
                 backgroundRepeat: "no-repeat",
                 backgroundPosition: "center",

--- a/apps/demo/config/index.tsx
+++ b/apps/demo/config/index.tsx
@@ -74,9 +74,10 @@ export const initialData: Record<string, Data> = {
           ],
           id: "Hero-1687283596554",
           height: "",
-          imageUrl:
-            "https://images.unsplash.com/photo-1687204209659-3bded6aecd79?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2670&q=80",
-          imageMode: "inline",
+          image: {
+            url: "https://images.unsplash.com/photo-1687204209659-3bded6aecd79?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2670&q=80",
+            mode: "inline",
+          },
           padding: "128px",
           align: "left",
         },

--- a/apps/docs/pages/docs/api-reference/configuration/fields.mdx
+++ b/apps/docs/pages/docs/api-reference/configuration/fields.mdx
@@ -7,6 +7,7 @@ A field represents a user input shown in the Puck interface.
 - [Custom](fields/custom) - Implement a field with a custom UI.
 - [External](fields/external) - Select data from a list, typically populated via a third-party API.
 - [Number](fields/number) - Render a `number` input.
+- [Object](fields/object) - Render a subset of fields.
 - [Radio](fields/radio) - Render a `radio` input with a list of options.
 - [Select](fields/select) - Render a `select` input with a list of options.
 - [Text](fields/text) - Render a `text` input.

--- a/apps/docs/pages/docs/api-reference/configuration/fields/object.mdx
+++ b/apps/docs/pages/docs/api-reference/configuration/fields/object.mdx
@@ -1,0 +1,98 @@
+import { ConfigPreview } from "@/docs/components/Preview";
+
+# Object
+
+Render an object with a subset of fields. Extends [Base](base).
+
+<ConfigPreview
+  label="Example"
+  componentConfig={{
+    fields: {
+      params: {
+        type: "object",
+        objectFields: {
+          title: { type: "text" },
+        },
+      },
+    },
+    defaultProps: { params: { title: "Hello, world" } },
+    render: ({ params }) => {
+      return <p>{params.title}</p>;
+    },
+  }}
+/>
+
+```tsx {5-10} copy
+const config = {
+  components: {
+    Example: {
+      fields: {
+        params: {
+          type: "object",
+          objectFields: {
+            title: { type: "text" },
+          },
+        },
+      },
+      render: ({ params }) => {
+        return <p>{params.title}</p>;
+      },
+    },
+  },
+};
+```
+
+## Params
+
+| Param                           | Example                                     | Type    | Status   |
+| ------------------------------- | ------------------------------------------- | ------- | -------- |
+| [`type`](#type)                 | `type: "array"`                             | "array" | Required |
+| [`objectFields`](#objectfields) | `objectFields: { title: { type: "text" } }` | Object  | Required |
+
+## Required params
+
+### `type`
+
+The type of the field. Must be `"object"` for Object fields.
+
+```tsx {6} copy
+const config = {
+  components: {
+    Example: {
+      fields: {
+        items: {
+          type: "object",
+          objectFields: {
+            title: { type: "text" },
+          },
+        },
+      },
+      // ...
+    },
+  },
+};
+```
+
+### `objectFields`
+
+Describe the fields for the object. Shares an API with `fields`.
+
+Can include any field type, including nested object fields.
+
+```tsx {7-9} copy
+const config = {
+  components: {
+    Example: {
+      fields: {
+        items: {
+          type: "array",
+          objectFields: {
+            title: { type: "text" },
+          },
+        },
+      },
+      // ...
+    },
+  },
+};
+```

--- a/packages/core/components/InputOrGroup/fields/ObjectField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/ObjectField/index.tsx
@@ -1,0 +1,70 @@
+import getClassNameFactory from "../../../../lib/get-class-name-factory";
+import styles from "./styles.module.css";
+import { MoreVertical } from "react-feather";
+import { FieldLabelInternal, InputOrGroup, type InputProps } from "../..";
+
+const getClassName = getClassNameFactory("ObjectField", styles);
+const getClassNameItem = getClassNameFactory("ObjectFieldItem", styles);
+
+export const ObjectField = ({
+  field,
+  onChange,
+  value,
+  name,
+  label,
+  readOnly,
+  readOnlyFields = {},
+  id,
+}: InputProps) => {
+  if (field.type !== "object" || !field.objectFields) {
+    return null;
+  }
+
+  const data = value || {};
+
+  return (
+    <FieldLabelInternal
+      label={label || name}
+      icon={<MoreVertical size={16} />}
+      el="div"
+      readOnly={readOnly}
+    >
+      <div className={getClassName()}>
+        <fieldset className={getClassName("fieldset")}>
+          {Object.keys(field.objectFields!).map((fieldName) => {
+            const subField = field.objectFields![fieldName];
+
+            const subFieldName = `${name}.${fieldName}`;
+            const wildcardFieldName = `${name}.${fieldName}`;
+
+            return (
+              <InputOrGroup
+                key={subFieldName}
+                name={subFieldName}
+                label={subField.label || fieldName}
+                id={`${id}_${fieldName}`}
+                readOnly={
+                  typeof readOnlyFields[subFieldName] !== "undefined"
+                    ? readOnlyFields[subFieldName]
+                    : readOnlyFields[wildcardFieldName]
+                }
+                readOnlyFields={readOnlyFields}
+                field={subField}
+                value={data[fieldName]}
+                onChange={(val, ui) => {
+                  onChange(
+                    {
+                      ...data,
+                      [fieldName]: val,
+                    },
+                    ui
+                  );
+                }}
+              />
+            );
+          })}
+        </fieldset>
+      </div>
+    </FieldLabelInternal>
+  );
+};

--- a/packages/core/components/InputOrGroup/fields/ObjectField/styles.module.css
+++ b/packages/core/components/InputOrGroup/fields/ObjectField/styles.module.css
@@ -1,0 +1,17 @@
+/**
+ * ObjectField
+ */
+
+.ObjectField {
+  display: flex;
+  flex-direction: column;
+  background-color: white;
+  border: 1px solid var(--puck-color-grey-8);
+  border-radius: 4px;
+}
+
+.ObjectField-fieldset {
+  border: none;
+  margin: 0;
+  padding: 16px 15px;
+}

--- a/packages/core/components/InputOrGroup/fields/RadioField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/RadioField/index.tsx
@@ -12,6 +12,7 @@ export const RadioField = ({
   value,
   name,
   id,
+  label,
 }: InputProps) => {
   if (field.type !== "radio" || !field.options) {
     return null;
@@ -20,7 +21,7 @@ export const RadioField = ({
   return (
     <FieldLabelInternal
       icon={<CheckCircle size={16} />}
-      label={field.label || name}
+      label={label || name}
       readOnly={readOnly}
       el="div"
     >

--- a/packages/core/components/InputOrGroup/index.tsx
+++ b/packages/core/components/InputOrGroup/index.tsx
@@ -13,6 +13,7 @@ import {
 } from "./fields";
 import { Lock } from "react-feather";
 import { useDebouncedCallback } from "use-debounce";
+import { ObjectField } from "./fields/ObjectField";
 
 const getClassName = getClassNameFactory("Input", styles);
 
@@ -119,6 +120,10 @@ export const InputOrGroup = ({ onChange, ...props }: InputProps) => {
 
   if (field.type === "external") {
     return <ExternalField {...props} {...localProps} />;
+  }
+
+  if (field.type === "object") {
+    return <ObjectField {...props} {...localProps} />;
   }
 
   if (field.type === "select") {

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -34,6 +34,15 @@ export type ArrayField<
   getItemSummary?: (item: Props[0], index?: number) => string;
 };
 
+export type ObjectField<
+  Props extends { [key: string]: any } = { [key: string]: any }
+> = BaseField & {
+  type: "object";
+  objectFields: {
+    [SubPropName in keyof Props[0]]: Field<Props[0][SubPropName]>;
+  };
+};
+
 // DEPRECATED
 export type Adaptor<
   AdaptorParams = {},
@@ -85,6 +94,7 @@ export type Field<
   | TextField
   | SelectField
   | ArrayField<Props>
+  | ObjectField<Props>
   | ExternalField<Props>
   | ExternalFieldWithAdaptor<Props>
   | CustomField;


### PR DESCRIPTION
This has come up numerous times (#60, #79, #226).

Whilst I still consider Fieldsets/Tabs (#64) and dot-notation (#142) good ways to solve for this, adding the `object` field type is much a lower effort way of supporting most of these use cases. These two APIs can also exist in parallel.

Closes #79.