### PR TITLE
Fix component item override

### DIFF
--- a/apps/docs/pages/docs/api-reference/overrides/component-item.mdx
+++ b/apps/docs/pages/docs/api-reference/overrides/component-item.mdx
@@ -14,10 +14,10 @@ const overrides = {
 
 ## Props
 
-| Prop                    | Example     | Type      |
-| ----------------------- | ----------- | --------- |
-| [`children`](#children) | `<input />` | ReactNode |
-| [`name`](#name)         | `"Button"`  | ReactNode |
+| Prop                    | Example    | Type      |
+| ----------------------- | ---------- | --------- |
+| [`children`](#children) | `<div />`  | ReactNode |
+| [`name`](#name)         | `"Button"` | ReactNode |
 
 ### `children`
 

--- a/apps/docs/pages/docs/api-reference/overrides/component-item.mdx
+++ b/apps/docs/pages/docs/api-reference/overrides/component-item.mdx
@@ -8,7 +8,7 @@ Override an individual item within the component list.
 
 ```tsx copy
 const overrides = {
-  componentList: ({ children }) => <div>{children}</div>,
+  componentList: ({ name }) => <div>{name}</div>,
 };
 ```
 
@@ -17,7 +17,12 @@ const overrides = {
 | Prop                    | Example     | Type      |
 | ----------------------- | ----------- | --------- |
 | [`children`](#children) | `<input />` | ReactNode |
+| [`name`](#name)         | `"Button"`  | ReactNode |
 
 ### `children`
 
 The default node for the component item.
+
+### `name`
+
+THe name of the component item.

--- a/apps/docs/pages/docs/api-reference/overrides/component-list.mdx
+++ b/apps/docs/pages/docs/api-reference/overrides/component-list.mdx
@@ -14,9 +14,9 @@ const overrides = {
 
 ## Props
 
-| Prop                    | Example     | Type      |
-| ----------------------- | ----------- | --------- |
-| [`children`](#children) | `<input />` | ReactNode |
+| Prop                    | Example   | Type      |
+| ----------------------- | --------- | --------- |
+| [`children`](#children) | `<div />` | ReactNode |
 
 ### `children`
 

--- a/apps/docs/pages/docs/api-reference/overrides/fields.mdx
+++ b/apps/docs/pages/docs/api-reference/overrides/fields.mdx
@@ -14,9 +14,9 @@ const overrides = {
 
 ## Props
 
-| Prop                    | Example     | Type      |
-| ----------------------- | ----------- | --------- |
-| [`children`](#children) | `<input />` | ReactNode |
+| Prop                    | Example   | Type      |
+| ----------------------- | --------- | --------- |
+| [`children`](#children) | `<div />` | ReactNode |
 
 ### `children`
 

--- a/apps/docs/pages/docs/api-reference/overrides/header-actions.mdx
+++ b/apps/docs/pages/docs/api-reference/overrides/header-actions.mdx
@@ -19,9 +19,9 @@ const overrides = {
 
 ## Props
 
-| Prop                    | Example     | Type      |
-| ----------------------- | ----------- | --------- |
-| [`children`](#children) | `<input />` | ReactNode |
+| Prop                    | Example   | Type      |
+| ----------------------- | --------- | --------- |
+| [`children`](#children) | `<div />` | ReactNode |
 
 ### `children`
 

--- a/apps/docs/pages/docs/api-reference/overrides/header.mdx
+++ b/apps/docs/pages/docs/api-reference/overrides/header.mdx
@@ -19,10 +19,10 @@ const overrides = {
 
 ## Props
 
-| Prop                    | Example     | Type      |
-| ----------------------- | ----------- | --------- |
-| [`actions`](#actions)   | `<div />`   | ReactNode |
-| [`children`](#children) | `<input />` | ReactNode |
+| Prop                    | Example   | Type      |
+| ----------------------- | --------- | --------- |
+| [`actions`](#actions)   | `<div />` | ReactNode |
+| [`children`](#children) | `<div />` | ReactNode |
 
 ### `actions`
 

--- a/apps/docs/pages/docs/api-reference/overrides/outline.mdx
+++ b/apps/docs/pages/docs/api-reference/overrides/outline.mdx
@@ -14,9 +14,9 @@ const overrides = {
 
 ## Props
 
-| Prop                    | Example     | Type      |
-| ----------------------- | ----------- | --------- |
-| [`children`](#children) | `<input />` | ReactNode |
+| Prop                    | Example   | Type      |
+| ----------------------- | --------- | --------- |
+| [`children`](#children) | `<div />` | ReactNode |
 
 ### `children`
 

--- a/apps/docs/pages/docs/api-reference/overrides/preview.mdx
+++ b/apps/docs/pages/docs/api-reference/overrides/preview.mdx
@@ -14,9 +14,9 @@ const overrides = {
 
 ## Props
 
-| Prop                    | Example     | Type      |
-| ----------------------- | ----------- | --------- |
-| [`children`](#children) | `<input />` | ReactNode |
+| Prop                    | Example   | Type      |
+| ----------------------- | --------- | --------- |
+| [`children`](#children) | `<div />` | ReactNode |
 
 ### `children`
 

--- a/apps/docs/pages/docs/api-reference/overrides/puck.mdx
+++ b/apps/docs/pages/docs/api-reference/overrides/puck.mdx
@@ -14,9 +14,9 @@ const overrides = {
 
 ## Props
 
-| Prop                    | Example     | Type      |
-| ----------------------- | ----------- | --------- |
-| [`children`](#children) | `<input />` | ReactNode |
+| Prop                    | Example   | Type      |
+| ----------------------- | --------- | --------- |
+| [`children`](#children) | `<div />` | ReactNode |
 
 ### `children`
 

--- a/packages/core/components/Drawer/index.tsx
+++ b/packages/core/components/Drawer/index.tsx
@@ -46,7 +46,7 @@ const DrawerItem = ({
   index,
 }: {
   name: string;
-  children?: (props: { children: ReactNode }) => ReactElement;
+  children?: (props: { children: ReactNode; name: string }) => ReactElement;
   id?: string;
   index: number;
 }) => {
@@ -57,7 +57,7 @@ const DrawerItem = ({
   const CustomInner = useMemo(
     () =>
       children ||
-      (({ children }: { children: ReactNode }) => (
+      (({ children, name }: { children: ReactNode; name: string }) => (
         <div className={getClassNameItem("default")}>{children}</div>
       )),
     [children]
@@ -65,7 +65,7 @@ const DrawerItem = ({
 
   return (
     <DrawerDraggable id={resolvedId} index={index}>
-      <CustomInner>
+      <CustomInner name={name}>
         <div className={getClassNameItem("draggableWrapper")}>
           <div className={getClassNameItem("draggable")}>
             <div className={getClassNameItem("name")}>{name}</div>

--- a/packages/core/types/Overrides.ts
+++ b/packages/core/types/Overrides.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { ReactElement, ReactNode } from "react";
 import { InputProps } from "../components/InputOrGroup";
 import { Field } from "./Config";
 import { ItemSelector } from "../lib/get-item";
@@ -6,7 +6,7 @@ import { ItemSelector } from "../lib/get-item";
 // Plugins can use `usePuck` instead of relying on props
 type RenderFunc<
   Props extends { [key: string]: any } = { children: ReactNode }
-> = React.FunctionComponent<Props>;
+> = (props: Props) => ReactElement;
 
 // All direct render methods, excluding fields
 export const overrideKeys = [

--- a/packages/core/types/Overrides.ts
+++ b/packages/core/types/Overrides.ts
@@ -44,7 +44,7 @@ export type Overrides = OverridesGeneric<{
     className?: string;
   }>;
   components: RenderFunc;
-  componentItem: RenderFunc;
+  componentItem: RenderFunc<{ children: ReactNode; name: string }>;
   outline: RenderFunc;
   puck: RenderFunc;
 }>;


### PR DESCRIPTION
In an attempt to address #334, I discovered that the feature was actually not implemented.

This PR implements a `name` prop for the `componentItem` override.

Closes #334 