### PR TITLE
Dont inline iframe styles

### DIFF
--- a/apps/demo/tsconfig/nextjs.json
+++ b/apps/demo/tsconfig/nextjs.json
@@ -14,7 +14,7 @@
     "noEmit": true,
     "resolveJsonModule": true,
     "strict": false,
-    "target": "es5"
+    "target": "es6"
   },
   "include": ["src", "next-env.d.ts"],
   "exclude": ["node_modules"]

--- a/apps/docs/tsconfig/nextjs.json
+++ b/apps/docs/tsconfig/nextjs.json
@@ -14,7 +14,7 @@
     "noEmit": true,
     "resolveJsonModule": true,
     "strict": false,
-    "target": "es5"
+    "target": "es6"
   },
   "include": ["src", "next-env.d.ts"],
   "exclude": ["node_modules"]

--- a/packages/core/components/AutoFrame/index.tsx
+++ b/packages/core/components/AutoFrame/index.tsx
@@ -1,0 +1,290 @@
+import React, { ReactNode, useEffect } from "react";
+import Frame, { FrameComponentProps, useFrame } from "react-frame-component";
+import hash from "object-hash";
+
+const styleSelector = 'style, link[as="style"], link[rel="stylesheet"]';
+
+const collectStyles = (doc: Document) => {
+  const collected: HTMLElement[] = [];
+
+  doc.head.querySelectorAll(styleSelector).forEach((style) => {
+    collected.push(style as HTMLElement);
+  });
+
+  return collected;
+};
+
+const getStyleSheet = (el: HTMLElement) => {
+  return Array.from(document.styleSheets).find((ss) => {
+    const ownerNode = ss.ownerNode as HTMLLinkElement;
+
+    return ownerNode.href === (el as HTMLLinkElement).href;
+  });
+};
+
+const getStyles = (styleSheet?: CSSStyleSheet) => {
+  if (styleSheet) {
+    try {
+      return [...styleSheet.cssRules].map((rule) => rule.cssText).join("");
+    } catch (e) {
+      console.warn(
+        "Access to stylesheet %s is denied. Ignoring…",
+        styleSheet.href
+      );
+    }
+  }
+
+  return "";
+};
+
+const defer = (fn: () => void) => setTimeout(fn, 0);
+
+const CopyHostStyles = ({
+  children,
+  debug = false,
+  onStylesLoaded = () => null,
+}: {
+  children: ReactNode;
+  debug?: boolean;
+  onStylesLoaded?: () => void;
+}) => {
+  const { document: doc, window: win } = useFrame();
+
+  useEffect(() => {
+    if (!win || !doc) {
+      return () => {};
+    }
+
+    let elements: { original: HTMLElement; mirror: HTMLElement }[] = [];
+    const hashes: Record<string, boolean> = {};
+
+    const lookupEl = (el: HTMLElement) =>
+      elements.findIndex((elementMap) => elementMap.original === el);
+
+    const mirrorEl = async (el: HTMLElement, onLoad: () => void = () => {}) => {
+      let mirror: HTMLStyleElement;
+
+      if (el.nodeName === "LINK") {
+        mirror = document.createElement("style") as HTMLStyleElement;
+        mirror.type = "text/css";
+
+        let styleSheet = getStyleSheet(el);
+
+        if (!styleSheet) {
+          await new Promise<void>((resolve) => {
+            const fn = () => {
+              resolve();
+              el.removeEventListener("load", fn);
+            };
+
+            el.addEventListener("load", fn);
+          });
+          styleSheet = getStyleSheet(el);
+        }
+
+        const styles = getStyles(styleSheet);
+
+        if (!styles) {
+          if (debug) {
+            console.warn(
+              `Tried to load styles for link element, but couldn't find them. Skipping...`
+            );
+          }
+
+          return;
+        }
+
+        mirror.innerHTML = styles;
+
+        mirror.setAttribute("data-href", el.getAttribute("href")!);
+      } else {
+        mirror = el.cloneNode(true) as HTMLStyleElement;
+      }
+
+      mirror.onload = onLoad;
+
+      return mirror;
+    };
+
+    const addEl = async (el: HTMLElement, onLoad: () => void = () => {}) => {
+      const index = lookupEl(el);
+      if (index > -1) {
+        if (debug)
+          console.log(
+            `Tried to add an element that was already mirrored. Updating instead...`
+          );
+
+        elements[index].mirror.innerText = el.innerText;
+
+        onLoad();
+
+        return;
+      }
+
+      const mirror = await mirrorEl(el, onLoad);
+
+      if (!mirror) {
+        onLoad();
+
+        return;
+      }
+
+      const elHash = hash(mirror.outerHTML);
+
+      if (hashes[elHash]) {
+        if (debug)
+          console.log(
+            `iframe already contains element that is being mirrored. Skipping...`
+          );
+
+        onLoad();
+
+        return;
+      }
+
+      hashes[elHash] = true;
+
+      mirror.onload = onLoad;
+
+      doc.head.append(mirror as HTMLElement);
+      elements.push({ original: el, mirror: mirror });
+
+      if (debug) console.log(`Added style node ${el.outerHTML}`);
+    };
+
+    const removeEl = (el: HTMLElement) => {
+      const index = lookupEl(el);
+      if (index === -1) {
+        if (debug)
+          console.log(
+            `Tried to remove an element that did not exist. Skipping...`
+          );
+
+        return;
+      }
+
+      const elHash = hash(el.outerHTML);
+
+      elements[index]?.mirror?.remove();
+      delete hashes[elHash];
+
+      if (debug) console.log(`Removed style node ${el.outerHTML}`);
+    };
+
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (mutation.type === "childList") {
+          mutation.addedNodes.forEach((node) => {
+            if (
+              node.nodeType === Node.TEXT_NODE ||
+              node.nodeType === Node.ELEMENT_NODE
+            ) {
+              const el =
+                node.nodeType === Node.TEXT_NODE
+                  ? node.parentElement
+                  : (node as HTMLElement);
+
+              if (el && el.matches(styleSelector)) {
+                defer(() => addEl(el));
+              }
+            }
+          });
+
+          mutation.removedNodes.forEach((node) => {
+            if (
+              node.nodeType === Node.TEXT_NODE ||
+              node.nodeType === Node.ELEMENT_NODE
+            ) {
+              const el =
+                node.nodeType === Node.TEXT_NODE
+                  ? node.parentElement
+                  : (node as HTMLElement);
+
+              if (el && el.matches(styleSelector)) {
+                defer(() => removeEl(el));
+              }
+            }
+          });
+        }
+      });
+    });
+
+    const parentDocument = win!.parent.document;
+
+    const collectedStyles = collectStyles(parentDocument);
+    const hrefs: string[] = [];
+
+    Promise.all(
+      collectedStyles.map(async (styleNode, i) => {
+        if (styleNode.nodeName === "LINK") {
+          const linkHref = (styleNode as HTMLLinkElement).href;
+
+          // Don't process link elements with identical hrefs more than once
+          if (hrefs.indexOf(linkHref) > -1) {
+            return;
+          }
+
+          hrefs.push(linkHref);
+        }
+
+        const mirror = await mirrorEl(styleNode);
+
+        if (!mirror) return;
+
+        elements.push({ original: styleNode, mirror });
+
+        return mirror;
+      })
+    ).then((mirrorStyles) => {
+      const filtered = mirrorStyles.filter(
+        (el) => typeof el !== "undefined"
+      ) as HTMLStyleElement[];
+
+      // Reset HTML (inside the promise) so in case running twice (i.e. for React Strict mode)
+      doc.head.innerHTML = "";
+
+      // Inject initial values in bulk
+      doc.head.append(...filtered);
+
+      observer.observe(parentDocument.head, { childList: true, subtree: true });
+
+      filtered.forEach((el) => {
+        const elHash = hash(el.outerHTML);
+
+        hashes[elHash] = true;
+      });
+
+      onStylesLoaded();
+    });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return <>{children}</>;
+};
+
+export type AutoFrameProps = FrameComponentProps & {
+  debug?: boolean;
+  onStylesLoaded?: () => void;
+};
+
+const AutoFrameComponent = React.forwardRef<HTMLIFrameElement, AutoFrameProps>(
+  function (
+    { children, debug, onStylesLoaded, ...props }: AutoFrameProps,
+    ref
+  ) {
+    return (
+      <Frame {...props} ref={ref}>
+        <CopyHostStyles debug={debug} onStylesLoaded={onStylesLoaded}>
+          {children}
+        </CopyHostStyles>
+      </Frame>
+    );
+  }
+);
+
+AutoFrameComponent.displayName = "AutoFrameComponent";
+
+export default AutoFrameComponent;

