### PR TITLE
chore: don't replace onload handler on existing style tags

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,7 +60,7 @@
     "typescript": "^4.5.2"
   },
   "dependencies": {
-    "@measured/auto-frame-component": "0.1.6-canary.ad6452f",
+    "@measured/auto-frame-component": "0.1.7",
     "@measured/dnd": "16.6.0-canary.4cba1d1",
     "deep-diff": "^1.0.2",
     "react-hotkeys-hook": "^4.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1445,10 +1445,10 @@
     "@types/mdx" "^2.0.0"
     "@types/react" ">=16"
 
-"@measured/auto-frame-component@0.1.6-canary.ad6452f":
-  version "0.1.6-canary.ad6452f"
-  resolved "https://registry.yarnpkg.com/@measured/auto-frame-component/-/auto-frame-component-0.1.6-canary.ad6452f.tgz#602abf314aac075bac62d44fecd2b4c296ca1843"
-  integrity sha512-6ewVocybiJkDBsKOqOr3X2fayVmiq9c9XrVwkxTj/jpy14EH3IStiKxRediLa26XEZdp5TMJu5jaP+djxRBAyg==
+"@measured/auto-frame-component@0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@measured/auto-frame-component/-/auto-frame-component-0.1.7.tgz#9d863feb11e3c36d67bf8bf83f66a107573957f2"
+  integrity sha512-bVaIvGFtA4kuuBxaOgtPD7S5a91aBiTPZ+VYm+URLdhKUEuhIUtATPm74NnO7M14IGteJGSGzNf28O/blXSU4g==
   dependencies:
     object-hash "^3.0.0"
     react-frame-component "5.2.6"


### PR DESCRIPTION
Closes #441, which was caused by auto-frame-component replacing the `onload` handler, which tinymce relies on. Fixed by replacing this with an event listener: https://github.com/measuredco/auto-frame-component/commit/c8e1b61caa22b445a88688bd0f5ec1833280e505

Closes #441