### PR TITLE
🐛 FIX(Recipes/Remix): explicit exports to fix paths links/metas

### DIFF
--- a/recipes/remix/app/getPuckPath.ts
+++ b/recipes/remix/app/getPuckPath.ts
@@ -1,0 +1,17 @@
+// puck is behaving weirdly between loaders/actions, so this is a workaround assuers that the path is always correct
+export function getPuckPath({
+  params,
+  request,
+}: {
+  params: any;
+  request: Request;
+}) {
+  let referer = request.headers.get("referer") || "http://localhost:3000";
+  let puckPath =
+    params.puckPath || new URL(referer).pathname.replace("/edit", "");
+
+  // Get path, and default to slash for root path.
+  if (!puckPath) puckPath = "/";
+
+  return puckPath;
+}

--- a/recipes/remix/app/routes/$puckPath.tsx
+++ b/recipes/remix/app/routes/$puckPath.tsx
@@ -1,2 +1,2 @@
 export { default } from "./_index";
-export * from "./_index";
+export { loader, meta } from "./_index";

--- a/recipes/remix/app/routes/$puckPath_.edit.tsx
+++ b/recipes/remix/app/routes/$puckPath_.edit.tsx
@@ -1,5 +1,2 @@
 export { default } from "./edit";
-// I think a bug in remix means loader needs to be explicitly exported here
-export { action, loader } from "./edit";
-// For meta and links etc.
-export * from "./edit";
+export { action, loader, links, meta } from "./edit";

--- a/recipes/remix/app/routes/_index.tsx
+++ b/recipes/remix/app/routes/_index.tsx
@@ -5,10 +5,10 @@ import { useLoaderData } from "@remix-run/react";
 
 import puckConfig from "../../puck.config";
 import { getPage } from "~/models/page.server";
+import { getPuckPath } from "~/getPuckPath";
 
-export const loader = async ({ params }: LoaderFunctionArgs) => {
-  // Get path, and default to slash for root path.
-  const puckPath = params.puckPath || "/";
+export const loader = async (args: LoaderFunctionArgs) => {
+  const puckPath = getPuckPath(args);
   // Get puckData for this path, this could be a database call.
   const puckData = getPage(puckPath);
   if (!puckData) {

--- a/recipes/remix/app/routes/edit.tsx
+++ b/recipes/remix/app/routes/edit.tsx
@@ -12,10 +12,11 @@ import invariant from "tiny-invariant";
 
 import puckConfig from "../../puck.config";
 import { getPage, setPage } from "~/models/page.server";
+import { getPuckPath } from "~/getPuckPath";
 
-export const action = async ({ params, request }: ActionFunctionArgs) => {
-  const puckPath = params.puckPath || "/";
-  const formData = await request.formData();
+export const action = async (args: ActionFunctionArgs) => {
+  const puckPath = getPuckPath(args);
+  const formData = await args.request.formData();
   const puckData = formData.get("puckData");
 
   invariant(puckData, "Missing data");
@@ -30,8 +31,8 @@ export const links: LinksFunction = () => [
   { rel: "stylesheet", href: styles, id: "puck-css" },
 ];
 
-export const loader = async ({ params }: LoaderFunctionArgs) => {
-  const puckPath = params.puckPath || "/";
+export const loader = async (args: LoaderFunctionArgs) => {
+  const puckPath = getPuckPath(args);
   const initialData = getPage(puckPath) || {
     content: [],
     root: {},


### PR DESCRIPTION
This PR assures that the routing catch is working
I noticed a bug in previous implementations ( using ```export * from ``` ) where remix was not able to detect the functions in all $puckPaths  so I just exported them explicitly and tested all sites and they are working by this PR