### PR TITLE
chore: fix Button color on dark mode

### DIFF
--- a/packages/core/components/Button/Button.module.css
+++ b/packages/core/components/Button/Button.module.css
@@ -65,18 +65,20 @@
 }
 
 .Button--secondary {
-  border: 1px solid var(--puck-color-grey-01);
-  color: var(--puck-color-black);
+  border: 1px solid currentColor;
+  color: currentColor;
 }
 
 @media (hover: hover) and (pointer: fine) {
   .Button--secondary:hover {
     background-color: var(--puck-color-azure-12);
+    color: var(--puck-color-black);
   }
 }
 
 .Button--secondary:active {
   background-color: var(--puck-color-azure-11);
+  color: var(--puck-color-black);
 }
 
 .Button--flush {


### PR DESCRIPTION
On dark color modes, the secondary Button is currently rendering with dark borders and text, resulting in poor contrast.

Using currentColor addresses this, especially since the main Puck editor does not yet have a dark mode, but the docs do.

Note, this bug is not yet released so a `chore` is the suitable commit type.