### PR TITLE
fix: Correct inference of objectFields in ObjectField type

### DIFF
--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -59,7 +59,7 @@ export type ObjectField<
 > = BaseField & {
   type: "object";
   objectFields: {
-    [SubPropName in keyof Props[0]]: Field<Props[0][SubPropName]>;
+    [SubPropName in keyof Props]: Field<Props[SubPropName]>;
   };
 };
 


### PR DESCRIPTION
Adjusted the ObjectField type definition to ensure that properties present in Props are required and typed in the objectFields property. This resolves an issue where properties were not being inferred, leading to untyped fields.

Before:
<img width="422" alt="image" src="https://github.com/measuredco/puck/assets/8417041/d690ae50-291a-4328-bc80-824873b14bca">

After:
<img width="774" alt="image" src="https://github.com/measuredco/puck/assets/8417041/3d8f88b9-220a-4e80-9c7c-ba38eb14b583">

