### PR TITLE
Migrate to Lucide icons

### DIFF
--- a/apps/demo/app/custom-ui/[...puckPath]/client.tsx
+++ b/apps/demo/app/custom-ui/[...puckPath]/client.tsx
@@ -10,7 +10,7 @@ import { useDemoData } from "../../../lib/use-demo-data";
 import { IconButton, usePuck } from "@/core";
 import { ReactNode, useEffect, useRef, useState } from "react";
 import { Drawer } from "@/core/components/Drawer";
-import { ChevronUp, ChevronDown, Globe } from "react-feather";
+import { ChevronUp, ChevronDown, Globe } from "lucide-react";
 
 const CustomHeader = ({ onPublish }: { onPublish: (data: Data) => void }) => {
   const { appState, dispatch } = usePuck();

--- a/apps/demo/config/blocks/Card/index.tsx
+++ b/apps/demo/config/blocks/Card/index.tsx
@@ -3,24 +3,21 @@ import React from "react";
 import { ComponentConfig } from "@/core/types/Config";
 import styles from "./styles.module.css";
 import { getClassNameFactory } from "@/core/lib";
-import * as reactFeather from "react-feather";
+import dynamic from "next/dynamic";
+import dynamicIconImports from "lucide-react/dynamicIconImports";
 
 const getClassName = getClassNameFactory("Card", styles);
 
-const icons = Object.keys(reactFeather).reduce((acc, iconName) => {
-  if (typeof reactFeather[iconName] === "object") {
-    const El = reactFeather[iconName];
+const icons = Object.keys(dynamicIconImports).reduce((acc, iconName) => {
+  const El = dynamic(dynamicIconImports[iconName]);
 
-    return {
-      ...acc,
-      [iconName]: <El />,
-    };
-  }
-
-  return acc;
+  return {
+    ...acc,
+    [iconName]: <El />,
+  };
 }, {});
 
-const iconOptions = Object.keys(reactFeather).map((iconName) => ({
+const iconOptions = Object.keys(dynamicIconImports).map((iconName) => ({
   label: iconName,
   value: iconName,
 }));

--- a/apps/demo/config/blocks/FeatureList/index.tsx
+++ b/apps/demo/config/blocks/FeatureList/index.tsx
@@ -4,24 +4,21 @@ import { ComponentConfig } from "@/core";
 import styles from "./styles.module.css";
 import { getClassNameFactory } from "@/core/lib";
 import { Section } from "../../components/Section";
-import * as reactFeather from "react-feather";
+import dynamic from "next/dynamic";
+import dynamicIconImports from "lucide-react/dynamicIconImports";
 
 const getClassName = getClassNameFactory("FeatureList", styles);
 
-const icons = Object.keys(reactFeather).reduce((acc, iconName) => {
-  if (typeof reactFeather[iconName] === "object") {
-    const El = reactFeather[iconName];
+const icons = Object.keys(dynamicIconImports).reduce((acc, iconName) => {
+  const El = dynamic(dynamicIconImports[iconName]);
 
-    return {
-      ...acc,
-      [iconName]: <El />,
-    };
-  }
-
-  return acc;
+  return {
+    ...acc,
+    [iconName]: <El />,
+  };
 }, {});
 
-const iconOptions = Object.keys(reactFeather).map((iconName) => ({
+const iconOptions = Object.keys(dynamicIconImports).map((iconName) => ({
   label: iconName,
   value: iconName,
 }));
@@ -30,7 +27,7 @@ export type FeatureListProps = {
   items: {
     title: string;
     description: string;
-    icon?: "Feather";
+    icon?: "feather";
   }[];
   mode: "flat" | "card";
 };
@@ -43,7 +40,7 @@ export const FeatureList: ComponentConfig<FeatureListProps> = {
       defaultItemProps: {
         title: "Title",
         description: "Description",
-        icon: "Feather",
+        icon: "feather",
       },
       arrayFields: {
         title: { type: "text" },
@@ -67,7 +64,7 @@ export const FeatureList: ComponentConfig<FeatureListProps> = {
       {
         title: "Feature",
         description: "Description",
-        icon: "Feather",
+        icon: "feather",
       },
     ],
     mode: "flat",

--- a/apps/demo/config/blocks/Stats/index.tsx
+++ b/apps/demo/config/blocks/Stats/index.tsx
@@ -4,24 +4,21 @@ import { ComponentConfig } from "@/core";
 import styles from "./styles.module.css";
 import { getClassNameFactory } from "@/core/lib";
 import { Section } from "../../components/Section";
-import * as reactFeather from "react-feather";
+import dynamic from "next/dynamic";
+import dynamicIconImports from "lucide-react/dynamicIconImports";
 
 const getClassName = getClassNameFactory("Stats", styles);
 
-const icons = Object.keys(reactFeather).reduce((acc, iconName) => {
-  if (typeof reactFeather[iconName] === "object") {
-    const El = reactFeather[iconName];
+const icons = Object.keys(dynamicIconImports).reduce((acc, iconName) => {
+  const El = dynamic(dynamicIconImports[iconName]);
 
-    return {
-      ...acc,
-      [iconName]: <El />,
-    };
-  }
-
-  return acc;
+  return {
+    ...acc,
+    [iconName]: <El />,
+  };
 }, {});
 
-const iconOptions = Object.keys(reactFeather).map((iconName) => ({
+const iconOptions = Object.keys(dynamicIconImports).map((iconName) => ({
   label: iconName,
   value: iconName,
 }));

--- a/apps/demo/config/index.tsx
+++ b/apps/demo/config/index.tsx
@@ -173,10 +173,10 @@ export const initialData: Record<string, Data> = {
         type: "Stats",
         props: {
           items: [
-            { title: "Users reached", description: "20M+", icon: "Feather" },
-            { title: "Cost savings", description: "$1.5M", icon: "Feather" },
-            { title: "Another stat", description: "5M kg", icon: "Feather" },
-            { title: "Final fake stat", description: "15K", icon: "Feather" },
+            { title: "Users reached", description: "20M+", icon: "feather" },
+            { title: "Cost savings", description: "$1.5M", icon: "feather" },
+            { title: "Another stat", description: "5M kg", icon: "feather" },
+            { title: "Final fake stat", description: "15K", icon: "feather" },
           ],
           mode: "flat",
           id: "Stats-1687297239724",
@@ -294,7 +294,7 @@ export const initialData: Record<string, Data> = {
             title: "Built for content teams",
             description:
               "Puck enables content teams to make changes to their content without a developer or breaking the UI.",
-            icon: "PenTool",
+            icon: "pen-tool",
             mode: "flat",
             id: "Card-0d9077e00e0ad66c34c62ab6986967e1ce04f9e4",
           },
@@ -307,7 +307,7 @@ export const initialData: Record<string, Data> = {
             title: "Easy to integrate",
             description:
               "Front-end developers can easily integrate their own components using a familiar React API.",
-            icon: "GitMerge",
+            icon: "git-merge",
             mode: "flat",
             id: "Card-978bef5d136d4b0d9855f5272429986ceb22e5a6",
           },
@@ -320,7 +320,7 @@ export const initialData: Record<string, Data> = {
             title: "No vendor lock-in",
             description:
               "Completely open-source, Puck is designed to be integrated into your existing React application.",
-            icon: "GitHub",
+            icon: "github",
             mode: "flat",
             id: "Card-133a61826f0019841aec6f0aec011bf07e6bc6de",
           },
@@ -333,7 +333,7 @@ export const initialData: Record<string, Data> = {
             title: "plugin-heading-analyzer",
             description:
               "Analyze the document structure and identify WCAG 2.1 issues with your heading hierarchy.",
-            icon: "AlignLeft",
+            icon: "align-left",
             mode: "card",
             id: "Card-e2e757b0b4a579d5f87564dfa9b4442f9794b45b",
           },
@@ -346,7 +346,7 @@ export const initialData: Record<string, Data> = {
             title: "External data",
             description:
               "Connect your components with an existing data source, like Strapi.js.",
-            icon: "Feather",
+            icon: "feather",
             mode: "card",
             id: "Card-4eea28543d13c41c30934c3e4c4c95a75017a89c",
           },
@@ -359,7 +359,7 @@ export const initialData: Record<string, Data> = {
             title: "Custom plugins",
             description:
               "Create your own plugin to extend Puck for your use case using React.",
-            icon: "Feather",
+            icon: "feather",
             mode: "card",
             id: "Card-3314e8b24aa52843ce22ab7424b8f3b8064acfdf",
           },
@@ -371,7 +371,7 @@ export const initialData: Record<string, Data> = {
           props: {
             title: "Title",
             description: "Description",
-            icon: "Feather",
+            icon: "feather",
             mode: "card",
             id: "Card-49b11940784cfe8dc1a2b2facc5ac2bcf797792f",
           },
@@ -383,7 +383,7 @@ export const initialData: Record<string, Data> = {
           props: {
             title: "Title",
             description: "Description",
-            icon: "Feather",
+            icon: "feather",
             mode: "card",
             id: "Card-efb0a1ed06cc4152a7861376aafbe62b0445382d",
           },
@@ -395,7 +395,7 @@ export const initialData: Record<string, Data> = {
           props: {
             title: "Title",
             description: "Description",
-            icon: "Feather",
+            icon: "feather",
             mode: "card",
             id: "Card-513cfb17d07ba4b6e0212d931571c0760839f029",
           },

--- a/apps/demo/next.config.js
+++ b/apps/demo/next.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   reactStrictMode: false,
-  transpilePackages: ["@measured/puck"],
+  transpilePackages: ["@measured/puck", "lucide-react"],
 };

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "classnames": "^2.3.2",
+    "lucide-react": "^0.298.0",
     "next": "^13.5.2",
     "rc-footer": "^0.6.8",
     "react": "^18.2.0",

--- a/apps/docs/pages/docs/api-reference/components/field-label.mdx
+++ b/apps/docs/pages/docs/api-reference/components/field-label.mdx
@@ -4,7 +4,7 @@ title: <FieldLabel>
 
 import { ConfigPreview } from "../../../../components/Preview";
 import { FieldLabel } from "@/core/components/InputOrGroup";
-import { Globe } from "react-feather";
+import { Globe } from "lucide-react";
 
 # \<FieldLabel\>
 
@@ -137,11 +137,11 @@ const CustomField = () => (
 
 ### `icon`
 
-Render an icon before the label text. Puck uses [react-feather](https://github.com/feathericons/react-feather) internally.
+Render an icon before the label text. Puck uses [lucide-react](https://lucide.dev/guide/packages/lucide-react) internally.
 
 ```tsx /icon={<Globe size="16" />}/ copy
 import { FieldLabel } from "@measured/puck";
-import { Globe } from "react-feather";
+import { Globe } from "lucide-react";
 
 const CustomField = () => (
   <FieldLabel icon={<Globe size="16" />} label="Title">

--- a/packages/core/components/ComponentList/index.tsx
+++ b/packages/core/components/ComponentList/index.tsx
@@ -2,7 +2,7 @@ import styles from "./styles.module.css";
 import getClassNameFactory from "../../lib/get-class-name-factory";
 import { ReactNode } from "react";
 import { useAppContext } from "../Puck/context";
-import { ChevronDown, ChevronUp } from "react-feather";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import { Drawer } from "../Drawer";
 
 const getClassName = getClassNameFactory("ComponentList", styles);

--- a/packages/core/components/DraggableComponent/index.tsx
+++ b/packages/core/components/DraggableComponent/index.tsx
@@ -2,7 +2,7 @@ import { CSSProperties, ReactNode, SyntheticEvent, useEffect } from "react";
 import { Draggable } from "@hello-pangea/dnd";
 import styles from "./styles.module.css";
 import getClassNameFactory from "../../lib/get-class-name-factory";
-import { Copy, Trash } from "react-feather";
+import { Copy, Trash } from "lucide-react";
 import { useModifierHeld } from "../../lib/use-modifier-held";
 import { ClipLoader } from "react-spinners";
 

--- a/packages/core/components/ExternalInput/index.tsx
+++ b/packages/core/components/ExternalInput/index.tsx
@@ -2,7 +2,7 @@ import { useMemo, useEffect, useState, useCallback } from "react";
 import styles from "./styles.module.css";
 import getClassNameFactory from "../../lib/get-class-name-factory";
 import { ExternalField } from "../../types/Config";
-import { Link, Search, Unlock } from "react-feather";
+import { Link, Search, Unlock } from "lucide-react";
 import { Modal } from "../Modal";
 import { Heading } from "../Heading";
 import { ClipLoader } from "react-spinners";

--- a/packages/core/components/InputOrGroup/fields/ArrayField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/ArrayField/index.tsx
@@ -1,6 +1,6 @@
 import getClassNameFactory from "../../../../lib/get-class-name-factory";
 import styles from "./styles.module.css";
-import { List, Plus, Trash } from "react-feather";
+import { List, Plus, Trash } from "lucide-react";
 import { FieldLabelInternal, InputOrGroup, type InputProps } from "../..";
 import { IconButton } from "../../../IconButton";
 import { reorder, replace } from "../../../../lib";

--- a/packages/core/components/InputOrGroup/fields/DefaultField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/DefaultField/index.tsx
@@ -1,6 +1,6 @@
 import getClassNameFactory from "../../../../lib/get-class-name-factory";
 import styles from "../../styles.module.css";
-import { Hash, Type } from "react-feather";
+import { Hash, Type } from "lucide-react";
 import { FieldLabelInternal, type InputProps } from "../..";
 
 const getClassName = getClassNameFactory("Input", styles);

--- a/packages/core/components/InputOrGroup/fields/ExternalField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/ExternalField/index.tsx
@@ -5,7 +5,7 @@ import {
   ExternalFieldWithAdaptor,
 } from "../../../../types/Config";
 import { ExternalInput } from "../../../ExternalInput";
-import { Link } from "react-feather";
+import { Link } from "lucide-react";
 
 export const ExternalField = ({
   field,

--- a/packages/core/components/InputOrGroup/fields/ObjectField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/ObjectField/index.tsx
@@ -1,6 +1,6 @@
 import getClassNameFactory from "../../../../lib/get-class-name-factory";
 import styles from "./styles.module.css";
-import { MoreVertical } from "react-feather";
+import { MoreVertical } from "lucide-react";
 import { FieldLabelInternal, InputOrGroup, type InputProps } from "../..";
 
 const getClassName = getClassNameFactory("ObjectField", styles);

--- a/packages/core/components/InputOrGroup/fields/RadioField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/RadioField/index.tsx
@@ -1,6 +1,6 @@
 import getClassNameFactory from "../../../../lib/get-class-name-factory";
 import styles from "../../styles.module.css";
-import { CheckCircle } from "react-feather";
+import { CheckCircle } from "lucide-react";
 import { FieldLabelInternal, type InputProps } from "../..";
 
 const getClassName = getClassNameFactory("Input", styles);

--- a/packages/core/components/InputOrGroup/fields/SelectField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/SelectField/index.tsx
@@ -1,6 +1,6 @@
 import getClassNameFactory from "../../../../lib/get-class-name-factory";
 import styles from "../../styles.module.css";
-import { ChevronDown } from "react-feather";
+import { ChevronDown } from "lucide-react";
 import { FieldLabelInternal, type InputProps } from "../..";
 
 const getClassName = getClassNameFactory("Input", styles);

--- a/packages/core/components/InputOrGroup/fields/TextareaField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/TextareaField/index.tsx
@@ -1,6 +1,6 @@
 import getClassNameFactory from "../../../../lib/get-class-name-factory";
 import styles from "../../styles.module.css";
-import { Type } from "react-feather";
+import { Type } from "lucide-react";
 import { FieldLabelInternal, type InputProps } from "../..";
 
 const getClassName = getClassNameFactory("Input", styles);

--- a/packages/core/components/InputOrGroup/index.tsx
+++ b/packages/core/components/InputOrGroup/index.tsx
@@ -18,7 +18,7 @@ import {
   DefaultField,
   TextareaField,
 } from "./fields";
-import { Lock } from "react-feather";
+import { Lock } from "lucide-react";
 import { useDebouncedCallback } from "use-debounce";
 import { ObjectField } from "./fields/ObjectField";
 import { useAppContext } from "../Puck/context";

--- a/packages/core/components/LayerTree/index.tsx
+++ b/packages/core/components/LayerTree/index.tsx
@@ -3,7 +3,7 @@ import getClassNameFactory from "../../lib/get-class-name-factory";
 import { Data } from "../../types/Config";
 import { ItemSelector, getItem } from "../../lib/get-item";
 import { scrollIntoView } from "../../lib/scroll-into-view";
-import { ChevronDown, Grid, Layers, Type } from "react-feather";
+import { ChevronDown, LayoutGrid, Layers, Type } from "lucide-react";
 import { rootDroppableId } from "../../lib/root-droppable-id";
 import { useContext } from "react";
 import { dropZoneContext } from "../DropZone/context";
@@ -125,7 +125,7 @@ export const LayerTree = ({
                       {item.type === "Text" || item.type === "Heading" ? (
                         <Type size="16" />
                       ) : (
-                        <Grid size="16" />
+                        <LayoutGrid size="16" />
                       )}
                     </div>
                     <div className={getClassNameLayer("name")}>{item.type}</div>

--- a/packages/core/components/MenuBar/index.tsx
+++ b/packages/core/components/MenuBar/index.tsx
@@ -1,5 +1,5 @@
 import { Dispatch, ReactElement, SetStateAction } from "react";
-import { Globe, ChevronLeft, ChevronRight } from "react-feather";
+import { Globe, ChevronLeft, ChevronRight } from "lucide-react";
 
 import { Button } from "../Button";
 import { IconButton } from "../IconButton/IconButton";

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -16,7 +16,13 @@ import { Plugin } from "../../types/Plugin";
 import { usePlaceholderStyle } from "../../lib/use-placeholder-style";
 
 import { SidebarSection } from "../SidebarSection";
-import { ChevronDown, ChevronUp, Globe, Sidebar } from "react-feather";
+import {
+  ChevronDown,
+  ChevronUp,
+  Globe,
+  PanelLeft,
+  PanelRight,
+} from "lucide-react";
 import { Heading } from "../Heading";
 import { IconButton } from "../IconButton/IconButton";
 import { DropZoneProvider } from "../DropZone";
@@ -416,7 +422,7 @@ export function Puck({
                               }}
                               title="Toggle left sidebar"
                             >
-                              <Sidebar focusable="false" />
+                              <PanelLeft focusable="false" />
                             </IconButton>
                           </div>
                           <div className={getClassName("rightSideBarToggle")}>
@@ -426,7 +432,7 @@ export function Puck({
                               }}
                               title="Toggle right sidebar"
                             >
-                              <Sidebar focusable="false" />
+                              <PanelRight focusable="false" />
                             </IconButton>
                           </div>
                         </div>

--- a/packages/core/components/Puck/styles.module.css
+++ b/packages/core/components/Puck/styles.module.css
@@ -118,10 +118,6 @@
   padding-top: 2px;
 }
 
-.Puck-rightSideBarToggle {
-  transform: rotate(180deg);
-}
-
 .Puck--rightSideBarVisible .Puck-rightSideBarToggle,
 .Puck--leftSideBarVisible .Puck-leftSideBarToggle {
   color: var(--puck-color-black);

--- a/packages/core/components/SidebarSection/index.tsx
+++ b/packages/core/components/SidebarSection/index.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from "react";
 import styles from "./styles.module.css";
 import getClassNameFactory from "../../lib/get-class-name-factory";
 import { Heading } from "../Heading";
-import { ChevronRight } from "react-feather";
+import { ChevronRight } from "lucide-react";
 import { useBreadcrumbs } from "../../lib/use-breadcrumbs";
 import { useAppContext } from "../Puck/context";
 import { ClipLoader } from "react-spinners";

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,7 @@
     "eslint-config-custom": "*",
     "jest": "^29.6.4",
     "jest-environment-jsdom": "^29.6.4",
-    "react-feather": "^2.0.10",
+    "lucide-react": "^0.298.0",
     "ts-jest": "^29.1.1",
     "tsconfig": "*",
     "tsup": "^6.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8516,6 +8516,11 @@ lru-cache@^7.14.1, lru-cache@^7.4.4, lru-cache@^7.5.1, lru-cache@^7.7.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.1.tgz#0a3be479df549cca0e5d693ac402ff19537a6b7a"
   integrity sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==
 
+lucide-react@^0.298.0:
+  version "0.298.0"
+  resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.298.0.tgz#1f4e5b8d848f339fc105f8eb959ca62467feb08a"
+  integrity sha512-tWoxZ663Zf/n8VxXTHnTJsU/w1ysWT1LORnIL1pzqElFdSqBhWbZeJ3sLdCZ5FpzpbkpkYEtluhuTyG2BTDYNQ==
+
 lz-string@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
@@ -10929,13 +10934,6 @@ react-dom@^18.2.0:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
-
-react-feather@^2.0.10:
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/react-feather/-/react-feather-2.0.10.tgz#0e9abf05a66754f7b7bb71757ac4da7fb6be3b68"
-  integrity sha512-BLhukwJ+Z92Nmdcs+EMw6dy1Z/VLiJTzEQACDUEnWMClhYnFykJCGWQx+NmwP/qQHGX/5CzQ+TGi8ofg2+HzVQ==
-  dependencies:
-    prop-types "^15.7.2"
 
 react-from-json@^0.7.2:
   version "0.7.2"


### PR DESCRIPTION
https://lucide.dev

Actively maintained fork of _Feather_ icons, with a much improved selection of icons! (I am a major contributor).

https://lucide.dev/guide/packages/lucide-react

> Lucide is built with ES Modules, so it's completely tree-shakable.
