### PR TITLE
fix:type annotations causing vite react app ts errors

### DIFF
--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -33,7 +33,7 @@ export type ComponentConfig<
   DefaultProps = ComponentProps,
   DataShape = Omit<ComponentData<ComponentProps>, "type">
 > = {
-  render: PuckComponent<ComponentProps>;
+  render: PuckComponent<Partial<ComponentProps>>;
   label?: string;
   defaultProps?: DefaultProps;
   fields?: Fields<ComponentProps>;

--- a/packages/core/types/Fields.ts
+++ b/packages/core/types/Fields.ts
@@ -127,7 +127,7 @@ export type Fields<
   ComponentProps extends DefaultComponentProps = DefaultComponentProps
 > = {
   [PropName in keyof Omit<
-    Partial<ComponentProps>,
+    ComponentProps,
     "children" | "editMode"
   >]: Field<ComponentProps[PropName]>;
 };

--- a/packages/core/types/Fields.ts
+++ b/packages/core/types/Fields.ts
@@ -127,7 +127,7 @@ export type Fields<
   ComponentProps extends DefaultComponentProps = DefaultComponentProps
 > = {
   [PropName in keyof Omit<
-    Required<ComponentProps>,
+    Partial<ComponentProps>,
     "children" | "editMode"
   >]: Field<ComponentProps[PropName]>;
 };


### PR DESCRIPTION
>## Steps To Reproduce
>1- ```npm create vite@latest my-puck-app -- --template react-ts && cd ./my-puck-app && npm i && npm i @measured/puck@latest```
>
>2- copy the following snapshot
>
>```tsx
>import { DefaultRootProps, Puck } from "@measured/puck";
>import { Config } from "@measured/puck";
>
>type Props = {
>  HeadingBlock: { title: string };
>};
>
>type Root = {
>  description: string;
>} & DefaultRootProps;
>
>export const config: Config<Props, Root> = {
>  components: {
>    HeadingBlock: {
>      fields: {
>        title: { type: "text" },
>      },
>      defaultProps: {
>        title: "Heading",
>      },
>      render: ({ title }) => (
>        <h1>{title}</h1>
>      ),
>    },
>  },
>  root: {
>    fields: {
>      description: { type: "text" },
>    },
>    defaultProps: {
>      description: "Description",
>    },
>    render: ({ children }) => {
>      return <div>{children}</div>;
>    },
>  },
>};
>const initialData = {};
>
>const save = () => {};
>
>// Render Puck edito
>export function Editor() {
>  return <Puck config={config} data={initialData} onPublish={save} />;
>}
>  ```