### PR TITLE
Add iframe spinner during slow loads

### DIFF
--- a/packages/core/components/Puck/components/Canvas/index.tsx
+++ b/packages/core/components/Puck/components/Canvas/index.tsx
@@ -14,6 +14,7 @@ import { getClassNameFactory } from "../../../../lib";
 import { Preview } from "../Preview";
 import { getZoomConfig } from "../../../../lib/get-zoom-config";
 import { AppState } from "../../../../types";
+import { Loader } from "../../../Loader";
 
 const getClassName = getClassNameFactory("PuckCanvas", styles);
 
@@ -100,10 +101,19 @@ export const Canvas = () => {
     };
   }, []);
 
+  const [showLoader, setShowLoader] = useState(false);
+
+  useEffect(() => {
+    setTimeout(() => {
+      setShowLoader(true);
+    }, 500);
+  }, []);
+
   return (
     <div
       className={getClassName({
         ready: status === "READY" || !iframe.enabled,
+        showLoader,
       })}
       onClick={() =>
         dispatch({
@@ -163,6 +173,9 @@ export const Canvas = () => {
           <CustomPreview>
             <Preview />
           </CustomPreview>
+        </div>
+        <div className={getClassName("loader")}>
+          <Loader size={24} />
         </div>
       </div>
     </div>

--- a/packages/core/components/Puck/components/Canvas/styles.module.css
+++ b/packages/core/components/Puck/components/Canvas/styles.module.css
@@ -55,5 +55,24 @@
 
 .PuckCanvas--ready .PuckCanvas-root {
   opacity: 1;
-  transition: opacity 150ms ease-out;
+}
+
+.PuckCanvas-loader {
+  align-items: center;
+  color: var(--puck-color-grey-06);
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  transition: opacity 250ms ease-out;
+  opacity: 0;
+}
+
+.PuckCanvas--showLoader .PuckCanvas-loader {
+  opacity: 1;
+}
+
+.PuckCanvas--showLoader.PuckCanvas--ready .PuckCanvas-loader {
+  opacity: 0;
+  height: 0;
+  transition: none;
 }


### PR DESCRIPTION
If loading takes over 500ms, show a spinner before rendering the iframe.