### PR TITLE
Refactor heading outline styles

### DIFF
--- a/packages/plugin-heading-analyzer/src/HeadingAnalyzer.module.css
+++ b/packages/plugin-heading-analyzer/src/HeadingAnalyzer.module.css
@@ -1,0 +1,3 @@
+.HeadingAnalyzerItem--missing {
+  color: var(--puck-color-red-04);
+}

--- a/packages/plugin-heading-analyzer/src/HeadingAnalyzer.module.css
+++ b/packages/plugin-heading-analyzer/src/HeadingAnalyzer.module.css
@@ -1,5 +1,13 @@
+.HeadingAnalyzer {
+  display: block;
+}
+
 .HeadingAnalyzer-cssWarning {
   display: none !important;
+}
+
+.HeadingAnalyzerItem {
+  display: inline;
 }
 
 .HeadingAnalyzerItem--missing {

--- a/packages/plugin-heading-analyzer/src/HeadingAnalyzer.module.css
+++ b/packages/plugin-heading-analyzer/src/HeadingAnalyzer.module.css
@@ -1,3 +1,7 @@
+.HeadingAnalyzer-cssWarning {
+  display: none !important;
+}
+
 .HeadingAnalyzerItem--missing {
   color: var(--puck-color-red-04);
 }

--- a/packages/plugin-heading-analyzer/src/HeadingAnalyzer.tsx
+++ b/packages/plugin-heading-analyzer/src/HeadingAnalyzer.tsx
@@ -12,6 +12,7 @@ import { getFrame } from "@/core/lib/get-frame";
 
 import { getClassNameFactory } from "@/core/lib";
 
+const getClassName = getClassNameFactory("HeadingAnalyzer", styles);
 const getClassNameItem = getClassNameFactory("HeadingAnalyzerItem", styles);
 
 import ReactFromJSON from "react-from-json";
@@ -116,7 +117,22 @@ export const HeadingAnalyzer = () => {
   }, [appState.data]);
 
   return (
-    <>
+    <div className={getClassName()}>
+      <small
+        className={getClassName("cssWarning")}
+        style={{
+          color: "var(--puck-color-red-04)",
+          display: "block",
+          marginBottom: 16,
+        }}
+      >
+        Heading analyzer styles not loaded. Please review the{" "}
+        <a href="https://github.com/measuredco/puck/blob/main/packages/plugin-heading-analyzer/README.md">
+          README
+        </a>
+        .
+      </small>
+
       {hierarchy.length === 0 && <div>No headings.</div>}
 
       <OutlineList>
@@ -192,7 +208,7 @@ export const HeadingAnalyzer = () => {
           }}
         />
       </OutlineList>
-    </>
+    </div>
   );
 };
 

--- a/packages/plugin-heading-analyzer/src/HeadingAnalyzer.tsx
+++ b/packages/plugin-heading-analyzer/src/HeadingAnalyzer.tsx
@@ -1,5 +1,7 @@
 import { ReactElement, useEffect, useState } from "react";
 
+import styles from "./HeadingAnalyzer.module.css";
+
 import { usePuck } from "@measured/puck";
 import { Plugin } from "@/core/types/Plugin";
 import { SidebarSection } from "@/core/components/SidebarSection";
@@ -7,6 +9,10 @@ import { OutlineList } from "@/core/components/OutlineList";
 
 import { scrollIntoView } from "@/core/lib/scroll-into-view";
 import { getFrame } from "@/core/lib/get-frame";
+
+import { getClassNameFactory } from "@/core/lib";
+
+const getClassNameItem = getClassNameFactory("HeadingAnalyzerItem", styles);
 
 import ReactFromJSON from "react-from-json";
 
@@ -124,6 +130,7 @@ export const HeadingAnalyzer = () => {
               <OutlineList.Item>
                 <OutlineList.Clickable>
                   <small
+                    className={getClassNameItem({ missing: props.missing })}
                     onClick={
                       typeof props.analyzeId == "undefined"
                         ? undefined
@@ -155,13 +162,13 @@ export const HeadingAnalyzer = () => {
                     }
                   >
                     {props.missing ? (
-                      <span style={{ color: "var(--puck-color-red-04)" }}>
+                      <>
                         <b>H{props.rank}</b>: Missing
-                      </span>
+                      </>
                     ) : (
-                      <span>
+                      <>
                         <b>H{props.rank}</b>: {props.text}
-                      </span>
+                      </>
                     )}
                   </small>
                 </OutlineList.Clickable>


### PR DESCRIPTION
Refactor heading analyzer to use CSS modules instead of inline styles, and show a warning if the user doesn't have the CSS styles loaded.