### PR TITLE
fix: fix initial UI state on mobile

### DIFF
--- a/packages/core/lib/use-resolved-data.ts
+++ b/packages/core/lib/use-resolved-data.ts
@@ -1,10 +1,4 @@
-import {
-  AppState,
-  ComponentData,
-  Config,
-  Data,
-  RootData,
-} from "../types/Config";
+import { AppState, ComponentData, Config, RootData } from "../types/Config";
 import { Dispatch, useCallback, useEffect, useState } from "react";
 import { PuckAction } from "../reducer";
 import { resolveComponentData } from "./resolve-component-data";
@@ -77,7 +71,7 @@ export const useResolvedData = (
           state: (prev) => ({
             ...prev,
             data: applyDynamicProps(prev.data, dynamicDataMap, dynamicRoot),
-            ui: { ...prev.ui, ...newAppState.ui },
+            ui: resolverKey > 0 ? { ...prev.ui, ...newAppState.ui } : prev.ui,
           }),
           recordHistory: resolverKey > 0,
         });


### PR DESCRIPTION
A race condition with the data resolvers meant that the UI state was being reset after the sidebars were collapsed. This is fixed by avoiding UI state updates on the initial resolveData call.