### PR TITLE
perf: don't lock main thread when iframe styles changed

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,7 +60,7 @@
     "typescript": "^4.5.2"
   },
   "dependencies": {
-    "@measured/auto-frame-component": "0.1.2",
+    "@measured/auto-frame-component": "0.1.3",
     "@measured/dnd": "16.6.0-canary.eda7e8b",
     "deep-diff": "^1.0.2",
     "react-hotkeys-hook": "^4.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1445,10 +1445,10 @@
     "@types/mdx" "^2.0.0"
     "@types/react" ">=16"
 
-"@measured/auto-frame-component@0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@measured/auto-frame-component/-/auto-frame-component-0.1.2.tgz#843452f23640c85e0664f90d7138dde6b7f15254"
-  integrity sha512-EWSGEbZMbsN2msHK0QMEoHZo9SgmD61/RSGQ/Wxo4TZoz5Fkqz8/k9+u4mbL8EpyL3o3tqouWp1bkNAiAkxf5g==
+"@measured/auto-frame-component@0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@measured/auto-frame-component/-/auto-frame-component-0.1.3.tgz#1bf58ebce336f813b0d96a914cc6ce2acf271b25"
+  integrity sha512-oDGftzZ/VsMfgwDZvOcYNPCFgz6Lj2Uy2llfejt3HoZMJ9Nro7dzCcxc+EYMoIVzZGAGXA2gpfMLTCJFcLfa6g==
   dependencies:
     object-hash "^3.0.0"
     react-frame-component "5.2.6"


### PR DESCRIPTION
This may occur in dev environments when styles are injected into the parent <head>, causing issues if this occurs during a drop. For example, using @mui/material in form inputs injects styles as soon as an item is dropped via emotion, causing the main thread to hang. Deferring this until after the main thread is completed via measured/auto-frame-component@0.1.3 [addresses the issue](https://github.com/measuredco/auto-frame-component/commit/f62f5e83d896557734306830344303bfd84aad95).

May address the final issues observed in https://github.com/measuredco/puck/issues/407#issuecomment-2049121046.