### PR TITLE
Add condition to fields

### DIFF
--- a/packages/core/components/Puck/components/Fields/index.tsx
+++ b/packages/core/components/Puck/components/Fields/index.tsx
@@ -184,6 +184,8 @@ export const Fields = () => {
 
           if (!field?.type) return null;
 
+          if (field.condition && selectedItem && !field.condition(selectedItem?.props)) return null;
+
           const onChange = (value: any, updatedUi?: Partial<UiState>) => {
             let currentProps;
 

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -17,6 +17,7 @@ type FieldOptions = Array<FieldOption> | ReadonlyArray<FieldOption>;
 
 export type BaseField = {
   label?: string;
+  condition?: (props: any) => boolean;
 };
 
 export type TextField = BaseField & {


### PR DESCRIPTION
To configure some complexer components, it would be nice to render some fields only when a condition is met.

```
...
    Button: {
      render: (props) => {
         ...
      },
      fields: {
        type: {
          type: 'radio',
          label: 'Type',
          options: [
            { label: 'Text', value: 'text' },
            { label: 'Icon', value: 'icon' },
            { label: 'Icon and Text', value: 'icon-text'}
          ]
        },
        text: {
          type: 'text',
          label: 'Text',
          condition: ({ type }) => type !== 'icon'
        },
        icon: {
          type: 'text',
          label: 'Icon',
          condition: ({ type }) => type !== 'text'
        }
      },
      defaultProps: {
        type: 'text',
        text: 'Button',
        icon: 'arrow-right'
      }
    }
...
```
