### PR TITLE
fix: Adjusted .DropZone--hasChildren CSS class to fix child element

### DIFF
--- a/packages/core/components/DropZone/styles.module.css
+++ b/packages/core/components/DropZone/styles.module.css
@@ -49,6 +49,15 @@
   ) !important;
 }
 
+.DropZone--hasChildren {
+  margin-left: initial;
+  margin-right: initial;
+  height: initial;
+  outline-offset: initial;
+  width: initial;
+  min-height: 128px;
+}
+
 .DropZone-item {
   position: relative;
 }


### PR DESCRIPTION
This change fixes an issue where the layout, a flexbox, was disrupted by the `dropzone` class modifying the children's CSS properties. As a result, the child element, meant to be flexible, was forced to take the entire space. This PR aims to rectify this by restoring the intended behavior. Tested on demo and personal project; no issues so far detected.

![322285985-3deddcec-611d-4e2c-adcf-0126124b58c1](https://github.com/measuredco/puck/assets/26123873/7be6066b-e914-4a14-9790-34931fadae28)
