### PR TITLE
fix: unified type of render value with onChange value for custom field

### DIFF
--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -104,14 +104,12 @@ export type ExternalField<
   initialFilters?: Record<string, any>;
 };
 
-export type CustomField<
-  Props extends { [key: string]: any } = { [key: string]: any }
-> = BaseField & {
+export type CustomField<Props extends any = {}> = BaseField & {
   type: "custom";
   render: (props: {
     field: CustomField;
     name: string;
-    value: any;
+    value: Props;
     onChange: (value: Props) => void;
     readOnly?: boolean;
   }) => ReactElement;


### PR DESCRIPTION
Trying to pass to CustomField any type as props give error because it required an object. The documentation, otherwise, show a working example with a plain input that return a string
![with error](https://github.com/measuredco/puck/assets/19906075/339360a6-4d07-4457-bbc6-2c6ddbd7d92d)
![suggested](https://github.com/measuredco/puck/assets/19906075/3761b3d9-b50f-4fa9-ac70-9dec74cc61e2)
