### PR TITLE
🐛 FIX(heading-analyzer/building):  fix plugin build

### DIFF
--- a/packages/plugin-heading-analyzer/package.json
+++ b/packages/plugin-heading-analyzer/package.json
@@ -24,6 +24,7 @@
     "eslint": "^7.32.0",
     "eslint-config-custom": "*",
     "tsconfig": "*",
+    "tsup": "^6.7.0",
     "tsup-config": "*",
     "typescript": "^4.5.2"
   },


### PR DESCRIPTION
the heading-analyzer plugin ```prepare``` and ```build```  often fails because of missing the tsup dev dependence in workspace