### PR TITLE
feature: add component toolbar portal target

### DIFF
--- a/packages/core/components/DraggableComponent/index.tsx
+++ b/packages/core/components/DraggableComponent/index.tsx
@@ -97,6 +97,7 @@ export const DraggableComponent = ({
               {label && (
                 <div className={getClassName("actionsLabel")}>{label}</div>
               )}
+              <div id={`DraggableComponentToolbarPortal-${id}`} />
               <button className={getClassName("action")} onClick={onDuplicate}>
                 <Copy size={16} />
               </button>

--- a/packages/core/components/DraggableComponent/index.tsx
+++ b/packages/core/components/DraggableComponent/index.tsx
@@ -104,6 +104,7 @@ export const DraggableComponent = ({
               <button className={getClassName("action")} onClick={onDelete}>
                 <Trash size={16} />
               </button>
+              <div className={getClassName("actionsMask")} />
             </div>
           </div>
           <div className={getClassName("contents")}>{children}</div>

--- a/packages/core/components/DraggableComponent/styles.module.css
+++ b/packages/core/components/DraggableComponent/styles.module.css
@@ -28,7 +28,7 @@
 
 .DraggableComponent-overlay {
   display: none;
-  background: color-mix(in srgb, var(--puck-color-azure-08) 30%, transparent);
+  background: green; /*color-mix(in srgb, var(--puck-color-azure-08) 30%, transparent);*/
   cursor: pointer;
   height: 100%;
   width: 100%;
@@ -99,12 +99,13 @@
 
 .DraggableComponent-actions {
   position: absolute;
-  right: -1px;
+  right: 6.5px;
   width: auto;
-  top: -37px;
+  top: -48px;
   padding: 4px;
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
+  border-radius: 8px;
   background: var(--puck-color-grey-01);
   color: var(--puck-color-white);
   cursor: grab;
@@ -113,6 +114,15 @@
   gap: 4px;
   pointer-events: auto;
   box-sizing: border-box;
+}
+
+.DraggableComponent-actionsMask {
+  position: absolute;
+  right: 0px;
+  top: 36px;
+  height: 11px;
+  width: 100%;
+  background: transparent;
 }
 
 .DraggableComponent--isSelected

--- a/packages/core/components/DraggableComponent/styles.module.css
+++ b/packages/core/components/DraggableComponent/styles.module.css
@@ -28,7 +28,7 @@
 
 .DraggableComponent-overlay {
   display: none;
-  background: green; /*color-mix(in srgb, var(--puck-color-azure-08) 30%, transparent);*/
+  background: color-mix(in srgb, var(--puck-color-azure-08) 30%, transparent);
   cursor: pointer;
   height: 100%;
   width: 100%;

--- a/packages/core/components/DraggableComponent/styles.module.css
+++ b/packages/core/components/DraggableComponent/styles.module.css
@@ -99,13 +99,12 @@
 
 .DraggableComponent-actions {
   position: absolute;
-  right: 6.5px;
+  right: -1px;
   width: auto;
-  top: -48px;
+  top: -37px;
   padding: 4px;
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
-  border-radius: 8px;
   background: var(--puck-color-grey-01);
   color: var(--puck-color-white);
   cursor: grab;


### PR DESCRIPTION
Note: This also adjusts the position of the toolbar, attaching it to the top border of the component to prevent the component above 'flashing' on hover. This becomes quite intrusive when interacting with the toolbar regularly.