--- a/packages/core/components/Puck/components/Preview/index.tsx
+++ b/packages/core/components/Puck/components/Preview/index.tsx
@@ -2,7 +2,7 @@ import { DropZone } from "../../../DropZone";
 import { rootDroppableId } from "../../../../lib/root-droppable-id";
 import { ReactNode, useCallback, useRef } from "react";
 import { useAppContext } from "../../context";
-import AutoFrame from "@measured/auto-frame-component";
+import AutoFrame from "../../../AutoFrame";
 import styles from "./styles.module.css";
 import { getClassNameFactory } from "../../../../lib";
 import { DefaultRootProps } from "../../../../types/Config";

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,9 +60,10 @@
     "typescript": "^4.5.2"
   },
   "dependencies": {
-    "@measured/auto-frame-component": "0.1.7",
     "@measured/dnd": "16.6.0-canary.4cba1d1",
     "deep-diff": "^1.0.2",
+    "object-hash": "^3.0.0",
+    "react-frame-component": "^5.2.6",
     "react-hotkeys-hook": "^4.4.1",
     "react-spinners": "^0.13.8",
     "ua-parser-js": "^1.0.37",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1445,14 +1445,6 @@
     "@types/mdx" "^2.0.0"
     "@types/react" ">=16"
 
-"@measured/auto-frame-component@0.1.7":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@measured/auto-frame-component/-/auto-frame-component-0.1.7.tgz#9d863feb11e3c36d67bf8bf83f66a107573957f2"
-  integrity sha512-bVaIvGFtA4kuuBxaOgtPD7S5a91aBiTPZ+VYm+URLdhKUEuhIUtATPm74NnO7M14IGteJGSGzNf28O/blXSU4g==
-  dependencies:
-    object-hash "^3.0.0"
-    react-frame-component "5.2.6"
-
 "@measured/dnd@16.6.0-canary.4cba1d1":
   version "16.6.0-canary.4cba1d1"
   resolved "https://registry.yarnpkg.com/@measured/dnd/-/dnd-16.6.0-canary.4cba1d1.tgz#47096fc962a9f69411e66e30d1c49b1ab4eb4e44"
@@ -11108,7 +11100,7 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
-react-frame-component@5.2.6:
+react-frame-component@^5.2.6:
   version "5.2.6"
   resolved "https://registry.yarnpkg.com/react-frame-component/-/react-frame-component-5.2.6.tgz#0d9991d251ff1f7177479d8f370deea06b824b79"
   integrity sha512-CwkEM5VSt6nFwZ1Op8hi3JB5rPseZlmnp5CGiismVTauE6S4Jsc4TNMlT0O7Cts4WgIC3ZBAQ2p1Mm9XgLbj+w==


### PR DESCRIPTION
Inlining link stylesheets has unexpected side effects as browsers serialize the styles. This can cause styles to become invalid in certain circumstanecs, such as those outline in https://github.com/measuredco/puck/issues/454.

This fix removes inlining of link styles, which may come at a performance cost. However, inlining was implemented before further performance optimisations were made, so the impact may be negliable. We should publish a canary to assess the impact.

09ca807b006c74a93325e3a7cad1b6cd60c45fba is the commit containing the changes. The initial commit just brings the auto-frame-component inline into the Puck repo, as it awkward to continuously iterate it externally.

Closes #454