### PR TITLE
fix: Fix support for boolean values with select field.

### DIFF
--- a/packages/core/components/InputOrGroup/fields/SelectField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/SelectField/index.tsx
@@ -33,7 +33,7 @@ export const SelectField = ({
             e.currentTarget.value === "true" ||
             e.currentTarget.value === "false"
           ) {
-            onChange(Boolean(e.currentTarget.value));
+            onChange(JSON.parse(e.currentTarget.value));
             return;
           }
 


### PR DESCRIPTION
When using a boolean value with the select field, the value always evaluates to true (a similar implementation works as expected with the radio field).

![puck-select-boolean](https://github.com/measuredco/puck/assets/3270818/2db893eb-822f-4e27-8007-812a2523df0e)


https://codesandbox.io/p/sandbox/sleepy-fast-x7cdwn

[Working Radio field code.](https://github.com/measuredco/puck/blob/main/packages/core/components/InputOrGroup/fields/RadioField/index.tsx#L40-L46)

