### PR TITLE
perf: batch load initial iframe styles

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,7 +60,7 @@
     "typescript": "^4.5.2"
   },
   "dependencies": {
-    "@measured/auto-frame-component": "0.1.3",
+    "@measured/auto-frame-component": "0.1.5",
     "@measured/dnd": "16.6.0-canary.4cba1d1",
     "deep-diff": "^1.0.2",
     "react-hotkeys-hook": "^4.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1445,10 +1445,10 @@
     "@types/mdx" "^2.0.0"
     "@types/react" ">=16"
 
-"@measured/auto-frame-component@0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@measured/auto-frame-component/-/auto-frame-component-0.1.3.tgz#1bf58ebce336f813b0d96a914cc6ce2acf271b25"
-  integrity sha512-oDGftzZ/VsMfgwDZvOcYNPCFgz6Lj2Uy2llfejt3HoZMJ9Nro7dzCcxc+EYMoIVzZGAGXA2gpfMLTCJFcLfa6g==
+"@measured/auto-frame-component@0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@measured/auto-frame-component/-/auto-frame-component-0.1.5.tgz#b481d6dab1bc38e3efdb9470dd44c4dc6f207130"
+  integrity sha512-Et7UhfUm8XPI1zSvcHr8OvtRptVwiDJocUWHmpSIzGZbCJwm2qarNPUCV0HuL0XrT1FCOV6KHbfTP8On7nu7CQ==
   dependencies:
     object-hash "^3.0.0"
     react-frame-component "5.2.6"


### PR DESCRIPTION
Batch load styles into the initial iframe load, which drastically increases performance when numerous <style> attributes exist. This is often the case when using solutions like emotion in development environments.

Refactor: https://github.com/measuredco/auto-frame-component/commit/0bb7efce9996a1f1a2fd110ded94fed0a3f88ecd

May resolve final #407 issues.