### PR TITLE
perf: add API for disabling auto-scroll due to performance issues

### DIFF
--- a/apps/docs/pages/docs/api-reference/components/puck.mdx
+++ b/apps/docs/pages/docs/api-reference/components/puck.mdx
@@ -156,9 +156,14 @@ export function Editor() {
 
 #### iframe params
 
-| Param                 | Example          | Type    | Status |
-| --------------------- | ---------------- | ------- | ------ |
-| [`enabled`](#enabled) | `enabled: false` | boolean | -      |
+| Param                                     | Example                   | Type    | Status |
+| ----------------------------------------- | ------------------------- | ------- | ------ |
+| [`disableAutoScroll`](#disableautoscroll) | `disableAutoScroll: true` | boolean | -      |
+| [`enabled`](#enabled)                     | `enabled: false`          | boolean | -      |
+
+##### `disableAutoScroll`
+
+Disable auto-scroll of the iframe when the user drag an item near the edge.
 
 ##### `enabled`
 

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -368,6 +368,7 @@ export function Puck<UserConfig extends Config = Config>({
         }}
       >
         <DragDropContext
+          autoScrollerOptions={{ disabled: iframe.disableAutoScroll }}
           onDragUpdate={(update) => {
             setDraggedItem({ ...draggedItem, ...update });
             onDragStartOrUpdate(update);

--- a/packages/core/types/IframeConfig.tsx
+++ b/packages/core/types/IframeConfig.tsx
@@ -1,3 +1,4 @@
 export type IframeConfig = {
   enabled?: boolean;
+  disableAutoScroll?: boolean;
 };


### PR DESCRIPTION
Adds an API to disable auto-scroll if necessary.

Some payloads may result in choppy scrolling. This is hard to patch without rebuilding the dnd library (which is in progress). Providing an opt-out allows users to disable it if necessary in the mean-time, and will still be a valid option in the future.

Flagged this as a `perf` instead of `feat` as it's necessary to stabilise the 0.14 release.