### PR TITLE
Fix broken link in AppState API Reference

### DIFF
--- a/apps/docs/pages/docs/api-reference/app-state.mdx
+++ b/apps/docs/pages/docs/api-reference/app-state.mdx
@@ -6,7 +6,7 @@ The internal state of the [`<Puck>`](/docs/api-reference/components/puck) compon
 
 ## `data`
 
-The current [`Data`](/api-reference/data) payload being managed by Puck.
+The current [`Data`](/docs/api-reference/data) payload being managed by Puck.
 
 ## `ui`
 


### PR DESCRIPTION
I found a broken link while browsing the docs.