### PR TITLE
Introducing field type of Checkbox

### DIFF
--- a/apps/demo/config/blocks/Hero/index.tsx
+++ b/apps/demo/config/blocks/Hero/index.tsx
@@ -10,6 +10,7 @@ import { quotes } from "./quotes";
 const getClassName = getClassNameFactory("Hero", styles);
 
 export type HeroProps = {
+  hasBackgroundColor?: boolean;
   quote?: { index: number; label: string };
   title: string;
   description: string;
@@ -113,6 +114,11 @@ export const Hero: ComponentConfig<HeroProps> = {
         { label: "center", value: "center" },
       ],
     },
+    hasBackgroundColor: {
+      type: "checkbox",
+      checkboxLabel: 'Apply background color to the section',
+      label: 'Background color'
+    },
     image: {
       type: "object",
       objectFields: {
@@ -164,18 +170,22 @@ export const Hero: ComponentConfig<HeroProps> = {
       readOnly: { title: true, description: true },
     };
   },
-  render: ({ align, title, description, buttons, padding, image }) => {
+  render: ({ align, title, description, buttons, padding, image, hasBackgroundColor }) => {
     // Empty state allows us to test that components support hooks
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [_] = useState(0);
 
     return (
       <Section
+        style={{
+          backgroundColor: hasBackgroundColor ? "var(--puck-color-azure-09)" : "",
+        }}
         padding={padding}
         className={getClassName({
           left: align === "left",
           center: align === "center",
           hasImageBackground: image?.mode === "background",
+          hasBackgroundColor
         })}
       >
         {image?.mode === "background" && (

--- a/apps/demo/config/blocks/Hero/styles.module.css
+++ b/apps/demo/config/blocks/Hero/styles.module.css
@@ -72,6 +72,24 @@
   left: 0;
 }
 
+.Hero--hasBackgroundColor .Hero-imageOverlay {
+  background-image: linear-gradient(
+    -90deg,
+    rgba(255, 255, 255, 0) 0%,
+    var(--puck-color-azure-09) 80%
+  );
+}
+
+@media (min-width: 768px) {
+  .Hero--hasBackgroundColor.Hero--left .Hero-imageOverlay {
+    background-image: linear-gradient(
+      -90deg,
+      rgba(255, 255, 255, 0) 0%,
+      var(--puck-color-azure-09) 70%
+    );
+  }
+}
+
 @media (min-width: 768px) {
   .Hero--left .Hero-imageOverlay {
     background-image: linear-gradient(

--- a/apps/docs/pages/docs/api-reference/fields.mdx
+++ b/apps/docs/pages/docs/api-reference/fields.mdx
@@ -9,6 +9,7 @@ A field represents a user input shown in the Puck interface.
 - [Number](fields/number) - Render a `number` input.
 - [Object](fields/object) - Render a subset of fields.
 - [Radio](fields/radio) - Render a `radio` input with a list of options.
+- [Checkbox](fields/checkbox) - Render a `checkbox` input.
 - [Select](fields/select) - Render a `select` input with a list of options.
 - [Text](fields/text) - Render a `text` input.
 - [Textarea](fields/textarea) - Render a `textarea` input.

--- a/apps/docs/pages/docs/api-reference/fields/checkbox.mdx
+++ b/apps/docs/pages/docs/api-reference/fields/checkbox.mdx
@@ -8,15 +8,15 @@ Render a `checkbox` input with a list of options. Extends [Base](base).
   label="Example"
   componentConfig={{
     fields: {
-      textAlign: {
+      textAlignLeft: {
         type: "checkbox",
       },
     },
     defaultProps: {
-      textAlign: "left",
+      textAlignLeft: true,
     },
-    render: ({ textAlign }) => {
-      return <p style={{ textAlign, margin: 0 }}>Hello, world</p>;
+    render: ({ textAlignLeft }) => {
+      return <p style={{ textAlign: textAlignLeft ? 'left' : 'right', margin: 0 }}>Hello, world</p>;
     },
   }}
 />
@@ -26,16 +26,15 @@ const config = {
   components: {
     Example: {
       fields: {
-        hasBackground: {
+        textAlignLeft: {
           type: "checkbox",
-          label: "Apply background color",
         },
       },
       defaultProps: {
-        hasBackground: "left",
+        textAlignLeft: true,
       },
-      render: ({ hasBackground }) => {
-        return <p style={{ backgroundColor: hasBackground ? 'red' : 'transparent' }}>Hello, world</p>;
+      render: ({ textAlignLeft }) => {
+        return <p style={{ textAlign: textAlignLeft ? 'left' : 'right', margin: 0 }}>Hello, world</p>;
       },
     },
   },
@@ -47,6 +46,7 @@ const config = {
 | Param                 | Example                                               | Type       | Status   |
 | --------------------- | ----------------------------------------------------- | ---------- | -------- |
 | [`type`](#type)       | `type: "checkbox"`                                    | "checkbox" | Required |
+| [`checkboxLabel`](#checkboxLabel)   | `checkboxLabel: "Apply Background color"`        | string   | -        |
 
 ## Required params
 
@@ -62,6 +62,27 @@ const config = {
         hasBackground: {
           type: "checkbox",
           label: "Apply background color",
+        },
+      },
+      // ...
+    },
+  },
+};
+```
+
+### `checkboxLabel`
+
+The label to sit alongside the checkbox field.
+
+```tsx {6} copy
+const config = {
+  components: {
+    Example: {
+      fields: {
+        textAlign: {
+          type: "checkbox",
+          label: "Text Align",
+          checkboxLabel: "Align text left",
         },
       },
       // ...

--- a/apps/docs/pages/docs/api-reference/fields/checkbox.mdx
+++ b/apps/docs/pages/docs/api-reference/fields/checkbox.mdx
@@ -1,0 +1,71 @@
+import { ConfigPreview } from "@/docs/components/Preview";
+
+# Checkbox
+
+Render a `checkbox` input with a list of options. Extends [Base](base).
+
+<ConfigPreview
+  label="Example"
+  componentConfig={{
+    fields: {
+      textAlign: {
+        type: "checkbox",
+      },
+    },
+    defaultProps: {
+      textAlign: "left",
+    },
+    render: ({ textAlign }) => {
+      return <p style={{ textAlign, margin: 0 }}>Hello, world</p>;
+    },
+  }}
+/>
+
+```tsx {5-11} copy
+const config = {
+  components: {
+    Example: {
+      fields: {
+        hasBackground: {
+          type: "checkbox",
+          label: "Apply background color",
+        },
+      },
+      defaultProps: {
+        hasBackground: "left",
+      },
+      render: ({ hasBackground }) => {
+        return <p style={{ backgroundColor: hasBackground ? 'red' : 'transparent' }}>Hello, world</p>;
+      },
+    },
+  },
+};
+```
+
+## Params
+
+| Param                 | Example                                               | Type       | Status   |
+| --------------------- | ----------------------------------------------------- | ---------- | -------- |
+| [`type`](#type)       | `type: "checkbox"`                                    | "checkbox" | Required |
+
+## Required params
+
+### `type`
+
+The type of the field. Must be `"checkbox"` for Checkbox fields.
+
+```tsx {6} copy
+const config = {
+  components: {
+    Example: {
+      fields: {
+        hasBackground: {
+          type: "checkbox",
+          label: "Apply background color",
+        },
+      },
+      // ...
+    },
+  },
+};
+```

--- a/packages/core/components/InputOrGroup/fields/CheckboxField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/CheckboxField/index.tsx
@@ -1,0 +1,49 @@
+import getClassNameFactory from "../../../../lib/get-class-name-factory";
+import styles from "../../styles.module.css";
+import { CheckSquare, ToggleLeft, ToggleRight } from "lucide-react";
+import { FieldLabelInternal, type InputProps } from "../..";
+
+const getClassName = getClassNameFactory("Input", styles);
+
+export const CheckboxField = ({
+  field,
+  onChange,
+  readOnly,
+  value,
+  name,
+  id,
+  label,
+}: InputProps) => {
+  if (field.type !== "checkbox") {
+    return null;
+  }
+
+  return (
+    <FieldLabelInternal
+      icon={<CheckSquare size={16} />}
+      label={label || value || name}
+      readOnly={readOnly}
+      el="div"
+    >
+      <div className={getClassName("checkboxGroupItems")} id={id}>
+        <label
+          className={getClassName("checkbox")}
+        >
+          <input
+            type="checkbox"
+            className={getClassName("checkboxInput")}
+            name={name}
+            onChange={(e) => {
+              onChange(e.currentTarget.checked);
+            }}
+            disabled={readOnly}
+            checked={value}
+          />
+          <div className={getClassName("checkboxInner")}>
+            {value === true ? <ToggleRight size={24} /> : <ToggleLeft size={24} />}<span>{field.checkboxLabel || label}</span>
+          </div>
+        </label>
+      </div>
+    </FieldLabelInternal>
+  );
+};

--- a/packages/core/components/InputOrGroup/fields/CheckboxField/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/CheckboxField/index.tsx
@@ -21,7 +21,7 @@ export const CheckboxField = ({
   return (
     <FieldLabelInternal
       icon={<CheckSquare size={16} />}
-      label={label || value || name}
+      label={label || name}
       readOnly={readOnly}
       el="div"
     >
@@ -40,7 +40,7 @@ export const CheckboxField = ({
             checked={value}
           />
           <div className={getClassName("checkboxInner")}>
-            {value === true ? <ToggleRight size={24} /> : <ToggleLeft size={24} />}<span>{field.checkboxLabel || label}</span>
+            {value === true ? <ToggleRight size={24} /> : <ToggleLeft size={24} />}<span>{field.checkboxLabel || label || name}</span>
           </div>
         </label>
       </div>

--- a/packages/core/components/InputOrGroup/fields/index.tsx
+++ b/packages/core/components/InputOrGroup/fields/index.tsx
@@ -4,3 +4,4 @@ export * from "./ExternalField";
 export * from "./RadioField";
 export * from "./SelectField";
 export * from "./TextareaField";
+export * from './CheckboxField';

--- a/packages/core/components/InputOrGroup/index.tsx
+++ b/packages/core/components/InputOrGroup/index.tsx
@@ -12,6 +12,7 @@ import {
 } from "react";
 import {
   RadioField,
+  CheckboxField,
   SelectField,
   ExternalField,
   ArrayField,
@@ -155,6 +156,7 @@ export const InputOrGroup = ({ onChange, ...props }: InputProps) => {
     select: SelectField,
     textarea: TextareaField,
     radio: RadioField,
+    checkbox: CheckboxField,
     text: DefaultField,
     number: DefaultField,
   };
@@ -167,6 +169,7 @@ export const InputOrGroup = ({ onChange, ...props }: InputProps) => {
     select: overrides.fieldTypes?.select || defaultFields.select,
     textarea: overrides.fieldTypes?.textarea || defaultFields.textarea,
     radio: overrides.fieldTypes?.radio || defaultFields.radio,
+    checkbox: overrides.fieldTypes?.checkbox || defaultFields.checkbox,
     text: overrides.fieldTypes?.text || defaultFields.text,
     number: overrides.fieldTypes?.number || defaultFields.number,
   };

--- a/packages/core/components/InputOrGroup/styles.module.css
+++ b/packages/core/components/InputOrGroup/styles.module.css
@@ -181,6 +181,74 @@ select.Input-input {
   width: 1px;
 }
 
+.Input-checkboxGroupItems {
+  display: flex;
+  border: 1px solid var(--puck-color-grey-09);
+  border-radius: 4px;
+  flex-wrap: wrap;
+  overflow: hidden;
+}
+
+.Input-checkbox {
+  flex-grow: 1;
+}
+
+.Input-checkboxInner {
+  background-color: var(--puck-color-white);
+  color: var(--puck-color-grey-04);
+  cursor: pointer;
+  font-size: var(--puck-font-size-xxxs);
+  padding: 8px 12px;
+  text-align: center;
+  transition: background-color 50ms ease-in;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+.Input-checkboxInner span {
+  margin-left: 4px;
+  text-align: left;
+}
+
+.Input-checkbox:has(:focus-visible) {
+  outline: 2px solid var(--puck-color-azure-05);
+  outline-offset: 2px;
+  position: relative;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .Input-checkboxInner:hover {
+    background-color: var(--puck-color-azure-12);
+    transition: none;
+  }
+}
+
+.Input--readOnly .Input-checkboxInner {
+  background-color: var(--puck-color-white);
+  color: var(--puck-color-grey-04);
+  cursor: default;
+}
+
+.Input-checkbox .Input-checkboxInput:checked ~ .Input-checkboxInner {
+  background-color: var(--puck-color-azure-11);
+  color: var(--puck-color-azure-04);
+}
+
+.Input--readOnly .Input-checkboxInput:checked ~ .Input-checkboxInner {
+  background-color: var(--puck-color-grey-11);
+  color: var(--puck-color-grey-04);
+}
+
+.Input-checkbox .Input-checkboxInput {
+  clip: rect(0 0 0 0);
+  clip-path: inset(100%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
 textarea.Input-input {
   margin-bottom: -4px; /* Remove strange bottom border */
 }

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -42,6 +42,11 @@ export type RadioField = BaseField & {
   options: FieldOptions;
 };
 
+export type CheckboxField = BaseField & {
+  type: "checkbox";
+  checkboxLabel?: string;
+};
+
 export type ArrayField<
   Props extends { [key: string]: any } = { [key: string]: any }
 > = BaseField & {
@@ -125,6 +130,7 @@ export type Field<
   | TextareaField
   | SelectField
   | RadioField
+  | CheckboxField
   | ArrayField<Props>
   | ObjectField<Props>
   | ExternalField<Props>


### PR DESCRIPTION
This PR introduces a new field type, "checkbox", to the Puck editor. Previously, there was no prebuilt field that allowed users to save a boolean value. As a basic primitive input type, this was an essential addition, similar to other field types like a radio button.

Key Changes:

- Checkbox Field Addition: Implemented a new checkbox field type that can store boolean values.
- Documentation and Examples: Added documentation and provided examples showing how to apply a label to the checkbox. This allows users to display a different title for the field and a label for the checkbox itself, enhancing flexibility and usability.

I welcome all feedback on usability and integration aspects and am ready to make any necessary adjustments based on the review.