### PR TITLE
Fix plugin currying

### DIFF
--- a/packages/core/lib/__tests__/load-overrides.spec.tsx
+++ b/packages/core/lib/__tests__/load-overrides.spec.tsx
@@ -49,4 +49,20 @@ describe("load-overrides", () => {
       "0 | 1 | 2 | 3"
     );
   });
+
+  it("should avoid mutating the provided overrides", () => {
+    const overrides = {};
+    const loaded = loadOverrides({
+      overrides,
+      plugins: [
+        {
+          overrides: {
+            fieldTypes: { text: ({ children }) => `${children} | 1` as any },
+          },
+        },
+      ],
+    });
+
+    expect(overrides).toEqual({});
+  });
 });

--- a/packages/core/lib/load-overrides.ts
+++ b/packages/core/lib/load-overrides.ts
@@ -8,7 +8,7 @@ export const loadOverrides = ({
   overrides: Partial<Overrides>;
   plugins: Plugin[];
 }) => {
-  const collected = overrides;
+  const collected = { ...overrides };
 
   plugins.forEach((plugin) => {
     Object.keys(plugin.overrides).forEach((overridesType) => {

--- a/packages/plugin-heading-analyzer/README.md
+++ b/packages/plugin-heading-analyzer/README.md
@@ -13,6 +13,7 @@ npm i @measured/puck-plugin-heading-analyzer
 ```jsx
 import { Puck } from "@measured/puck";
 import headingAnalyzer from "@measured/puck-plugin-heading-analyzer";
+import "@measured/puck-plugin-heading-analyzer/dist/index.css";
 
 ...
 


### PR DESCRIPTION
React strict mode causes the Puck component to be rendered twice. The existing implementation treated the overrides as mutable, which resulted in plugins currying themselves on the second render. This would in turn cause a hydration error when server rendering as the resulting nodes differ between server and client.