### PR TITLE
Add search to external fields

### DIFF
--- a/apps/demo/config/blocks/Hero/index.tsx
+++ b/apps/demo/config/blocks/Hero/index.tsx
@@ -30,12 +30,31 @@ export const Hero: ComponentConfig<HeroProps> = {
     quote: {
       type: "external",
       placeholder: "Select a quote",
-      fetchList: async () =>
-        quotes.map((quote, idx) => ({
-          index: idx,
-          title: quote.author,
-          description: quote.content,
-        })),
+      showSearch: true,
+      fetchList: async ({ query }) => {
+        // Simulate delay
+        await new Promise((res) => setTimeout(res, 500));
+
+        return quotes
+          .map((quote, idx) => ({
+            index: idx,
+            title: quote.author,
+            description: quote.content,
+          }))
+          .filter((item) => {
+            if (!query) return item;
+
+            const queryLowercase = query.toLowerCase();
+
+            if (item.title.toLowerCase().indexOf(queryLowercase) > -1) {
+              return item;
+            }
+
+            if (item.description.toLowerCase().indexOf(queryLowercase) > -1) {
+              return item;
+            }
+          });
+      },
       mapProp: (result) => {
         return { index: result.index, label: result.description };
       },

--- a/apps/docs/pages/docs/api-reference/configuration/fields/external.mdx
+++ b/apps/docs/pages/docs/api-reference/configuration/fields/external.mdx
@@ -146,30 +146,29 @@ const config = {
 <ConfigPreview
   label="Example"
   componentConfig={{
-      fields: {
-        data: {
-          type: "external",
-          fetchList: async () => {
-            return [
-              { title: "Hello, world", description: "Lorem ipsum 1" },
-              { title: "Goodbye, world", description: "Lorem ipsum 2" },
-            ];
-          },
-          getItemSummary: (item) => item.title,
+    fields: {
+      data: {
+        type: "external",
+        fetchList: async () => {
+          return [
+            { title: "Hello, world", description: "Lorem ipsum 1" },
+            { title: "Goodbye, world", description: "Lorem ipsum 2" },
+          ];
         },
+        getItemSummary: (item) => item.title,
       },
-      defaultProps: {
-        data: {
-          title: 'Hello, world',
-          description: 'Lorem ipsum 1'
-        }
+    },
+    defaultProps: {
+      data: {
+        title: "Hello, world",
+        description: "Lorem ipsum 1",
       },
-      render: ({ data }) => {
-        return <p>{data?.title || "No data selected"}</p>;
-      },
-      // ...
-    }}
-
+    },
+    render: ({ data }) => {
+      return <p>{data?.title || "No data selected"}</p>;
+    },
+    // ...
+  }}
 />
 
 ### `mapProp(item)`
@@ -204,24 +203,23 @@ const config = {
 <ConfigPreview
   label="Example"
   componentConfig={{
-      fields: {
-        data: {
-          type: "external",
-          fetchList: async () => {
-            return [
-              { title: "Hello, world", description: "Lorem ipsum 1" },
-              { title: "Goodbye, world", description: "Lorem ipsum 2" },
-            ];
-          },
-          mapProp: (item) => item.description,
+    fields: {
+      data: {
+        type: "external",
+        fetchList: async () => {
+          return [
+            { title: "Hello, world", description: "Lorem ipsum 1" },
+            { title: "Goodbye, world", description: "Lorem ipsum 2" },
+          ];
         },
+        mapProp: (item) => item.description,
       },
-      render: ({ data }) => {
-        return <p>{data || "No data selected"}</p>;
-      },
-      // ...
-    }}
-
+    },
+    render: ({ data }) => {
+      return <p>{data || "No data selected"}</p>;
+    },
+    // ...
+  }}
 />
 
 ### `placeholder`
@@ -253,24 +251,31 @@ const config = {
 <ConfigPreview
   label="Example"
   componentConfig={{
-      fields: {
-        data: {
-          type: "external",
-          fetchList: async () => {
-            return [
-              { title: "Apple", description: "An apple is a round, edible fruit produced by an apple tree." },
-              { title: "Orange", description: "An orange is a fruit of various citrus species in the family Rutaceae." },
-            ];
-          },
-          placeholder: "Pick your favorite fruit",
+    fields: {
+      data: {
+        type: "external",
+        fetchList: async () => {
+          return [
+            {
+              title: "Apple",
+              description:
+                "An apple is a round, edible fruit produced by an apple tree.",
+            },
+            {
+              title: "Orange",
+              description:
+                "An orange is a fruit of various citrus species in the family Rutaceae.",
+            },
+          ];
         },
+        placeholder: "Pick your favorite fruit",
       },
-      render: ({ data }) => {
-        return <p>{data?.title || "No data selected"}</p>;
-      },
-      // ...
-    }}
-
+    },
+    render: ({ data }) => {
+      return <p>{data?.title || "No data selected"}</p>;
+    },
+    // ...
+  }}
 />
 
 <div id="puck-portal-root" />

--- a/apps/docs/pages/docs/api-reference/configuration/fields/external.mdx
+++ b/apps/docs/pages/docs/api-reference/configuration/fields/external.mdx
@@ -58,6 +58,8 @@ const config = {
 | [`getItemSummary()`](#getitemsummaryitem) | `getItemSummary: async ({ title }) => title` | Function   | -        |
 | [`mapProp()`](#mappropitem)               | `mapProp: async ({ title }) => title`        | Function   | -        |
 | [`placeholder`](#placeholder)             | `placeholder: "Select content"`              | String     | -        |
+| [`showSearch`](#showsearch)               | `showSearch: true`                           | Boolean    | -        |
+| [`initialQuery`](#initialquery)           | `initialQuery: "Hello, world"`               | String     | -        |
 
 ## Required params
 
@@ -276,6 +278,150 @@ const config = {
     },
     // ...
   }}
+/>
+
+### `showSearch`
+
+Show a search input, the value of which will be passed to `fetchList` as the `query` param.
+
+```tsx {15} copy
+const config = {
+  components: {
+    Example: {
+      fields: {
+        data: {
+          type: "external",
+          fetchList: async ({ params }) => {
+            return [
+              { title: "Apple", description: "Lorem ipsum 1" },
+              { title: "Orange", description: "Lorem ipsum 2" },
+            ].filter((item) => {
+              // ...
+            });
+          },
+          showSearch: true,
+        },
+      },
+      // ...
+    },
+  },
+};
+```
+
+<ConfigPreview
+  label="Example"
+  componentConfig={{
+    fields: {
+      data: {
+        type: "external",
+        fetchList: async ({ query }) => {
+          return [
+            {
+              title: "Apple",
+              description:
+                "An apple is a round, edible fruit produced by an apple tree.",
+            },
+            {
+              title: "Orange",
+              description:
+                "An orange is a fruit of various citrus species in the family Rutaceae.",
+            },
+          ].filter((item) => {
+            if (!query) return item;
+
+            const queryLowercase = query.toLowerCase();
+
+            if (item.title.toLowerCase().indexOf(queryLowercase) > -1) {
+              return item;
+            }
+
+            if (item.description.toLowerCase().indexOf(queryLowercase) > -1) {
+              return item;
+            }
+          })
+        },
+        showSearch: true,
+      },
+    },
+    render: ({ data }) => {
+      return <p>{data?.title || "No data selected"}</p>;
+    },
+    // ...
+
+}}
+/>
+
+### `initialQuery`
+
+Set an initial query when using showing a search input with [`showSearch`](#showsearch).
+
+```tsx {16} copy
+const config = {
+  components: {
+    Example: {
+      fields: {
+        data: {
+          type: "external",
+          fetchList: async ({ params }) => {
+            return [
+              { title: "Apple", description: "Lorem ipsum 1" },
+              { title: "Orange", description: "Lorem ipsum 2" },
+            ].filter((item) => {
+              // ...
+            });
+          },
+          showSearch: true,
+          initialQuery: "Apple",
+        },
+      },
+      // ...
+    },
+  },
+};
+```
+
+<ConfigPreview
+  label="Example"
+  componentConfig={{
+    fields: {
+      data: {
+        type: "external",
+        fetchList: async ({ query }) => {
+          return [
+            {
+              title: "Apple",
+              description:
+                "An apple is a round, edible fruit produced by an apple tree.",
+            },
+            {
+              title: "Orange",
+              description:
+                "An orange is a fruit of various citrus species in the family Rutaceae.",
+            },
+          ].filter((item) => {
+            if (!query) return item;
+
+            const queryLowercase = query.toLowerCase();
+
+            if (item.title.toLowerCase().indexOf(queryLowercase) > -1) {
+              return item;
+            }
+
+            if (item.description.toLowerCase().indexOf(queryLowercase) > -1) {
+              return item;
+            }
+          })
+        },
+        showSearch: true,
+        initialQuery: 'apple'
+      },
+    },
+    render: ({ data }) => {
+      return <p>{data?.title || "No data selected"}</p>;
+    },
+    // ...
+
+}}
 />
 
 <div id="puck-portal-root" />

--- a/apps/docs/pages/docs/integrating-puck/external-data-sources.mdx
+++ b/apps/docs/pages/docs/integrating-puck/external-data-sources.mdx
@@ -79,6 +79,8 @@ const config = {
 };
 ```
 
+You can also use the [`showSearch` parameter](/docs/api-reference/configuration/fields/external#showsearch) to show a search input to the user.
+
 ## Data syncing
 
 To keep the data in sync with the external source, we can combine the `external` field with the [`resolveData`](/docs/api-reference/configuration/component-config#resolvedatadata-params) function.

--- a/packages/core/components/Button/Button.tsx
+++ b/packages/core/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import styles from "./Button.module.css";
 import getClassNameFactory from "../../lib/get-class-name-factory";
 import { ClipLoader } from "react-spinners";
@@ -17,6 +17,7 @@ export const Button = ({
   fullWidth,
   icon,
   size = "medium",
+  loading: loadingProp = false,
 }: {
   children: ReactNode;
   href?: string;
@@ -29,8 +30,11 @@ export const Button = ({
   fullWidth?: boolean;
   icon?: ReactNode;
   size?: "medium" | "large";
+  loading?: boolean;
 }) => {
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(loadingProp);
+
+  useEffect(() => setLoading(loadingProp), [loadingProp]);
 
   const ElementType = href ? "a" : "button";
 

--- a/packages/core/components/ExternalInput/styles.module.css
+++ b/packages/core/components/ExternalInput/styles.module.css
@@ -54,6 +54,7 @@
 }
 
 .ExternalInputModal {
+  color: black;
   display: flex;
   flex-direction: column;
   position: relative;
@@ -216,7 +217,6 @@
   border: none;
   border-radius: 4px;
   background: white;
-  color: black;
   font-family: inherit;
   font-size: 14px;
   padding: 12px 15px;

--- a/packages/core/components/ExternalInput/styles.module.css
+++ b/packages/core/components/ExternalInput/styles.module.css
@@ -62,10 +62,14 @@
 
 .ExternalInputModal-masthead {
   background-color: white;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
   padding: 32px 24px;
 }
 
 .ExternalInputModal-tableWrapper {
+  position: relative;
   overflow-x: auto;
   overflow-y: auto;
   flex-grow: 1;
@@ -136,10 +140,15 @@
 
 .ExternalInputModal-loadingBanner {
   display: none;
-  background-color: white;
+  background-color: #ffffff90;
   padding: 64px;
   align-items: center;
   justify-content: center;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
 }
 
 .ExternalInputModal--isLoading .ExternalInputModal-loadingBanner {
@@ -148,10 +157,74 @@
 
 .ExternalInputModal-noContentBanner {
   display: none;
+  border-top: 1px solid var(--puck-color-grey-8);
+  padding: 24px;
+  text-align: center;
 }
 
 .ExternalInputModal--loaded:not(.ExternalInputModal--hasData)
   .ExternalInputModal-noContentBanner {
   display: block;
-  padding: 24px;
+}
+
+.ExternalInputModal-searchForm {
+  display: flex;
+  margin-left: auto;
+  height: 43px;
+  gap: 12px;
+}
+
+.ExternalInputModal-search {
+  display: flex;
+  background: white;
+  border-width: 1px;
+  border-style: solid;
+  border-color: var(--puck-color-grey-8);
+  border-radius: 4px;
+  width: 100%;
+}
+
+.ExternalInputModal-search:focus-within {
+  border-color: var(--puck-color-azure-4);
+  outline: var(--puck-color-azure-8) 4px solid;
+  outline-offset: 0;
+}
+
+.ExternalInputModal-searchIcon {
+  align-items: center;
+  background: var(--puck-color-grey-11);
+  border-bottom-left-radius: 4px;
+  border-top-left-radius: 4px;
+  border-right: 1px solid var(--puck-color-grey-8);
+  color: var(--puck-color-grey-6);
+  display: flex;
+  justify-content: center;
+  padding: 12px 15px;
+}
+
+.ExternalInputModal-searchIconText {
+  clip: rect(0 0 0 0);
+  clip-path: inset(100%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.ExternalInputModal-searchInput {
+  border: none;
+  border-radius: 4px;
+  background: white;
+  color: black;
+  font-family: inherit;
+  font-size: 14px;
+  padding: 12px 15px;
+  width: 100%;
+}
+
+.ExternalInputModal-searchInput:focus {
+  border: none;
+  outline: none;
+  box-shadow: none;
 }

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -61,9 +61,11 @@ export type ExternalField<
 > = BaseField & {
   type: "external";
   placeholder?: string;
-  fetchList: () => Promise<any[] | null>;
+  fetchList: (params: { query: string }) => Promise<any[] | null>;
   mapProp?: (value: any) => Props;
   getItemSummary: (item: Props, index?: number) => string;
+  showSearch?: boolean;
+  initialQuery?: string;
 };
 
 export type CustomField<


### PR DESCRIPTION
This PR adds a search input to external fields with the new `showSearch` and `initialQuery` APIs added to the external field type.

https://github.com/measuredco/puck/assets/985961/53b6a864-b09d-4faa-a4cc-745b1f936d69

It is a partial implementation of #203. I chose to leave out pagination (due to complexity) and filtering (unclear how common a use-case this would be) for the time-being. We can track those in new tickets.

Closes #203
