### PR TITLE
Removing the stroke from the Lucide icon

### DIFF
--- a/packages/core/components/MenuBar/index.tsx
+++ b/packages/core/components/MenuBar/index.tsx
@@ -60,21 +60,12 @@ export const MenuBar = ({
           <IconButton title="undo" disabled={!hasPast} onClick={back}>
             <Undo2Icon
               size={21}
-              stroke={
-                hasPast
-                  ? "var(--puck-color-black)"
-                  : "var(--puck-color-grey-08)"
-              }
+              
             />
           </IconButton>
           <IconButton title="redo" disabled={!hasFuture} onClick={forward}>
             <Redo2Icon
               size={21}
-              stroke={
-                hasFuture
-                  ? "var(--puck-color-black)"
-                  : "var(--puck-color-grey-08)"
-              }
             />
           </IconButton>
         </div>

--- a/packages/core/components/MenuBar/index.tsx
+++ b/packages/core/components/MenuBar/index.tsx
@@ -58,15 +58,10 @@ export const MenuBar = ({
       <div className={getClassName("inner")}>
         <div className={getClassName("history")}>
           <IconButton title="undo" disabled={!hasPast} onClick={back}>
-            <Undo2Icon
-              size={21}
-              
-            />
+            <Undo2Icon size={21} />
           </IconButton>
           <IconButton title="redo" disabled={!hasFuture} onClick={forward}>
-            <Redo2Icon
-              size={21}
-            />
+            <Redo2Icon size={21} />
           </IconButton>
         </div>
         <>


### PR DESCRIPTION
Removing the stroke from the Lucide icon as the fill can be inherited by the parent icon button CSS. 

Fixes #330 