### PR TITLE
chore: prevent iOS crashes when dragging in large viewport

### DIFF
--- a/packages/core/components/DraggableComponent/index.tsx
+++ b/packages/core/components/DraggableComponent/index.tsx
@@ -1,9 +1,16 @@
-import { CSSProperties, ReactNode, SyntheticEvent, useEffect } from "react";
+import {
+  CSSProperties,
+  ReactNode,
+  SyntheticEvent,
+  useEffect,
+  useState,
+} from "react";
 import { Draggable } from "@measured/dnd";
 import styles from "./styles.module.css";
 import getClassNameFactory from "../../lib/get-class-name-factory";
 import { Copy, Trash } from "lucide-react";
 import { useModifierHeld } from "../../lib/use-modifier-held";
+import { isIos } from "../../lib/is-ios";
 import { ClipLoader } from "react-spinners";
 import { useAppContext } from "../Puck/context";
 import { DefaultDraggable } from "../Draggable";
@@ -68,8 +75,24 @@ export const DraggableComponent = ({
 
   useEffect(onMount, []);
 
+  const [disableSecondaryAnimation, setDisableSecondaryAnimation] =
+    useState(false);
+
+  useEffect(() => {
+    // Disable animations on iOS to prevent GPU memory crashes
+    if (isIos()) {
+      setDisableSecondaryAnimation(true);
+    }
+  }, []);
+
   return (
-    <El key={id} draggableId={id} index={index} isDragDisabled={isDragDisabled}>
+    <El
+      key={id}
+      draggableId={id}
+      index={index}
+      isDragDisabled={isDragDisabled}
+      disableSecondaryAnimation={disableSecondaryAnimation}
+    >
       {(provided, snapshot) => (
         <div
           ref={provided.innerRef}

--- a/packages/core/lib/is-ios.ts
+++ b/packages/core/lib/is-ios.ts
@@ -1,0 +1,11 @@
+export const isIos = () =>
+  [
+    "iPad Simulator",
+    "iPhone Simulator",
+    "iPod Simulator",
+    "iPad",
+    "iPhone",
+    "iPod",
+  ].includes(navigator.platform) ||
+  // iPad on iOS 13 detection
+  (navigator.userAgent.includes("Mac") && "ontouchend" in document);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@measured/auto-frame-component": "0.1.1",
-    "@measured/dnd": "16.6.0-canary.dcf051d",
+    "@measured/dnd": "16.6.0-canary.c7c88e8",
     "deep-diff": "^1.0.2",
     "react-hotkeys-hook": "^4.4.1",
     "react-spinners": "^0.13.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1458,10 +1458,10 @@
     object-hash "^3.0.0"
     react-frame-component "5.2.6"
 
-"@measured/dnd@16.6.0-canary.dcf051d":
-  version "16.6.0-canary.dcf051d"
-  resolved "https://registry.yarnpkg.com/@measured/dnd/-/dnd-16.6.0-canary.dcf051d.tgz#7c3f5c5f295a72046e77dbd108af01cb80b5dd70"
-  integrity sha512-JsI/KaL7z44A4wSn2LY1Mr27pZUx2YdSpdEVY0EsBxh5FjZmcQ44KnOtzFQDEXbW3lSaU7789/5zvDZTJJ6Esg==
+"@measured/dnd@16.6.0-canary.c7c88e8":
+  version "16.6.0-canary.c7c88e8"
+  resolved "https://registry.yarnpkg.com/@measured/dnd/-/dnd-16.6.0-canary.c7c88e8.tgz#8587e1ba86a55d6e720bbf98c04d3f17b3865553"
+  integrity sha512-RZGmVyBaB6kaUblBAMptwOKiWSSwfiLuN/Ai0er0oiWjgL/p5/LWwcHRsR2TGuyNL2od4EY+eAeG+9kc+F50NA==
   dependencies:
     "@babel/runtime" "^7.23.2"
     css-box-model "^1.2.1"


### PR DESCRIPTION
Disabling animations prevents a "Safari encountered a problem" error when dragging an item on a desktop viewport on iOS Safari, which was likely due to a GPU memory issue.