### PR TITLE
Streamline history APIs and docs

### DIFF
--- a/apps/docs/pages/docs/api-reference/app-state.mdx
+++ b/apps/docs/pages/docs/api-reference/app-state.mdx
@@ -14,45 +14,13 @@ The current state of the Puck editor interface.
 
 | Param                                           | Example                                               | Type    |
 | ----------------------------------------------- | ----------------------------------------------------- | ------- |
-| [`leftSideBarVisible`](#uileftsidebarvisible)   | `false`                                               | Boolean |
-| [`rightSideBarVisible`](#uirightsidebarvisible) | `false`                                               | Boolean |
-| [`itemSelector`](#uiitemselector)               | `{ index: 0, zone: "my-content" }`                    | Object  |
-| [`isDragging`](#isdragging)                     | `false`                                               | Boolean |
 | [`arrayState`](#uiarraystate)                   | `{}`                                                  | Object  |
 | [`componentList`](#uicomponentlist)             | `{ typography: { components: [ "HeadingBlock" ] } }`  | Object  |
+| [`isDragging`](#isdragging)                     | `false`                                               | Boolean |
+| [`itemSelector`](#uiitemselector)               | `{ index: 0, zone: "my-content" }`                    | Object  |
+| [`leftSideBarVisible`](#uileftsidebarvisible)   | `false`                                               | Boolean |
+| [`rightSideBarVisible`](#uirightsidebarvisible) | `false`                                               | Boolean |
 | [`viewports`](#uiviewports)                     | `{ controlsVisible: true, current: {}, options: [] }` | Object  |
-
----
-
-### `ui.leftSideBarVisible`
-
-Whether or not the left side bar is visible.
-
----
-
-### `ui.rightSideBarVisible`
-
-Whether or not the right side bar is visible.
-
----
-
-### `ui.itemSelector`
-
-An object describing which item is selected.
-
-#### `ui.itemSelector.index`
-
-The index of the item within the zone.
-
-#### `ui.itemSelector.zone`
-
-The zone that the item is defined within. **Defaults to [main content zone](/docs/api-reference/data#content).**
-
----
-
-### `ui.isDragging`
-
-A boolean stating whether or not the user is currently dragging a component.
 
 ---
 
@@ -81,6 +49,38 @@ Whether or not the category is visible in the side bar
 #### `ui.componentList[key].expanded`
 
 Whether or not the category is expanded in the side bar
+
+---
+
+### `ui.isDragging`
+
+A boolean stating whether or not the user is currently dragging a component.
+
+---
+
+### `ui.itemSelector`
+
+An object describing which item is selected.
+
+#### `ui.itemSelector.index`
+
+The index of the item within the zone.
+
+#### `ui.itemSelector.zone`
+
+The zone that the item is defined within. **Defaults to [main content zone](/docs/api-reference/data#content).**
+
+---
+
+### `ui.leftSideBarVisible`
+
+Whether or not the left side bar is visible.
+
+---
+
+### `ui.rightSideBarVisible`
+
+Whether or not the right side bar is visible.
 
 ---
 

--- a/apps/docs/pages/docs/api-reference/components/puck.mdx
+++ b/apps/docs/pages/docs/api-reference/components/puck.mdx
@@ -25,22 +25,22 @@ export function Editor() {
 
 ## Props
 
-| Param                                   | Example                                           | Type                                               | Status       |
-| --------------------------------------- | ------------------------------------------------- | -------------------------------------------------- | ------------ |
-| [`config`](#config)                     | `config: { components: {} }`                      | [Config](/docs/api-reference/configuration/config) | Required     |
-| [`data`](#data)                         | `data: {}`                                        | [Data](/docs/api-reference/data)                   | Required     |
-| [`dnd`](#dnd)                           | `dnd: {}`                                         | [DndConfig](#dnd-params)                           | -            |
-| [`children`](#children)                 | `children: <Puck.Preview />`                      | ReactNode                                          | -            |
-| [`headerPath`](#headerpath)             | `headerPath: "/my-page"`                          | String                                             | -            |
-| [`headerTitle`](#headertitle)           | `headerTitle: "My Page"`                          | String                                             | -            |
-| [`iframe`](#iframe)                     | `iframe: {}`                                      | [IframeConfig](#iframe-params)                     | -            |
-| [`initialHistories`](#initialHistories) | `initialHistories: [{ histories: [], index: 0 }]` | [Viewport\[\]](#initialHistories-params)           | -            |
-| [`onChange()`](#onchangedata)           | `onChange: (data) => {}`                          | Function                                           | -            |
-| [`onPublish()`](#onpublishdata)         | `onPublish: async (data) => {}`                   | Function                                           | -            |
-| [`overrides`](#overrides)               | `overrides: { header: () => <div /> }`            | [Overrides](/docs/api-reference/overrides)         | Experimental |
-| [`plugins`](#plugins)                   | `plugins: [myPlugin]`                             | [Plugin\[\]](/docs/api-reference/plugin)           | Experimental |
-| [`ui`](#ui)                             | `ui: {leftSideBarVisible: false}`                 | [AppState.ui](/docs/api-reference/app-state#ui)    | -            |
-| [`viewports`](#viewports)               | `viewports: [{ width: 1440 }]`                    | [Viewport\[\]](#viewport-params)                   | -            |
+| Param                               | Example                                | Type                                               | Status       |
+| ----------------------------------- | -------------------------------------- | -------------------------------------------------- | ------------ |
+| [`config`](#config)                 | `config: { components: {} }`           | [Config](/docs/api-reference/configuration/config) | Required     |
+| [`data`](#data)                     | `data: {}`                             | [Data](/docs/api-reference/data)                   | Required     |
+| [`dnd`](#dnd)                       | `dnd: {}`                              | [DndConfig](#dnd-params)                           | -            |
+| [`children`](#children)             | `children: <Puck.Preview />`           | ReactNode                                          | -            |
+| [`headerPath`](#headerpath)         | `headerPath: "/my-page"`               | String                                             | -            |
+| [`headerTitle`](#headertitle)       | `headerTitle: "My Page"`               | String                                             | -            |
+| [`iframe`](#iframe)                 | `iframe: {}`                           | [IframeConfig](#iframe-params)                     | -            |
+| [`initialHistory`](#initialhistory) | `initialHistory: {}`                   | [InitialHistory](#initialhistory-params)           | -            |
+| [`onChange()`](#onchangedata)       | `onChange: (data) => {}`               | Function                                           | -            |
+| [`onPublish()`](#onpublishdata)     | `onPublish: async (data) => {}`        | Function                                           | -            |
+| [`overrides`](#overrides)           | `overrides: { header: () => <div /> }` | [Overrides](/docs/api-reference/overrides)         | Experimental |
+| [`plugins`](#plugins)               | `plugins: [myPlugin]`                  | [Plugin\[\]](/docs/api-reference/plugin)           | Experimental |
+| [`ui`](#ui)                         | `ui: {leftSideBarVisible: false}`      | [AppState.ui](/docs/api-reference/app-state#ui)    | -            |
+| [`viewports`](#viewports)           | `viewports: [{ width: 1440 }]`         | [Viewport\[\]](#viewport-params)                   | -            |
 
 ## Required props
 
@@ -182,16 +182,16 @@ Render the Puck preview within iframe. Defaults to `true`.
 
 Disabling iframes will also disable [viewports](#viewports).
 
-### `initialHistories`
+### `initialHistory`
 
-Sets the undo/redo Puck history state.
+Sets the undo/redo Puck history state when using the `usePuck` [history API](/docs/api-reference/functions/use-puck#history).
 
-#### InitialHistories params
+#### `initialHistory` params
 
-| Param                     | Example         | Type    | Status   |
-| ------------------------- | --------------- | ------- | -------- |
-| [`histories`](#histories) | `histories: []` | History | Required |
-| [`index`](#index)         | `index: 2`      | number  | Required |
+| Param                     | Example         | Type                                                                   | Status   |
+| ------------------------- | --------------- | ---------------------------------------------------------------------- | -------- |
+| [`histories`](#histories) | `histories: []` | [History](/docs/api-reference/functions/use-puck#historyhistories)\[\] | Required |
+| [`index`](#index)         | `index: 2`      | Number                                                                 | Required |
 
 ##### `histories`
 

--- a/apps/docs/pages/docs/api-reference/functions/use-puck.mdx
+++ b/apps/docs/pages/docs/api-reference/functions/use-puck.mdx
@@ -32,6 +32,7 @@ export function Editor() {
 | ------------------------------- | ------------------------------------------------ | --------------------------------------------------- |
 | [`appState`](#appstate)         | `{ data: {}, ui: {} }`                           | [AppState](/docs/api-reference/app-state)           |
 | [`dispatch`](#dispatch)         | `(action: PuckAction) => void`                   | Function                                            |
+| [`history`](#history)           | `{}`                                             | Object                                              |
 | [`selectedItem`](#selecteditem) | `{ type: "Heading", props: {id: "my-heading"} }` | [ComponentData](/docs/api-reference/data#content-1) |
 
 ### `appState`
@@ -55,6 +56,58 @@ dispatch({
   },
 });
 ```
+
+### `history`
+
+The `history` API provides programmatic access to the undo/redo [AppState](/docs/api-reference/app-state) history.
+
+| Param                            | Example                        | Type                           |
+| -------------------------------- | ------------------------------ | ------------------------------ |
+| [`back`](#historyback)           | `() => void`                   | Function                       |
+| [`forward`](#historyforward)     | `() => void`                   | Function                       |
+| [`hasPast`](#historyhaspast)     | `true`                         | Boolean                        |
+| [`hasFuture`](#historyhasfuture) | `false`                        | Boolean                        |
+| [`histories`](#historyhistories) | `[{ id: 'abc123', data: {} }]` | [History](#history-params)\[\] |
+| [`index`](#historyindex)         | `5`                            | Number                         |
+
+#### `history.back`
+
+A function to move the app state back through the [histories](#historyhistories).
+
+#### `history.forward`
+
+A function to move the app state forward through the [histories](#historyhistories).
+
+#### `history.hasPast`
+
+A boolean describing whether or not the present app state has past history items.
+
+#### `history.hasFuture`
+
+A boolean describing whether or not the present app state has future history items.
+
+#### `history.histories`
+
+An array describing the recorded history as `History` objects.
+
+##### `History` params
+
+| Param  | Example  | Type                                      |
+| ------ | -------- | ----------------------------------------- |
+| `data` | `{}`     | [AppState](/docs/api-reference/app-state) |
+| `id`   | `abc123` | String                                    |
+
+###### `data`
+
+The [app state](/docs/api-reference/app-state) payload for this history entry.
+
+###### `id`
+
+A unique ID for this history entry.
+
+#### `history.index`
+
+The index of the currently selected history in [`history.histories`](#historyhistories)
 
 ### `selectedItem`
 

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -69,7 +69,7 @@ export function Puck<UserConfig extends Config = Config>({
     enabled: true,
   },
   dnd,
-  initialHistories,
+  initialHistory,
 }: {
   children?: ReactNode;
   config: UserConfig;
@@ -95,12 +95,12 @@ export function Puck<UserConfig extends Config = Config>({
   dnd?: {
     disableAutoScroll?: boolean;
   };
-  initialHistories?: {
+  initialHistory?: {
     histories: History<any>[];
     index: number;
   };
 }) {
-  const historyStore = useHistoryStore(initialHistories);
+  const historyStore = useHistoryStore(initialHistory);
 
   const [reducer] = useState(() =>
     createReducer<UserConfig>({ config, record: historyStore.record })

--- a/packages/core/lib/use-history-store.ts
+++ b/packages/core/lib/use-history-store.ts
@@ -25,16 +25,16 @@ export type HistoryStore<D = any> = {
 
 const EMPTY_HISTORY_INDEX = -1;
 
-export function useHistoryStore<D = any>(initialHistories?: {
+export function useHistoryStore<D = any>(initialHistory?: {
   histories: History<any>[];
   index: number;
 }): HistoryStore<D> {
   const [histories, setHistories] = useState<History<D>[]>(
-    initialHistories?.histories ?? []
+    initialHistory?.histories ?? []
   );
 
   const [index, setIndex] = useState(
-    initialHistories?.index ?? EMPTY_HISTORY_INDEX
+    initialHistory?.index ?? EMPTY_HISTORY_INDEX
   );
 
   const hasPast = index > EMPTY_HISTORY_INDEX;

--- a/packages/core/lib/use-history-store.ts
+++ b/packages/core/lib/use-history-store.ts
@@ -8,16 +8,19 @@ export type History<D = any> = {
 };
 
 export type HistoryStore<D = any> = {
+  // Exposed via usePuck
   index: number;
-  currentHistory: History;
   hasPast: boolean;
   hasFuture: boolean;
+  histories: History<D>[];
+
+  // Internal
   record: (data: D) => void;
   back: VoidFunction;
   forward: VoidFunction;
+  currentHistory: History;
   nextHistory: History<D> | null;
   prevHistory: History<D> | null;
-  histories: History<D>[];
 };
 
 const EMPTY_HISTORY_INDEX = -1;

--- a/packages/core/lib/use-puck.ts
+++ b/packages/core/lib/use-puck.ts
@@ -13,7 +13,15 @@ export const usePuck = () => {
     appState,
     config,
     dispatch,
-    history,
+    history: {
+      back: history.back!,
+      forward: history.forward!,
+      hasPast: history.historyStore!.hasPast,
+      hasFuture: history.historyStore!.hasFuture,
+      histories: history.historyStore!.histories,
+      index: history.historyStore!.index,
+      historyStore: history.historyStore,
+    },
     selectedItem: selectedItem || null,
   };
 };


### PR DESCRIPTION
Streamline history APIs and docs, including:

1. Exposing more useful props under the `usePuck` history API, so the user doesn't need to reach into `history.historyStore`
2. Documenting the `usePuck` history API, which should have been done when the feature was implemented
3. Renaming the new `initialHistories` API to `initialHistory` to match the usePuck history API
4. Make references from the new `initialHistory` API to the usePuck `histories` API

Tagging @mkilpatrick for review since you implemented `initialHistories` in #505.