### PR TITLE
Refactor: dropzone context

### DIFF
--- a/packages/core/components/DropZone/context.tsx
+++ b/packages/core/components/DropZone/context.tsx
@@ -44,10 +44,10 @@ export type DropZoneEditContext<
   setHoveringZone: (zone: string | null) => void;
   hoveringComponent?: string | null;
   setHoveringComponent: (id: string | null) => void;
-  registerZoneArea?: (areaId: string) => void;
+  registerZoneArea: (areaId: string) => void;
   areasWithZones?: Record<string, boolean>;
-  registerZone?: (zoneCompound: string) => void;
-  unregisterZone?: (zoneCompound: string) => void;
+  registerZone: (zoneCompound: string) => void;
+  unregisterZone: (zoneCompound: string) => void;
   activeZones?: Record<string, boolean>;
   pathData?: PathData;
   registerPath: (selector: ItemSelector) => void;

--- a/packages/core/components/DropZone/context.tsx
+++ b/packages/core/components/DropZone/context.tsx
@@ -62,15 +62,12 @@ const dropZoneContext = createContext<DropZoneContext>(null);
 
 export const useDropZoneContext = () => {
   const ctx = useContext(dropZoneContext);
-  if (!ctx) {
-    throw Error("No dropzone context provided");
-  }
   return ctx;
 };
 
 export const useDropZoneEditContext = () => {
   const ctx = useDropZoneContext();
-  if (ctx.mode !== "edit") {
+  if (ctx?.mode !== "edit") {
     throw Error("No dropzone edit context provided");
   }
   return ctx;
@@ -78,7 +75,7 @@ export const useDropZoneEditContext = () => {
 
 export const useDropZoneRenderContext = () => {
   const ctx = useDropZoneContext();
-  if (ctx.mode !== "render") {
+  if (ctx?.mode !== "render") {
     throw Error("No dropzone render context provided");
   }
   return ctx;

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -29,6 +29,7 @@ type DropZoneProps = {
 
 function DropZoneEdit({ zone, allow, disallow, style }: DropZoneProps) {
   const appContext = useAppContext();
+
   const ctx = useDropZoneEditContext();
 
   const {

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -60,21 +60,16 @@ function DropZoneEdit({ zone, allow, disallow, style }: DropZoneProps) {
   let zoneCompound = rootDroppableId;
 
   useEffect(() => {
-    if (areaId && registerZoneArea) {
+    if (areaId) {
       registerZoneArea(areaId);
     }
   }, [areaId]);
 
   // Register and unregister zone on mount
   useEffect(() => {
-    if (registerZone) {
-      registerZone(zoneCompound);
-    }
-
+    registerZone(zoneCompound);
     return () => {
-      if (unregisterZone) {
-        unregisterZone(zoneCompound);
-      }
+      unregisterZone(zoneCompound);
     };
   }, []);
 

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -397,6 +397,10 @@ function DropZoneRender({ zone }: DropZoneProps) {
 export function DropZone(props: DropZoneProps) {
   const ctx = useDropZoneContext();
 
+  if (!ctx) {
+    return <div>DropZone requires context to work.</div>;
+  }
+
   if (ctx.mode === "edit") {
     return <DropZoneEdit {...props} />;
   }

--- a/packages/core/components/LayerTree/index.tsx
+++ b/packages/core/components/LayerTree/index.tsx
@@ -5,8 +5,7 @@ import { ItemSelector, getItem } from "../../lib/get-item";
 import { scrollIntoView } from "../../lib/scroll-into-view";
 import { ChevronDown, LayoutGrid, Layers, Type } from "lucide-react";
 import { rootDroppableId } from "../../lib/root-droppable-id";
-import { useContext } from "react";
-import { dropZoneContext } from "../DropZone/context";
+import { useDropZoneEditContext } from "../DropZone/context";
 import { findZonesForArea } from "../../lib/find-zones-for-area";
 import { getZoneId } from "../../lib/get-zone-id";
 import { isChildOfZone } from "../../lib/is-child-of-zone";
@@ -31,7 +30,8 @@ export const LayerTree = ({
 }) => {
   const zones = data.zones || {};
 
-  const ctx = useContext(dropZoneContext);
+  const ctx = useDropZoneEditContext();
+  const { setHoveringArea, setHoveringComponent, hoveringComponent } = ctx;
 
   return (
     <>
@@ -55,12 +55,6 @@ export const LayerTree = ({
 
           const zonesForItem = findZonesForArea(data, item.props.id);
           const containsZone = Object.keys(zonesForItem).length > 0;
-
-          const {
-            setHoveringArea = () => {},
-            setHoveringComponent = () => {},
-            hoveringComponent,
-          } = ctx || {};
 
           const selectedItem =
             itemSelector && data ? getItem(itemSelector, data) : null;

--- a/packages/core/components/Puck/components/Outline/index.tsx
+++ b/packages/core/components/Puck/components/Outline/index.tsx
@@ -3,9 +3,10 @@ import { findZonesForArea } from "../../../../lib/find-zones-for-area";
 import { rootDroppableId } from "../../../../lib/root-droppable-id";
 import { LayerTree } from "../../../LayerTree";
 import { useAppContext } from "../../context";
-import { dropZoneContext } from "../../../DropZone";
+
 import { useCallback, useMemo } from "react";
 import { ItemSelector } from "../../../../lib/get-item";
+import { useDropZoneEditContext } from "../../../DropZone/context";
 
 export const Outline = () => {
   const { dispatch, state, overrides } = useAppContext();
@@ -24,38 +25,32 @@ export const Outline = () => {
 
   const Wrapper = useMemo(() => overrides.outline || "div", [overrides]);
 
+  const ctx = useDropZoneEditContext();
+
   return (
     <Wrapper>
-      <dropZoneContext.Consumer>
-        {(ctx) => (
-          <>
-            {ctx?.activeZones && ctx?.activeZones[rootDroppableId] && (
-              <LayerTree
-                data={data}
-                label={areaContainsZones(data, "root") ? rootDroppableId : ""}
-                zoneContent={data.content}
-                setItemSelector={setItemSelector}
-                itemSelector={itemSelector}
-              />
-            )}
-            {Object.entries(findZonesForArea(data, "root")).map(
-              ([zoneKey, zone]) => {
-                return (
-                  <LayerTree
-                    key={zoneKey}
-                    data={data}
-                    label={zoneKey}
-                    zone={zoneKey}
-                    zoneContent={zone}
-                    setItemSelector={setItemSelector}
-                    itemSelector={itemSelector}
-                  />
-                );
-              }
-            )}
-          </>
-        )}
-      </dropZoneContext.Consumer>
+      {ctx.activeZones && ctx.activeZones[rootDroppableId] && (
+        <LayerTree
+          data={data}
+          label={areaContainsZones(data, "root") ? rootDroppableId : ""}
+          zoneContent={data.content}
+          setItemSelector={setItemSelector}
+          itemSelector={itemSelector}
+        />
+      )}
+      {Object.entries(findZonesForArea(data, "root")).map(([zoneKey, zone]) => {
+        return (
+          <LayerTree
+            key={zoneKey}
+            data={data}
+            label={zoneKey}
+            zone={zoneKey}
+            zoneContent={zone}
+            setItemSelector={setItemSelector}
+            itemSelector={itemSelector}
+          />
+        );
+      })}
     </Wrapper>
   );
 };

--- a/packages/core/components/Puck/components/Outline/index.tsx
+++ b/packages/core/components/Puck/components/Outline/index.tsx
@@ -3,7 +3,6 @@ import { findZonesForArea } from "../../../../lib/find-zones-for-area";
 import { rootDroppableId } from "../../../../lib/root-droppable-id";
 import { LayerTree } from "../../../LayerTree";
 import { useAppContext } from "../../context";
-
 import { useCallback, useMemo } from "react";
 import { ItemSelector } from "../../../../lib/get-item";
 import { useDropZoneEditContext } from "../../../DropZone/context";

--- a/packages/core/components/Puck/components/Preview/index.tsx
+++ b/packages/core/components/Puck/components/Preview/index.tsx
@@ -1,7 +1,8 @@
-import { DropZone, dropZoneContext } from "../../../DropZone";
+import { DropZone } from "../../../DropZone";
 import { rootDroppableId } from "../../../../lib/root-droppable-id";
-import { useCallback, useContext } from "react";
+import { useCallback } from "react";
 import { useAppContext } from "../../context";
+import { useDropZoneEditContext } from "../../../DropZone/context";
 
 export const Preview = ({ id = "puck-preview" }: { id?: string }) => {
   const { config, dispatch, state } = useAppContext();
@@ -17,7 +18,7 @@ export const Preview = ({ id = "puck-preview" }: { id?: string }) => {
   // DEPRECATED
   const rootProps = state.data.root.props || state.data.root;
 
-  const { disableZoom = false } = useContext(dropZoneContext) || {};
+  const { disableZoom = false } = useDropZoneEditContext();
 
   return (
     <div

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -25,7 +25,7 @@ import {
 } from "lucide-react";
 import { Heading } from "../Heading";
 import { IconButton } from "../IconButton/IconButton";
-import { DropZoneProvider } from "../DropZone";
+import { DropZoneEditProvider } from "../DropZone";
 import { ItemSelector, getItem } from "../../lib/get-item";
 import { PuckAction, StateReducer, createReducer } from "../../reducer";
 import { flushZones } from "../../lib/flush-zones";
@@ -375,7 +375,7 @@ export function Puck<
             }
           }}
         >
-          <DropZoneProvider
+          <DropZoneEditProvider
             value={{
               data,
               itemSelector,
@@ -518,7 +518,7 @@ export function Puck<
                 </div>
               )}
             </CustomPuck>
-          </DropZoneProvider>
+          </DropZoneEditProvider>
         </DragDropContext>
       </AppProvider>
       <div id="puck-portal-root" />

--- a/packages/core/components/Render/index.tsx
+++ b/packages/core/components/Render/index.tsx
@@ -2,7 +2,7 @@
 
 import { rootDroppableId } from "../../lib/root-droppable-id";
 import { Config, Data } from "../../types/Config";
-import { DropZone, DropZoneProvider } from "../DropZone";
+import { DropZone, DropZoneRenderProvider } from "../DropZone";
 
 export function Render<
   UserConfig extends Config<any, any, any> = Config<any, any, any>
@@ -13,7 +13,7 @@ export function Render<
 
   if (config.root?.render) {
     return (
-      <DropZoneProvider value={{ data, config, mode: "render" }}>
+      <DropZoneRenderProvider value={{ data, config, mode: "render" }}>
         <config.root.render
           {...rootProps}
           puck={{
@@ -25,13 +25,13 @@ export function Render<
         >
           <DropZone zone={rootDroppableId} />
         </config.root.render>
-      </DropZoneProvider>
+      </DropZoneRenderProvider>
     );
   }
 
   return (
-    <DropZoneProvider value={{ data, config, mode: "render" }}>
+    <DropZoneRenderProvider value={{ data, config, mode: "render" }}>
       <DropZone zone={rootDroppableId} />
-    </DropZoneProvider>
+    </DropZoneRenderProvider>
   );
 }

--- a/packages/core/lib/__tests__/is-child-of-zone.spec.tsx
+++ b/packages/core/lib/__tests__/is-child-of-zone.spec.tsx
@@ -1,4 +1,3 @@
-import { DropZoneContext } from "../../components/DropZone/context";
 import { Config, Data } from "../../types/Config";
 import { isChildOfZone } from "../is-child-of-zone";
 
@@ -24,7 +23,7 @@ const config: Config = {
   },
 };
 
-const dropzoneContext: DropZoneContext = {
+const dropzoneContext = {
   data,
   config,
   pathData: {

--- a/packages/core/lib/__tests__/use-breadcrumbs.spec.tsx
+++ b/packages/core/lib/__tests__/use-breadcrumbs.spec.tsx
@@ -24,7 +24,7 @@ const config: Config = {
   },
 };
 
-const dropzoneContext: DropZoneContext = {
+const dropzoneContext = {
   data,
   config,
   pathData: {

--- a/packages/core/lib/is-child-of-zone.ts
+++ b/packages/core/lib/is-child-of-zone.ts
@@ -1,14 +1,13 @@
-import { DropZoneContext } from "../components/DropZone/context";
+import { DropZoneEditContext } from "../components/DropZone/context";
 import { Content } from "../types/Config";
-import { getItem } from "./get-item";
 import { getZoneId } from "./get-zone-id";
 
 export const isChildOfZone = (
   item: Content[0],
   maybeChild: Content[0] | null | undefined,
-  ctx: DropZoneContext
+  ctx: Pick<DropZoneEditContext, 'data' | 'pathData'>
 ) => {
-  const { data, pathData = {} } = ctx || {};
+  const { data, pathData = {} } = ctx;
 
   return maybeChild && data
     ? !!pathData[maybeChild.props.id]?.path.find((zoneCompound) => {

--- a/packages/core/lib/is-child-of-zone.ts
+++ b/packages/core/lib/is-child-of-zone.ts
@@ -5,7 +5,7 @@ import { getZoneId } from "./get-zone-id";
 export const isChildOfZone = (
   item: Content[0],
   maybeChild: Content[0] | null | undefined,
-  ctx: Pick<DropZoneEditContext, 'data' | 'pathData'>
+  ctx: Pick<DropZoneEditContext, "data" | "pathData">
 ) => {
   const { data, pathData = {} } = ctx;
 

--- a/packages/core/lib/use-breadcrumbs.ts
+++ b/packages/core/lib/use-breadcrumbs.ts
@@ -1,5 +1,8 @@
 import { useMemo } from "react";
-import { useDropZoneEditContext, PathData } from "../components/DropZone/context";
+import {
+  useDropZoneEditContext,
+  PathData,
+} from "../components/DropZone/context";
 import { useAppContext } from "../components/Puck/context";
 import { getZoneId } from "./get-zone-id";
 import { rootDroppableId } from "./root-droppable-id";

--- a/packages/core/lib/use-breadcrumbs.ts
+++ b/packages/core/lib/use-breadcrumbs.ts
@@ -82,6 +82,7 @@ export const useBreadcrumbs = (renderCount?: number) => {
     state: { data },
     selectedItem,
   } = useAppContext();
+
   const dzContext = useDropZoneEditContext();
 
   return useMemo<Breadcrumb[]>(() => {

--- a/packages/core/lib/use-breadcrumbs.ts
+++ b/packages/core/lib/use-breadcrumbs.ts
@@ -1,5 +1,5 @@
-import { useContext, useMemo } from "react";
-import { dropZoneContext, PathData } from "../components/DropZone/context";
+import { useMemo } from "react";
+import { useDropZoneEditContext, PathData } from "../components/DropZone/context";
 import { useAppContext } from "../components/Puck/context";
 import { getZoneId } from "./get-zone-id";
 import { rootDroppableId } from "./root-droppable-id";
@@ -82,12 +82,12 @@ export const useBreadcrumbs = (renderCount?: number) => {
     state: { data },
     selectedItem,
   } = useAppContext();
-  const dzContext = useContext(dropZoneContext);
+  const dzContext = useDropZoneEditContext();
 
   return useMemo<Breadcrumb[]>(() => {
     const breadcrumbs = convertPathDataToBreadcrumbs(
       selectedItem,
-      dzContext?.pathData,
+      dzContext.pathData,
       data
     );
 
@@ -96,5 +96,5 @@ export const useBreadcrumbs = (renderCount?: number) => {
     }
 
     return breadcrumbs;
-  }, [selectedItem, dzContext?.pathData, renderCount]);
+  }, [selectedItem, dzContext.pathData, renderCount]);
 };

--- a/packages/core/lib/use-breadcrumbs.ts
+++ b/packages/core/lib/use-breadcrumbs.ts
@@ -83,12 +83,12 @@ export const useBreadcrumbs = (renderCount?: number) => {
     selectedItem,
   } = useAppContext();
 
-  const dzContext = useDropZoneEditContext();
+  const { pathData } = useDropZoneEditContext();
 
   return useMemo<Breadcrumb[]>(() => {
     const breadcrumbs = convertPathDataToBreadcrumbs(
       selectedItem,
-      dzContext.pathData,
+      pathData,
       data
     );
 
@@ -97,5 +97,5 @@ export const useBreadcrumbs = (renderCount?: number) => {
     }
 
     return breadcrumbs;
-  }, [selectedItem, dzContext.pathData, renderCount]);
+  }, [selectedItem, pathData, renderCount]);
 };


### PR DESCRIPTION
Use discriminated union type for DropZoneContext to provide a better typed context.

Facilitates the removal of a bunch of guard clauses and better documents the expected use.

Export DropZoneContext inside useDropZoneContext, useDropZoneEditContext and useDropZoneRenderContext.
Throw error on incorrect mode - we could add an ErrorBoundary to catch this, shouldn't be necessary due to:.
The current behaviour of gracefully showing a message on missing context is retained by moving it to the parent <DropZone> component.

