### PR TITLE
type: feature Add `onSelectionChange` callback that emits the currently selected component

### DIFF
--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -78,7 +78,9 @@ export function Puck<UserConfig extends Config = Config>({
   ui?: Partial<UiState>;
   onChange?: (data: Data) => void;
   onPublish?: (data: Data) => void;
-  onSelectionChange?: (itemSelector: { id: string, type: string } | null) => void;
+  onSelectionChange?: (
+    selectedItem: { id: string; type: string } | null
+  ) => void;
   plugins?: Plugin[];
   overrides?: Partial<Overrides>;
   renderHeader?: (props: {
@@ -239,7 +241,11 @@ export function Puck<UserConfig extends Config = Config>({
 
   useEffect(() => {
     if (onSelectionChange) {
-      onSelectionChange(selectedItem ? { id: selectedItem.props.id, type: selectedItem.type.toString() } : null);
+      onSelectionChange(
+        selectedItem
+          ? { id: selectedItem.props.id, type: selectedItem.type.toString() }
+          : null
+      );
     }
   }, [selectedItem?.props?.id]);
 

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -58,6 +58,7 @@ export function Puck<UserConfig extends Config = Config>({
   ui: initialUi,
   onChange,
   onPublish,
+  onSelectionChange,
   plugins = [],
   overrides = {},
   renderHeader,
@@ -77,6 +78,7 @@ export function Puck<UserConfig extends Config = Config>({
   ui?: Partial<UiState>;
   onChange?: (data: Data) => void;
   onPublish?: (data: Data) => void;
+  onSelectionChange?: (itemSelector: { id: string, type: string } | null) => void;
   plugins?: Plugin[];
   overrides?: Partial<Overrides>;
   renderHeader?: (props: {
@@ -234,6 +236,12 @@ export function Puck<UserConfig extends Config = Config>({
   );
 
   const selectedItem = itemSelector ? getItem(itemSelector, data) : null;
+
+  useEffect(() => {
+    if (onSelectionChange) {
+      onSelectionChange(selectedItem ? { id: selectedItem.props.id, type: selectedItem.type.toString() } : null);
+    }
+  }, [selectedItem?.props?.id]);
 
   useEffect(() => {
     if (onChange) onChange(data);


### PR DESCRIPTION
Hello there!
This is my first PR on puck, I hope you'll find it valuable ;)

This pull request adds a `onSelectionChange` callback to the Puck component that emits the id and the type of the currently selected component in the editor.

When no component is selected (i.e. you click outside of the editor), it returns `null`.

It's very useful to extend puck!

Example usage:
```typescript
<Puck
  ...
  onSelectionChange={(item) => { console.log(item) }}
  ...
/>
```