### PR TITLE
feat: export InputOrGroup component

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -17,4 +17,4 @@ export * from "./lib/transform-props";
 export * from "./lib/resolve-all-data";
 export { usePuck } from "./lib/use-puck";
 
-export { FieldLabel } from "./components/InputOrGroup";
+export { FieldLabel, InputOrGroup } from "./components/InputOrGroup";


### PR DESCRIPTION
Allows the use of puck InputOrGroup component within a custom field