### PR TITLE
Add `dnd.isDisabled` option in the Puck component to disable drag and drop

### DIFF
--- a/packages/core/components/DraggableComponent/index.tsx
+++ b/packages/core/components/DraggableComponent/index.tsx
@@ -109,7 +109,7 @@ export const DraggableComponent = ({
           style={{
             ...style,
             ...provided.draggableProps.style,
-            cursor: isModifierHeld ? "initial" : "grab",
+            cursor: isModifierHeld || isDragDisabled ? "initial" : "grab",
           }}
           onMouseOver={onMouseOver}
           onMouseOut={onMouseOut}

--- a/packages/core/components/DropZone/context.tsx
+++ b/packages/core/components/DropZone/context.tsx
@@ -41,6 +41,7 @@ export type DropZoneContext<UserConfig extends Config = Config> = {
   mode?: "edit" | "render";
   zoneWillDrag?: string;
   setZoneWillDrag?: (zone: string) => void;
+  isDragDisabled?: boolean;
 } | null;
 
 export const dropZoneContext = createContext<DropZoneContext>(null);

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -35,6 +35,7 @@ function DropZoneEdit({ zone, allow, disallow, style }: DropZoneProps) {
     hoveringComponent,
     zoneWillDrag,
     setZoneWillDrag = () => null,
+    isDragDisabled,
   } = ctx! || {};
 
   let content = data.content || [];
@@ -255,6 +256,7 @@ function DropZoneEdit({ zone, allow, disallow, style }: DropZoneProps) {
                         index={i}
                         isSelected={isSelected}
                         isLocked={userIsDragging}
+                        isDragDisabled={isDragDisabled}
                         forceHover={
                           hoveringComponent === componentId && !userIsDragging
                         }

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -97,6 +97,7 @@ export function Puck<UserConfig extends Config = Config>({
   iframe?: IframeConfig;
   dnd?: {
     disableAutoScroll?: boolean;
+    isDisabled?: boolean;
   };
   initialHistory?: {
     histories: History<any>[];
@@ -469,6 +470,7 @@ export function Puck<UserConfig extends Config = Config>({
           <DropZoneProvider
             value={{
               data,
+              isDragDisabled: dnd?.isDisabled,
               itemSelector,
               setItemSelector,
               config,


### PR DESCRIPTION
Hi there!

Here I am again with a new PR.

This adds the option to disable the drag and drop feature of the editor.

Usage:
```typescript
export function Editor() {
  return (
    <Puck
       dnd={{ isDisabled: true }}
       data={{ ... }}
        /*...*/
    />
  );
}
```