### PR TITLE
fix: use 100% width for Puck frame when iframe disabled

### DIFF
--- a/packages/core/components/Puck/components/Canvas/index.tsx
+++ b/packages/core/components/Puck/components/Canvas/index.tsx
@@ -150,7 +150,7 @@ export const Canvas = () => {
         <div
           className={getClassName("root")}
           style={{
-            width: iframe.enabled ? ui.viewports.current.width : undefined,
+            width: iframe.enabled ? ui.viewports.current.width : "100%",
             height: zoomConfig.rootHeight,
             transform: iframe.enabled ? `scale(${zoomConfig.zoom})` : undefined,
             transition: showTransition


### PR DESCRIPTION
#412 identified an issue that resulted in the preview width collapsing down to the width of the contents when iframes are disabled. If there is no contents, the preview would not be visible.

This fixes it by setting the width to 100%, as expected.

Closes #412