### PR TITLE
Help out the generics by ensuring that objectFields is never an array.

### DIFF
--- a/packages/core/types/Fields.ts
+++ b/packages/core/types/Fields.ts
@@ -52,9 +52,11 @@ export type ObjectField<
   Props extends { [key: string]: any } = { [key: string]: any }
 > = BaseField & {
   type: "object";
-  objectFields: {
-    [SubPropName in keyof Props]: Field<Props[SubPropName]>;
-  };
+  objectFields: Props extends any[]
+    ? never
+    : {
+        [SubPropName in keyof Props]: Field<Props[SubPropName]>;
+      };
 };
 
 // DEPRECATED


### PR DESCRIPTION
I narrowed the TypeScript errors to this PR #368

Because the ObjectField is `any` objectFields _could_ be an array here:

 [SubPropName in keyof Props]: Field<Props[SubPropName]>;
 
 I've added a check so that it can only be an object which gets rid of the the Config mismatch errors and keeps typing within the objectFields