### PR TITLE
Now Publish will appears if render action button is not provided.

### DIFF
--- a/packages/core/components/MenuBar/index.tsx
+++ b/packages/core/components/MenuBar/index.tsx
@@ -29,6 +29,7 @@ export const MenuBar = ({
   renderHeaderActions?: (props: {
     state: AppState;
     dispatch: (action: PuckAction) => void;
+    onPublish?: (data: Data) => void;
   }) => ReactElement;
   setMenuOpen: Dispatch<SetStateAction<boolean>>;
 }) => {
@@ -77,22 +78,25 @@ export const MenuBar = ({
           </IconButton>
         </div>
         <>
-          {renderHeaderActions &&
+          {renderHeaderActions ? (
             renderHeaderActions({
               state: appState,
               dispatch,
-            })}
+              onPublish: () => onPublish && onPublish(data),
+            })
+          ) : (
+            <div>
+              <Button
+                onClick={() => {
+                  onPublish && onPublish(data);
+                }}
+                icon={<Globe size="14px" />}
+              >
+                Publish
+              </Button>
+            </div>
+          )}
         </>
-        <div>
-          <Button
-            onClick={() => {
-              onPublish && onPublish(data);
-            }}
-            icon={<Globe size="14px" />}
-          >
-            Publish
-          </Button>
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
      ```
      renderHeaderActions
      ```

Publish button can be handled with renderHeaderAction.

My use case want to rename publish button to export currently there is no option to do that. We can have on prop to change the text of publish button but feel as we currently have a prop to add more button we can handle publish button also by this section.