### PR TITLE
docs: link to versioned docs on homepage "Read docs" CTA

### DIFF
--- a/apps/docs/components/Home/index.tsx
+++ b/apps/docs/components/Home/index.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import styles from "./styles.module.css";
 import getClassNameFactory from "@/core/lib/get-class-name-factory";
 import { Button } from "@/core/components/Button";
+import Link from "next/link";
 
 const getClassName = getClassNameFactory("Home", styles);
 
@@ -26,7 +27,9 @@ export const Home = () => {
       <div style={{ paddingTop: 32 }} />
       <div className={getClassName("ctas")}>
         <div className={getClassName("actions")}>
-          <Button href="/docs">Read docs</Button>
+          <Link href="/docs" style={{ display: "flex" }}>
+            <Button>Read docs</Button>
+          </Link>
           <Button href="https://demo.puckeditor.com/edit" variant="secondary">
             View demo
           </Button>

--- a/packages/core/components/Button/Button.tsx
+++ b/packages/core/components/Button/Button.tsx
@@ -36,7 +36,7 @@ export const Button = ({
 
   useEffect(() => setLoading(loadingProp), [loadingProp]);
 
-  const ElementType = href ? "a" : "button";
+  const ElementType = href ? "a" : onClick ? "button" : "div";
 
   const el = (
     <ElementType


### PR DESCRIPTION
The Next.js basePath was not getting applied as the `<Button>` component doesn't use Next's `<Link>` component.