### PR TITLE
Resolve default props

### DIFF
--- a/apps/demo/config/blocks/Hero/index.tsx
+++ b/apps/demo/config/blocks/Hero/index.tsx
@@ -136,6 +136,20 @@ export const Hero: ComponentConfig<HeroProps> = {
     padding: "64px",
   },
   /**
+   * The resolveDefaultProps method allows the user to set component data asynchronously.
+   *
+   * It is called when a new component is dragged down.
+   *
+   * For example, requesting a third-party API for the default content.
+  */
+  resolveDefaultProps: async (defaultProps) => {
+    // Simulate a delay
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    defaultProps.align = "center";
+    return defaultProps
+  },
+  /**
    * The resolveData method allows us to modify component data after being
    * set by the user.
    *

--- a/apps/docs/pages/docs/api-reference/configuration/component-config.mdx
+++ b/apps/docs/pages/docs/api-reference/configuration/component-config.mdx
@@ -26,14 +26,15 @@ const config = {
 
 ## Params
 
-| Param                                          | Example                                         | Type     | Status   |
-| ---------------------------------------------- | ----------------------------------------------- | -------- | -------- |
-| [`render()`](#renderprops)                     | `render: () => <div />`                         | Function | Required |
-| [`fields`](#fields)                            | `fields: { title: { type: "text"} }`            | Object   | -        |
-| [`defaultProps`](#defaultprops)                | `defaultProps: { title: "Hello, world" }`       | Object   | -        |
-| [`label`](#label)                              | `label: "Heading Block"`                        | String   | -        |
-| [`resolveData()`](#resolvedatadata-params)     | `resolveData: async ({ props }) => ({ props })` | Object   | -        |
-| [`resolveFields()`](#resolvefieldsdata-params) | `resolveFields: async ({ props }) => ({})}`     | Object   | -        |
+| Param                                                       | Example                                          | Type     | Status   |
+| ----------------------------------------------------------- | ------------------------------------------------ | -------- | -------- |
+| [`render()`](#renderprops)                                  | `render: () => <div />`                          | Function | Required |
+| [`fields`](#fields)                                         | `fields: { title: { type: "text"} }`             | Object   | -        |
+| [`defaultProps`](#defaultprops)                             | `defaultProps: { title: "Hello, world" }`        | Object   | -        |
+| [`label`](#label)                                           | `label: "Heading Block"`                         | String   | -        |
+| [`resolveData()`](#resolvedatadata-params)                  | `resolveData: async ({ props }) => ({ props })`  | Object   | -        |
+| [`resolveFields()`](#resolvefieldsdata-params)              | `resolveFields: async ({ props }) => ({})`       | Object   | -        |
+| [`resolveDefaultProps()`](#resolvedefaultpropsprops)        | `resolveDefaultProps: async (props) => ({})`     | Object   | -        |
 
 ## Required params
 
@@ -445,3 +446,62 @@ The last fields object created by the previous run of this function.
 #### Returns
 
 A [`fields`](#fields) object.
+
+
+### `resolveDefaultProps(props)`
+
+Dynamically set the defaultProps for this component. Can be used to make asynchronous calls.
+
+This function is triggered when a new component is added.
+
+```tsx {10-13} copy filename="Example setting default props asynchronously"
+const config = {
+  components: {
+    MyComponent: {
+      fields: {
+        title: {type: "text", label: "Title"}
+      },
+      defaultProps: {
+        title: "Unchanged Title"
+      },
+      resolveDefaultProps: async (props) => {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        return {...props, title: "Changed Title"};;
+      },
+      // ...
+    },
+  },
+};
+```
+
+<ConfigPreview
+  label='Default props changed'
+  componentConfig={{
+    fields: {
+      title: {type: "text", label: "Title"}
+    },
+    defaultProps: {
+      title: "Unchanged Title"
+    },
+    resolveDefaultProps: async (props) => {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      return {...props, title: "Changed Title"};
+    },
+    render: ({ title }) => <h1>{title}</h1>,
+    
+}}
+/>
+
+#### Args
+
+| Prop     | Example                                                                   | Type   |
+| -------- | ------------------------------------------------------------------------- | ------ |
+| `props`  | `{ title: "Hello, world" }`                                               | Object |
+
+##### `props`
+
+The default static props for the component.
+
+#### Returns
+
+A [`defaultProps`](#defaultprops) object.

--- a/apps/docs/pages/docs/integrating-puck/component-configuration.mdx
+++ b/apps/docs/pages/docs/integrating-puck/component-configuration.mdx
@@ -211,3 +211,48 @@ Unlike [default parameters](https://developer.mozilla.org/en-US/docs/Web/JavaScr
     },
   }}
 />
+
+## Setting default props asynchronously
+
+The [`resolveDefaultProps` function](/docs/api-reference/configuration/component-config#resolvedefaultpropsprops) allows you to set default props asynchronously.
+
+For example we can set the value of default props by making an asynchronous call.
+
+```tsx {10-13} copy filename="Example setting default props asynchronously"
+const config = {
+  components: {
+    MyComponent: {
+      fields: {
+        title: {type: "text", label: "Title"}
+      },
+      defaultProps: {
+        title: "Hello, world"
+      },
+      resolveDefaultProps: async (props) => {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        return {...props, title: "Hello, world again!"};;
+      },
+      render: ({ title }) => <h1>{title}</h1>,
+    },
+  },
+};
+```
+
+The `resolved defaultProps` are stored in the data payload and will populate the Puck fields.
+
+<ConfigPreview
+  label="Text field example"
+  componentConfig={{
+    fields: {
+      title: {type: "text", label: "Title"}
+    },
+    defaultProps: {
+      title: "Hello, world"
+    },
+    resolveDefaultProps: async (props) => {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      return {...props, title: "Hello, world again!"};;
+    },
+    render: ({ title }) => <h1>{title}</h1>,
+  }}
+/>

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -241,7 +241,7 @@ function DropZoneEdit({ zone, allow, disallow, style }: DropZoneProps) {
                 };
 
                 const defaultedProps = {
-                  ...resolvedDefaultPropsMapper[item.type] || {},
+                  ...(resolvedDefaultPropsMapper[item.type] || {}),
                   ...item.props,
                   puck: puckProps,
                   editMode: true, // DEPRECATED

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -36,6 +36,9 @@ export type ComponentConfig<
   render: PuckComponent<ComponentProps>;
   label?: string;
   defaultProps?: DefaultProps;
+  resolveDefaultProps?: (
+    defaultProps: DefaultProps
+  ) => Promise<DefaultProps> | DefaultProps
   fields?: Fields<ComponentProps>;
   resolveFields?: (
     data: DataShape,
@@ -55,13 +58,13 @@ export type ComponentConfig<
     }
   ) =>
     | Promise<{
-        props?: Partial<ComponentProps>;
-        readOnly?: Partial<Record<keyof ComponentProps, boolean>>;
-      }>
+      props?: Partial<ComponentProps>;
+      readOnly?: Partial<Record<keyof ComponentProps, boolean>>;
+    }>
     | {
-        props?: Partial<ComponentProps>;
-        readOnly?: Partial<Record<keyof ComponentProps, boolean>>;
-      };
+      props?: Partial<ComponentProps>;
+      readOnly?: Partial<Record<keyof ComponentProps, boolean>>;
+    };
 };
 
 type Category<ComponentName> = {


### PR DESCRIPTION
This is for the issue #496 (feature).

How it does?
1. config contains `resolveDefaultProps` function (async) that returns DefaultProps type.  
2. I made a `mapper` of resolved defaultProps for each component by using a hook inside `DropZoneEdit`. The hook contains a mapper state and a `memoized function` that depends on config.components only. That function is called in useEffect (no dependency) to return a mapper which is set to the mapper.
3. The hook returns the mapper state (consumed as below):

```
    const { resolvedDefaultPropsMapper } = useResolvedDefaultProps(config.components)
```

Previous defaultedProps initialization:
```
    const defaultedProps = {
      ...config.components[item.type],
      ...item.props,
      puck: puckProps,
      editMode: true, // DEPRECATED
    };
```

The above was changed to:
```
    const defaultedProps = {
      ...(resolvedDefaultPropsMapper[item.type] || {}),
      ...item.props,
      puck: puckProps,
      editMode: true, // DEPRECATED
    };
``` 



Ps: I'm not sure this is a good way to do it or it works properly.