### PR TITLE
feat: adding hidden field to BaseField

### DIFF
--- a/packages/core/components/AutoField/index.tsx
+++ b/packages/core/components/AutoField/index.tsx
@@ -164,6 +164,10 @@ function AutoFieldInternal<
     id: resolvedId,
   };
 
+  if (field.hidden) {
+    return null;
+  }
+
   if (field.type === "custom") {
     if (!field.render) {
       return null;

--- a/packages/core/types/Fields.ts
+++ b/packages/core/types/Fields.ts
@@ -10,6 +10,7 @@ type FieldOptions = Array<FieldOption> | ReadonlyArray<FieldOption>;
 
 export type BaseField = {
   label?: string;
+  hidden?: boolean;
 };
 
 export type TextField = BaseField & {


### PR DESCRIPTION
- Added `hidden` property to BaseField type in packages/core/types/Fields.ts
- Modified AutoField component to handle hidden fields in packages/core/components/AutoField/index.tsx
- Updated other Field type definitions in packages/core/types/Fields.ts

Usage Examples:
```tsx
export type TestProps = {
    language: "en" | "fr" | "es";
    title: {
        en: string;
        fr: string;
        es: string;
    }
}

export const Test: ComponentConfig<TestProps> = {
    resolveFields: (data) => ({
        language: {
            type: "radio",
            options: [
                { label: "English", value: "en" },
                { label: "French", value: "fr" },
                { label: "Spanish", value: "es" },
            ],
        },
        title: {
            type: "object",
            objectFields: {
                en: {
                    type: "text",
                    hidden: data.props.language !== "en",
                },
                fr: {
                    type: "text",
                    hidden: data.props.language !== "fr",
                },
                es: {
                    type: "text",
                    hidden: data.props.language !== "es",
                },
            }
        }
    }),
    render: ({ language, title, puck: { isEditing } }) => {
        const i18nLang = useCurrentLocale();
        return <div>{title[isEditing ? language : i18nLang]}</div>
    },
}
```