### PR TITLE
chore: load iframe consistently

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,7 +60,7 @@
     "typescript": "^4.5.2"
   },
   "dependencies": {
-    "@measured/auto-frame-component": "0.1.5",
+    "@measured/auto-frame-component": "0.1.6-canary.ad6452f",
     "@measured/dnd": "16.6.0-canary.4cba1d1",
     "deep-diff": "^1.0.2",
     "react-hotkeys-hook": "^4.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1445,10 +1445,10 @@
     "@types/mdx" "^2.0.0"
     "@types/react" ">=16"
 
-"@measured/auto-frame-component@0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@measured/auto-frame-component/-/auto-frame-component-0.1.5.tgz#b481d6dab1bc38e3efdb9470dd44c4dc6f207130"
-  integrity sha512-Et7UhfUm8XPI1zSvcHr8OvtRptVwiDJocUWHmpSIzGZbCJwm2qarNPUCV0HuL0XrT1FCOV6KHbfTP8On7nu7CQ==
+"@measured/auto-frame-component@0.1.6-canary.ad6452f":
+  version "0.1.6-canary.ad6452f"
+  resolved "https://registry.yarnpkg.com/@measured/auto-frame-component/-/auto-frame-component-0.1.6-canary.ad6452f.tgz#602abf314aac075bac62d44fecd2b4c296ca1843"
+  integrity sha512-6ewVocybiJkDBsKOqOr3X2fayVmiq9c9XrVwkxTj/jpy14EH3IStiKxRediLa26XEZdp5TMJu5jaP+djxRBAyg==
   dependencies:
     object-hash "^3.0.0"
     react-frame-component "5.2.6"


### PR DESCRIPTION
auto-frame-component was not handling some `<link>` tags correctly, and attempting to load them twice when preload links were present.

Fix: https://github.com/measuredco/auto-frame-component/commit/d298f1b36ed31611604ad4a9f3e5f91da61ba775
Prevent duplicate loading: https://github.com/measuredco/auto-frame-component/commit/ad6452fdac880b3dc202aeab006d48ab8328e0e7

Addresses another issue in #407 

## TODO

- [x] Publish auto-frame-component stable