### PR TITLE
Add on action prop

### DIFF
--- a/apps/docs/pages/docs/api-reference/components/puck.mdx
+++ b/apps/docs/pages/docs/api-reference/components/puck.mdx
@@ -25,23 +25,23 @@ export function Editor() {
 
 ## Props
 
-| Param                               | Example                                | Type                                               | Status       |
-| ----------------------------------- | -------------------------------------- | -------------------------------------------------- | ------------ |
-| [`config`](#config)                 | `config: { components: {} }`           | [Config](/docs/api-reference/configuration/config) | Required     |
-| [`data`](#data)                     | `data: {}`                             | [Data](/docs/api-reference/data)                   | Required     |
-| [`dnd`](#dnd)                       | `dnd: {}`                              | [DndConfig](#dnd-params)                           | -            |
-| [`children`](#children)             | `children: <Puck.Preview />`           | ReactNode                                          | -            |
-| [`headerPath`](#headerpath)         | `headerPath: "/my-page"`               | String                                             | -            |
-| [`headerTitle`](#headertitle)       | `headerTitle: "My Page"`               | String                                             | -            |
-| [`iframe`](#iframe)                 | `iframe: {}`                           | [IframeConfig](#iframe-params)                     | -            |
-| [`initialHistory`](#initialhistory) | `initialHistory: {}`                   | [InitialHistory](#initialhistory-params)           | -            |
-| [`onChange()`](#onchangedata)       | `onChange: (data) => {}`               | Function                                           | -            |
-| [`onPublish()`](#onpublishdata)     | `onPublish: async (data) => {}`        | Function                                           | -            |
-| [`onAction()`](#onactionaction-appstate-prevappstate) | `onAction: (action, appState, prevAppState) => {}`        | Function                                           | -            |
-| [`overrides`](#overrides)           | `overrides: { header: () => <div /> }` | [Overrides](/docs/api-reference/overrides)         | Experimental |
-| [`plugins`](#plugins)               | `plugins: [myPlugin]`                  | [Plugin\[\]](/docs/api-reference/plugin)           | Experimental |
-| [`ui`](#ui)                         | `ui: {leftSideBarVisible: false}`      | [AppState.ui](/docs/api-reference/app-state#ui)    | -            |
-| [`viewports`](#viewports)           | `viewports: [{ width: 1440 }]`         | [Viewport\[\]](#viewport-params)                   | -            |
+| Param                                                 | Example                                            | Type                                               | Status       |
+| ----------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------- | ------------ |
+| [`config`](#config)                                   | `config: { components: {} }`                       | [Config](/docs/api-reference/configuration/config) | Required     |
+| [`data`](#data)                                       | `data: {}`                                         | [Data](/docs/api-reference/data)                   | Required     |
+| [`dnd`](#dnd)                                         | `dnd: {}`                                          | [DndConfig](#dnd-params)                           | -            |
+| [`children`](#children)                               | `children: <Puck.Preview />`                       | ReactNode                                          | -            |
+| [`headerPath`](#headerpath)                           | `headerPath: "/my-page"`                           | String                                             | -            |
+| [`headerTitle`](#headertitle)                         | `headerTitle: "My Page"`                           | String                                             | -            |
+| [`iframe`](#iframe)                                   | `iframe: {}`                                       | [IframeConfig](#iframe-params)                     | -            |
+| [`initialHistory`](#initialhistory)                   | `initialHistory: {}`                               | [InitialHistory](#initialhistory-params)           | -            |
+| [`onAction()`](#onactionaction-appstate-prevappstate) | `onAction: (action, appState, prevAppState) => {}` | Function                                           | -            |
+| [`onChange()`](#onchangedata)                         | `onChange: (data) => {}`                           | Function                                           | -            |
+| [`onPublish()`](#onpublishdata)                       | `onPublish: async (data) => {}`                    | Function                                           | -            |
+| [`overrides`](#overrides)                             | `overrides: { header: () => <div /> }`             | [Overrides](/docs/api-reference/overrides)         | Experimental |
+| [`plugins`](#plugins)                                 | `plugins: [myPlugin]`                              | [Plugin\[\]](/docs/api-reference/plugin)           | Experimental |
+| [`ui`](#ui)                                           | `ui: {leftSideBarVisible: false}`                  | [AppState.ui](/docs/api-reference/app-state#ui)    | -            |
+| [`viewports`](#viewports)                             | `viewports: [{ width: 1440 }]`                     | [Viewport\[\]](#viewport-params)                   | -            |
 
 ## Required props
 
@@ -202,6 +202,31 @@ An array of histories to reset the Puck state history state to.
 
 The index of the histories to set the user to.
 
+### `onAction(action, appState, prevAppState)`
+
+Callback that triggers when Puck dispatches an [action](https://puckeditor.com/docs/api-reference/actions), like as `insert` or `set`. Use this to track changes, perform side effects, or sync with external systems.
+
+Receives three arguments:
+
+1. `action`: The action that was dispatched
+2. `appState`: The new [`AppState`](/docs/api-reference/app-state) after the action was applied
+3. `prevAppState`: The previous [`AppState`](/docs/api-reference/app-state) before the action was applied
+
+```tsx {4-8} copy
+export function Editor() {
+  return (
+    <Puck
+      onAction={(action, appState, prevAppState) => {
+        if (action.type === "insert") {
+          console.log("New component was inserted", appState);
+        }
+      }}
+      // ...
+    />
+  );
+}
+```
+
 ### `onChange(data)`
 
 Callback that triggers when the user makes a change.
@@ -236,30 +261,6 @@ export function Editor() {
           method: "post",
           body: JSON.stringify({ data }),
         });
-      }}
-      // ...
-    />
-  );
-}
-```
-
-### `onAction(action, appState, prevAppState)`
-
-Callback that triggers when an action occurs in the Puck. Use this to track changes, perform side effects, or sync with external systems.
-
-Receives three arguments:
-1. `action`: The action that was dispatched
-2. `appState`: The new [`AppState`](/docs/api-reference/app-state) after the action was applied
-3. `prevAppState`: The previous [`AppState`](/docs/api-reference/app-state) before the action was applied
-
-```tsx {4-8} copy
-export function Editor() {
-  return (
-    <Puck
-      onAction={(action, appState, prevAppState) => {
-        if (action.type === 'insert') {
-          console.log('New component was inserted', appState)
-        }
       }}
       // ...
     />

--- a/apps/docs/pages/docs/api-reference/components/puck.mdx
+++ b/apps/docs/pages/docs/api-reference/components/puck.mdx
@@ -37,6 +37,7 @@ export function Editor() {
 | [`initialHistory`](#initialhistory) | `initialHistory: {}`                   | [InitialHistory](#initialhistory-params)           | -            |
 | [`onChange()`](#onchangedata)       | `onChange: (data) => {}`               | Function                                           | -            |
 | [`onPublish()`](#onpublishdata)     | `onPublish: async (data) => {}`        | Function                                           | -            |
+| [`onAction()`](#onactionaction-appstate-prevappstate) | `onAction: (action, appState, prevAppState) => {}`        | Function                                           | -            |
 | [`overrides`](#overrides)           | `overrides: { header: () => <div /> }` | [Overrides](/docs/api-reference/overrides)         | Experimental |
 | [`plugins`](#plugins)               | `plugins: [myPlugin]`                  | [Plugin\[\]](/docs/api-reference/plugin)           | Experimental |
 | [`ui`](#ui)                         | `ui: {leftSideBarVisible: false}`      | [AppState.ui](/docs/api-reference/app-state#ui)    | -            |
@@ -235,6 +236,30 @@ export function Editor() {
           method: "post",
           body: JSON.stringify({ data }),
         });
+      }}
+      // ...
+    />
+  );
+}
+```
+
+### `onAction(action, appState, prevAppState)`
+
+Callback that triggers when an action occurs in the Puck. Use this to track changes, perform side effects, or sync with external systems.
+
+Receives three arguments:
+1. `action`: The action that was dispatched
+2. `appState`: The new [`AppState`](/docs/api-reference/app-state) after the action was applied
+3. `prevAppState`: The previous [`AppState`](/docs/api-reference/app-state) before the action was applied
+
+```tsx {4-8} copy
+export function Editor() {
+  return (
+    <Puck
+      onAction={(action, appState, prevAppState) => {
+        if (action.type === 'insert') {
+          console.log('New component was inserted', appState)
+        }
       }}
       // ...
     />

--- a/apps/docs/pages/docs/api-reference/components/puck.mdx
+++ b/apps/docs/pages/docs/api-reference/components/puck.mdx
@@ -204,7 +204,7 @@ The index of the histories to set the user to.
 
 ### `onAction(action, appState, prevAppState)`
 
-Callback that triggers when Puck dispatches an [action](https://puckeditor.com/docs/api-reference/actions), like as `insert` or `set`. Use this to track changes, perform side effects, or sync with external systems.
+Callback that triggers when Puck dispatches an [action](https://puckeditor.com/docs/api-reference/actions), like `insert` or `set`. Use this to track changes, perform side effects, or sync with external systems.
 
 Receives three arguments:
 

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -186,19 +186,19 @@ export function Puck<UserConfig extends Config = Config>({
         // Store categories under componentList on state to allow render functions and plugins to modify
         componentList: config.categories
           ? Object.entries(config.categories).reduce(
-            (acc, [categoryName, category]) => {
-              return {
-                ...acc,
-                [categoryName]: {
-                  title: category.title,
-                  components: category.components,
-                  expanded: category.defaultExpanded,
-                  visible: category.visible,
-                },
-              };
-            },
-            {}
-          )
+              (acc, [categoryName, category]) => {
+                return {
+                  ...acc,
+                  [categoryName]: {
+                    title: category.title,
+                    components: category.components,
+                    expanded: category.defaultExpanded,
+                    visible: category.visible,
+                  },
+                };
+              },
+              {}
+            )
           : {},
       },
     };

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -10,6 +10,7 @@ import {
 import { DragStart, DragUpdate } from "@measured/dnd";
 
 import type { AppState, Config, Data, UiState } from "../../types/Config";
+import type { OnAction } from "../../types/OnAction";
 import { Button } from "../Button";
 
 import { Plugin } from "../../types/Plugin";
@@ -58,6 +59,7 @@ export function Puck<UserConfig extends Config = Config>({
   ui: initialUi,
   onChange,
   onPublish,
+  onAction,
   plugins = [],
   overrides = {},
   renderHeader,
@@ -77,6 +79,7 @@ export function Puck<UserConfig extends Config = Config>({
   ui?: Partial<UiState>;
   onChange?: (data: Data) => void;
   onPublish?: (data: Data) => void;
+  onAction?: OnAction;
   plugins?: Plugin[];
   overrides?: Partial<Overrides>;
   renderHeader?: (props: {
@@ -103,7 +106,7 @@ export function Puck<UserConfig extends Config = Config>({
   const historyStore = useHistoryStore(initialHistory);
 
   const [reducer] = useState(() =>
-    createReducer<UserConfig>({ config, record: historyStore.record })
+    createReducer<UserConfig>({ config, record: historyStore.record, onAction })
   );
 
   const [initialAppState] = useState<AppState>(() => {
@@ -183,19 +186,19 @@ export function Puck<UserConfig extends Config = Config>({
         // Store categories under componentList on state to allow render functions and plugins to modify
         componentList: config.categories
           ? Object.entries(config.categories).reduce(
-              (acc, [categoryName, category]) => {
-                return {
-                  ...acc,
-                  [categoryName]: {
-                    title: category.title,
-                    components: category.components,
-                    expanded: category.defaultExpanded,
-                    visible: category.visible,
-                  },
-                };
-              },
-              {}
-            )
+            (acc, [categoryName, category]) => {
+              return {
+                ...acc,
+                [categoryName]: {
+                  title: category.title,
+                  components: category.components,
+                  expanded: category.defaultExpanded,
+                  visible: category.visible,
+                },
+              };
+            },
+            {}
+          )
           : {},
       },
     };

--- a/packages/core/reducer/index.ts
+++ b/packages/core/reducer/index.ts
@@ -62,15 +62,18 @@ export function createReducer<UserConfig extends Config = Config>({
   record?: (appState: AppState) => void;
   onAction?: OnAction;
 }): StateReducer {
-  return storeInterceptor((state, action) => {
-    const data = reduceData(state.data, action, config);
-    const ui = reduceUi(state.ui, action);
+  return storeInterceptor(
+    (state, action) => {
+      const data = reduceData(state.data, action, config);
+      const ui = reduceUi(state.ui, action);
 
-    if (action.type === "set") {
-      return setAction(state, action);
-    }
+      if (action.type === "set") {
+        return setAction(state, action);
+      }
 
-    return { data, ui };
-
-  }, record, onAction);
+      return { data, ui };
+    },
+    record,
+    onAction
+  );
 }

--- a/packages/core/reducer/index.ts
+++ b/packages/core/reducer/index.ts
@@ -3,6 +3,7 @@ import { AppState, Config } from "../types/Config";
 import { reduceData } from "./data";
 import { PuckAction, SetAction } from "./actions";
 import { reduceUi } from "./state";
+import type { OnAction } from "../types/OnAction";
 
 export * from "./actions";
 export * from "./data";
@@ -13,7 +14,8 @@ export type StateReducer = Reducer<AppState, PuckAction>;
 
 const storeInterceptor = (
   reducer: StateReducer,
-  record?: (appState: AppState) => void
+  record?: (appState: AppState) => void,
+  onAction?: OnAction
 ) => {
   return (state: AppState, action: PuckAction) => {
     const newAppState = reducer(state, action);
@@ -34,6 +36,8 @@ const storeInterceptor = (
       if (record) record(newAppState);
     }
 
+    onAction?.(action, newAppState, state);
+
     return newAppState;
   };
 };
@@ -52,9 +56,11 @@ export const setAction = (state: AppState, action: SetAction) => {
 export function createReducer<UserConfig extends Config = Config>({
   config,
   record,
+  onAction,
 }: {
   config: UserConfig;
   record?: (appState: AppState) => void;
+  onAction?: OnAction;
 }): StateReducer {
   return storeInterceptor((state, action) => {
     const data = reduceData(state.data, action, config);
@@ -65,5 +71,6 @@ export function createReducer<UserConfig extends Config = Config>({
     }
 
     return { data, ui };
-  }, record);
+
+  }, record, onAction);
 }

--- a/packages/core/types/OnAction.ts
+++ b/packages/core/types/OnAction.ts
@@ -1,4 +1,8 @@
 import type { PuckAction } from "../reducer";
 import type { AppState } from "./Config";
 
-export type OnAction = (action: PuckAction, appState: AppState, prevAppState: AppState) => void;
+export type OnAction = (
+  action: PuckAction,
+  appState: AppState,
+  prevAppState: AppState
+) => void;

--- a/packages/core/types/OnAction.ts
+++ b/packages/core/types/OnAction.ts
@@ -1,0 +1,4 @@
+import type { PuckAction } from "../reducer";
+import type { AppState } from "./Config";
+
+export type OnAction = (action: PuckAction, appState: AppState, prevAppState: AppState) => void;


### PR DESCRIPTION
Addresses https://github.com/measuredco/puck/issues/534

This change adds an `onAction` callback to the Puck editor. When an action occurs in the editor, this callback is called with the `action`, `appState`, and `prevAppState`. Enables tracking changes, performing side effects, or syncing with external systems.