### PR TITLE
fix: Reflect value changes made in resolveData in radio field.

### DIFF
--- a/packages/core/components/InputOrGroup/fields/RadioField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/RadioField/index.tsx
@@ -48,7 +48,7 @@ export const RadioField = ({
                 onChange(e.currentTarget.value);
               }}
               disabled={readOnly}
-              defaultChecked={value === option.value}
+              checked={value === option.value}
             />
             <div className={getClassName("radioInner")}>
               {option.label || option.value}


### PR DESCRIPTION
When a prop change is made in `resolveData`, that value is not reflected when using a radio field but reflected in the render of the component.

In this example, when a change is made to `children` the expected behaviour is that the `align` prop reverts to `"center"`.
Notice that even though the text is aligned in the centre and the prop value has changed, the radio button shows either "left" or "right" as the selected value.

![radio-bug](https://github.com/measuredco/puck/assets/3270818/ec9286e3-be0d-44c1-b47e-c29922927e8d)


[Bug reproduction ](https://codesandbox.io/p/sandbox/elastic-sutherland-x963k4).


Example with this PR's code change.
![radio-working](https://github.com/measuredco/puck/assets/3270818/4bd303ad-1667-465c-9f01-98d6ec9a09f6)


