### PR TITLE
Fix file options types to allow readonly arrays

### DIFF
--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -7,6 +7,13 @@ type WithPuckProps<Props> = Props & {
   id: string;
 };
 
+type FieldOption = {
+  label: string;
+  value: string | number | boolean;
+};
+
+type FieldOptions = Array<FieldOption> | ReadonlyArray<FieldOption>;
+
 export type BaseField = {
   label?: string;
 };
@@ -26,18 +33,12 @@ export type TextareaField = BaseField & {
 
 export type SelectField = BaseField & {
   type: "select";
-  options: {
-    label: string;
-    value: string | number | boolean;
-  }[];
+  options: FieldOptions;
 };
 
 export type RadioField = BaseField & {
   type: "radio";
-  options: {
-    label: string;
-    value: string | number | boolean;
-  }[];
+  options: FieldOptions;
 };
 
 export type ArrayField<


### PR DESCRIPTION
# tl;dr;
Allow both inline and read-only arrays for fields that take an `options` array (`select` and `radio` fields)

## details
Currently, if you provide a readonly array (by specifying `as const` on the array), Puck will throw a TypeScript error.

```tsx
const selectOptions = [
  {
    label: "A",
    value: "a",
  },
  {
    label: "B",
    value: "b",
  },
] as const

export const SomeComponent: ComponentConfig<SomeComponentProps> = {
  fields: {
    selectField: {
      type: "select",
      options: selectOptions, // <-- This has a TS error
    },
  },
}
```