### PR TITLE
Rework history store

### DIFF
--- a/apps/docs/pages/docs/api-reference/components/puck.mdx
+++ b/apps/docs/pages/docs/api-reference/components/puck.mdx
@@ -189,10 +189,11 @@ Sets the undo/redo Puck history state when using the `usePuck` [history API](/do
 
 #### `initialHistory` params
 
-| Param                     | Example         | Type                                                                   | Status   |
-| ------------------------- | --------------- | ---------------------------------------------------------------------- | -------- |
-| [`histories`](#histories) | `histories: []` | [History](/docs/api-reference/functions/use-puck#historyhistories)\[\] | Required |
-| [`index`](#index)         | `index: 2`      | Number                                                                 | Required |
+| Param                       | Example             | Type                                                                   | Status   |
+| --------------------------- | ------------------- | ---------------------------------------------------------------------- | -------- |
+| [`histories`](#histories)   | `histories: []`     | [History](/docs/api-reference/functions/use-puck#historyhistories)\[\] | Required |
+| [`index`](#index)           | `index: 2`          | Number                                                                 | Required |
+| [`appendData`](#appenddata) | `appendData: false` | Boolean                                                                | -        |
 
 ##### `histories`
 
@@ -201,6 +202,12 @@ An array of histories to reset the Puck state history state to.
 ##### `index`
 
 The index of the histories to set the user to.
+
+##### `appendData`
+
+Append the Puck [`data`](#data) prop onto the end of [`histories`](#histories). Defaults to `true`.
+
+When `false`, the Puck `data` prop will be ignored but you must specify at least one item in the `histories` array.
 
 ### `onAction(action, appState, prevAppState)`
 

--- a/apps/docs/pages/docs/api-reference/functions/use-puck.mdx
+++ b/apps/docs/pages/docs/api-reference/functions/use-puck.mdx
@@ -105,7 +105,7 @@ The [app state](/docs/api-reference/app-state) payload for this history entry.
 
 ###### `id`
 
-A unique ID for this history entry.
+An optional ID for this history entry.
 
 #### `history.index`
 

--- a/packages/core/components/Puck/components/Canvas/index.tsx
+++ b/packages/core/components/Puck/components/Canvas/index.tsx
@@ -85,6 +85,14 @@ export const Canvas = () => {
     }
   }, [zoomConfig.zoom]);
 
+  // Zoom whenever state changes, even if external driver
+  useEffect(() => {
+    if (ZOOM_ON_CHANGE) {
+      setShowTransition(true);
+      resetAutoZoom(ui);
+    }
+  }, [ui.viewports.current.width]);
+
   // Resize based on window size
   useEffect(() => {
     const observer = new ResizeObserver(() => {

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -219,12 +219,12 @@ export function Puck<
   const initialHistory: InitialHistory<AppState> = {
     histories: [
       ...(_initialHistory?.histories || []),
-      { data: generatedAppState },
+      { state: generatedAppState },
     ],
     index: _initialHistory?.index || 0,
   };
 
-  const initialAppState = initialHistory?.histories[initialHistory.index].data;
+  const initialAppState = initialHistory?.histories[initialHistory.index].state;
 
   const historyStore = useHistoryStore(initialHistory);
 

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -218,21 +218,21 @@ export function Puck<
 
   const { appendData = true } = _initialHistory || {};
 
-  const initialHistory: InitialHistory<AppState> = {
-    histories: [
-      ...(_initialHistory?.histories || []),
-      ...(appendData ? [{ state: generatedAppState }] : []),
-    ].map((history) => ({
-      ...history,
-      // Inject default data to enable partial history injections
-      state: { ...generatedAppState, ...history.state },
-    })),
-    index: _initialHistory?.index || 0,
-  };
+  const histories = [
+    ...(_initialHistory?.histories || []),
+    ...(appendData ? [{ state: generatedAppState }] : []),
+  ].map((history) => ({
+    ...history,
+    // Inject default data to enable partial history injections
+    state: { ...generatedAppState, ...history.state },
+  }));
+  const initialHistoryIndex = _initialHistory?.index || histories.length - 1;
+  const initialAppState = histories[initialHistoryIndex].state;
 
-  const initialAppState = initialHistory?.histories[initialHistory.index].state;
-
-  const historyStore = useHistoryStore(initialHistory);
+  const historyStore = useHistoryStore({
+    histories,
+    index: initialHistoryIndex,
+  });
 
   const [reducer] = useState(() =>
     createReducer<UserConfig, UserData>({

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -222,7 +222,11 @@ export function Puck<
     histories: [
       ...(_initialHistory?.histories || []),
       ...(appendData ? [{ state: generatedAppState }] : []),
-    ],
+    ].map((history) => ({
+      ...history,
+      // Inject default data to enable partial history injections
+      state: { ...generatedAppState, ...history.state },
+    })),
     index: _initialHistory?.index || 0,
   };
 

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -216,10 +216,12 @@ export function Puck<
     } as AppState<UserData>;
   });
 
+  const { appendData = true } = _initialHistory || {};
+
   const initialHistory: InitialHistory<AppState> = {
     histories: [
       ...(_initialHistory?.histories || []),
-      { state: generatedAppState },
+      ...(appendData ? [{ state: generatedAppState }] : []),
     ],
     index: _initialHistory?.index || 0,
   };

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -13,8 +13,6 @@ export * from "./components/AutoField";
 export * from "./components/Button";
 export { Drawer } from "./components/Drawer";
 
-export type { History } from "./lib/use-history-store";
-
 // DEPRECATED
 export * from "./components/DropZone";
 export * from "./components/IconButton";

--- a/packages/core/lib/__tests__/use-history-store.spec.tsx
+++ b/packages/core/lib/__tests__/use-history-store.spec.tsx
@@ -12,7 +12,7 @@ describe("use-history-store", () => {
     renderedHook = renderHook(() =>
       useHistoryStore({
         index: 0,
-        histories: [{ data: "Strawberries", id: "initial" }],
+        histories: [{ state: "Strawberries", id: "initial" }],
       })
     );
   });
@@ -21,7 +21,7 @@ describe("use-history-store", () => {
     expect(renderedHook.result.current.hasPast).toBe(false);
     expect(renderedHook.result.current.hasFuture).toBe(false);
     expect(renderedHook.result.current.histories.length).toBe(1);
-    expect(renderedHook.result.current.histories[0].data).toBe("Strawberries");
+    expect(renderedHook.result.current.histories[0].state).toBe("Strawberries");
   });
 
   test("should record the history", () => {
@@ -31,9 +31,9 @@ describe("use-history-store", () => {
     expect(renderedHook.result.current.hasPast).toBe(true);
     expect(renderedHook.result.current.hasFuture).toBe(false);
     expect(renderedHook.result.current.histories.length).toBe(3);
-    expect(renderedHook.result.current.histories[1].data).toBe("Apples");
-    expect(renderedHook.result.current.histories[2].data).toBe("Oranges");
-    expect(renderedHook.result.current.currentHistory.data).toBe("Oranges");
+    expect(renderedHook.result.current.histories[1].state).toBe("Apples");
+    expect(renderedHook.result.current.histories[2].state).toBe("Oranges");
+    expect(renderedHook.result.current.currentHistory.state).toBe("Oranges");
   });
 
   test("should enable partial rewinds through history", () => {
@@ -43,7 +43,7 @@ describe("use-history-store", () => {
 
     expect(renderedHook.result.current.hasPast).toBe(true);
     expect(renderedHook.result.current.hasFuture).toBe(true);
-    expect(renderedHook.result.current.currentHistory.data).toBe("Apples");
+    expect(renderedHook.result.current.currentHistory.state).toBe("Apples");
   });
 
   test("should enable full rewinds through history", () => {
@@ -54,7 +54,7 @@ describe("use-history-store", () => {
 
     expect(renderedHook.result.current.hasPast).toBe(false);
     expect(renderedHook.result.current.hasFuture).toBe(true);
-    expect(renderedHook.result.current.currentHistory.data).toBe(
+    expect(renderedHook.result.current.currentHistory.state).toBe(
       "Strawberries"
     );
   });
@@ -68,7 +68,7 @@ describe("use-history-store", () => {
 
     expect(renderedHook.result.current.hasPast).toBe(true);
     expect(renderedHook.result.current.hasFuture).toBe(true);
-    expect(renderedHook.result.current.currentHistory.data).toBe("Apples");
+    expect(renderedHook.result.current.currentHistory.state).toBe("Apples");
   });
 
   test("should enable full fast-forwards through history", () => {
@@ -81,7 +81,7 @@ describe("use-history-store", () => {
 
     expect(renderedHook.result.current.hasPast).toBe(true);
     expect(renderedHook.result.current.hasFuture).toBe(false);
-    expect(renderedHook.result.current.currentHistory.data).toBe("Oranges");
+    expect(renderedHook.result.current.currentHistory.state).toBe("Oranges");
   });
 
   test("should replace the history if record is triggered after back", () => {
@@ -93,9 +93,9 @@ describe("use-history-store", () => {
     expect(renderedHook.result.current.hasPast).toBe(true);
     expect(renderedHook.result.current.hasFuture).toBe(false);
     expect(renderedHook.result.current.histories.length).toBe(3);
-    expect(renderedHook.result.current.histories[1].data).toBe("Apples");
-    expect(renderedHook.result.current.histories[2].data).toBe("Banana");
-    expect(renderedHook.result.current.currentHistory.data).toBe("Banana");
+    expect(renderedHook.result.current.histories[1].state).toBe("Apples");
+    expect(renderedHook.result.current.histories[2].state).toBe("Banana");
+    expect(renderedHook.result.current.currentHistory.state).toBe("Banana");
   });
 
   test("should reset histories and index on setHistories", () => {
@@ -105,7 +105,7 @@ describe("use-history-store", () => {
       renderedHook.result.current.setHistories([
         {
           id: "1",
-          data: "Oreo",
+          state: "Oreo",
         },
       ])
     );
@@ -113,8 +113,8 @@ describe("use-history-store", () => {
     expect(renderedHook.result.current.hasPast).toBe(false);
     expect(renderedHook.result.current.hasFuture).toBe(false);
     expect(renderedHook.result.current.histories.length).toBe(1);
-    expect(renderedHook.result.current.histories[0].data).toBe("Oreo");
-    expect(renderedHook.result.current.currentHistory.data).toBe("Oreo");
+    expect(renderedHook.result.current.histories[0].state).toBe("Oreo");
+    expect(renderedHook.result.current.currentHistory.state).toBe("Oreo");
     expect(renderedHook.result.current.index).toBe(0);
   });
 
@@ -126,7 +126,7 @@ describe("use-history-store", () => {
     expect(renderedHook.result.current.hasPast).toBe(false);
     expect(renderedHook.result.current.hasFuture).toBe(true);
     expect(renderedHook.result.current.histories.length).toBe(3);
-    expect(renderedHook.result.current.currentHistory.data).toBe(
+    expect(renderedHook.result.current.currentHistory.state).toBe(
       "Strawberries"
     );
     expect(renderedHook.result.current.index).toBe(0);
@@ -140,9 +140,9 @@ describe("use-history-store-prefilled", () => {
     renderedHook = renderHook(() =>
       useHistoryStore({
         histories: [
-          { id: "0", data: {} },
-          { id: "1", data: {} },
-          { id: "2", data: {} },
+          { id: "0", state: {} },
+          { id: "1", state: {} },
+          { id: "2", state: {} },
         ],
         index: 2,
       })

--- a/packages/core/lib/__tests__/use-history-store.spec.tsx
+++ b/packages/core/lib/__tests__/use-history-store.spec.tsx
@@ -9,13 +9,19 @@ describe("use-history-store", () => {
   let renderedHook: RenderHookResult<ReturnType<typeof useHistoryStore>, any>;
 
   beforeEach(() => {
-    renderedHook = renderHook(() => useHistoryStore());
+    renderedHook = renderHook(() =>
+      useHistoryStore({
+        index: 0,
+        histories: [{ data: "Strawberries", id: "initial" }],
+      })
+    );
   });
 
   test("should have the correct initial state", () => {
     expect(renderedHook.result.current.hasPast).toBe(false);
     expect(renderedHook.result.current.hasFuture).toBe(false);
-    expect(renderedHook.result.current.histories.length).toBe(0);
+    expect(renderedHook.result.current.histories.length).toBe(1);
+    expect(renderedHook.result.current.histories[0].data).toBe("Strawberries");
   });
 
   test("should record the history", () => {
@@ -24,9 +30,9 @@ describe("use-history-store", () => {
 
     expect(renderedHook.result.current.hasPast).toBe(true);
     expect(renderedHook.result.current.hasFuture).toBe(false);
-    expect(renderedHook.result.current.histories.length).toBe(2);
-    expect(renderedHook.result.current.histories[0].data).toBe("Apples");
-    expect(renderedHook.result.current.histories[1].data).toBe("Oranges");
+    expect(renderedHook.result.current.histories.length).toBe(3);
+    expect(renderedHook.result.current.histories[1].data).toBe("Apples");
+    expect(renderedHook.result.current.histories[2].data).toBe("Oranges");
     expect(renderedHook.result.current.currentHistory.data).toBe("Oranges");
   });
 
@@ -48,7 +54,9 @@ describe("use-history-store", () => {
 
     expect(renderedHook.result.current.hasPast).toBe(false);
     expect(renderedHook.result.current.hasFuture).toBe(true);
-    expect(renderedHook.result.current.currentHistory).toBeFalsy();
+    expect(renderedHook.result.current.currentHistory.data).toBe(
+      "Strawberries"
+    );
   });
 
   test("should enable partial fast-forwards through history", () => {
@@ -84,9 +92,9 @@ describe("use-history-store", () => {
 
     expect(renderedHook.result.current.hasPast).toBe(true);
     expect(renderedHook.result.current.hasFuture).toBe(false);
-    expect(renderedHook.result.current.histories.length).toBe(2);
-    expect(renderedHook.result.current.histories[0].data).toBe("Apples");
-    expect(renderedHook.result.current.histories[1].data).toBe("Banana");
+    expect(renderedHook.result.current.histories.length).toBe(3);
+    expect(renderedHook.result.current.histories[1].data).toBe("Apples");
+    expect(renderedHook.result.current.histories[2].data).toBe("Banana");
     expect(renderedHook.result.current.currentHistory.data).toBe("Banana");
   });
 
@@ -102,7 +110,7 @@ describe("use-history-store", () => {
       ])
     );
 
-    expect(renderedHook.result.current.hasPast).toBe(true);
+    expect(renderedHook.result.current.hasPast).toBe(false);
     expect(renderedHook.result.current.hasFuture).toBe(false);
     expect(renderedHook.result.current.histories.length).toBe(1);
     expect(renderedHook.result.current.histories[0].data).toBe("Oreo");
@@ -115,10 +123,12 @@ describe("use-history-store", () => {
     act(() => renderedHook.result.current.record("Oranges"));
     act(() => renderedHook.result.current.setHistoryIndex(0));
 
-    expect(renderedHook.result.current.hasPast).toBe(true);
+    expect(renderedHook.result.current.hasPast).toBe(false);
     expect(renderedHook.result.current.hasFuture).toBe(true);
-    expect(renderedHook.result.current.histories.length).toBe(2);
-    expect(renderedHook.result.current.currentHistory.data).toBe("Apples");
+    expect(renderedHook.result.current.histories.length).toBe(3);
+    expect(renderedHook.result.current.currentHistory.data).toBe(
+      "Strawberries"
+    );
     expect(renderedHook.result.current.index).toBe(0);
   });
 });

--- a/packages/core/lib/__tests__/use-puck-history.spec.tsx
+++ b/packages/core/lib/__tests__/use-puck-history.spec.tsx
@@ -40,7 +40,6 @@ describe("use-puck-history", () => {
   test("back function calls dispatch when there is a history", () => {
     historyStore.hasPast = true;
     historyStore.prevHistory = {
-      id: "",
       data: {
         ...defaultAppState,
         ui: { ...defaultAppState.ui, leftSideBarVisible: false },
@@ -80,7 +79,6 @@ describe("use-puck-history", () => {
 
   test("forward function calls dispatch when there is a future", () => {
     historyStore.nextHistory = {
-      id: "",
       data: {
         ...defaultAppState,
         ui: { ...defaultAppState.ui, leftSideBarVisible: false },

--- a/packages/core/lib/__tests__/use-puck-history.spec.tsx
+++ b/packages/core/lib/__tests__/use-puck-history.spec.tsx
@@ -40,7 +40,7 @@ describe("use-puck-history", () => {
   test("back function calls dispatch when there is a history", () => {
     historyStore.hasPast = true;
     historyStore.prevHistory = {
-      data: {
+      state: {
         ...defaultAppState,
         ui: { ...defaultAppState.ui, leftSideBarVisible: false },
       },
@@ -57,7 +57,7 @@ describe("use-puck-history", () => {
     expect(historyStore.back).toHaveBeenCalled();
     expect(dispatch).toHaveBeenCalledWith({
       type: "set",
-      state: historyStore.prevHistory?.data || initialAppState,
+      state: historyStore.prevHistory?.state || initialAppState,
     });
   });
 
@@ -79,7 +79,7 @@ describe("use-puck-history", () => {
 
   test("forward function calls dispatch when there is a future", () => {
     historyStore.nextHistory = {
-      data: {
+      state: {
         ...defaultAppState,
         ui: { ...defaultAppState.ui, leftSideBarVisible: false },
       },
@@ -96,7 +96,7 @@ describe("use-puck-history", () => {
     expect(historyStore.forward).toHaveBeenCalled();
     expect(dispatch).toHaveBeenCalledWith({
       type: "set",
-      state: historyStore.nextHistory?.data,
+      state: historyStore.nextHistory?.state,
     });
   });
 
@@ -108,14 +108,14 @@ describe("use-puck-history", () => {
     const updatedHistories = [
       {
         id: "1",
-        data: {
+        state: {
           one: "foo 1",
           two: "bar 1",
         },
       },
       {
         id: "2",
-        data: {
+        state: {
           one: "foo 2",
           two: "bar 2",
         },
@@ -129,7 +129,7 @@ describe("use-puck-history", () => {
     expect(historyStore.setHistories).toHaveBeenCalled();
     expect(dispatch).toHaveBeenCalledWith({
       type: "set",
-      state: updatedHistories[1].data,
+      state: updatedHistories[1].state,
     });
   });
 
@@ -137,14 +137,14 @@ describe("use-puck-history", () => {
     const updatedHistories = [
       {
         id: "1",
-        data: {
+        state: {
           one: "foo 1",
           two: "bar 1",
         },
       },
       {
         id: "2",
-        data: {
+        state: {
           one: "foo 2",
           two: "bar 2",
         },
@@ -163,7 +163,7 @@ describe("use-puck-history", () => {
     expect(historyStore.setHistoryIndex).toHaveBeenCalled();
     expect(dispatch).toHaveBeenCalledWith({
       type: "set",
-      state: updatedHistories[0].data,
+      state: updatedHistories[0].state,
     });
   });
 

--- a/packages/core/lib/flush-zones.ts
+++ b/packages/core/lib/flush-zones.ts
@@ -8,8 +8,8 @@ import { addToZoneCache } from "../reducer/data";
  * @returns appState with zones removed from data
  */
 export const flushZones = <UserData extends Data>(
-  appState: AppState<UserData>
-): AppState<UserData> => {
+  appState: AppState | AppState<UserData>
+): AppState | AppState<UserData> => {
   const containsZones = typeof appState.data.zones !== "undefined";
 
   if (containsZones) {

--- a/packages/core/lib/use-history-store.ts
+++ b/packages/core/lib/use-history-store.ts
@@ -1,11 +1,7 @@
 import { useState } from "react";
-import { generateId } from "./generate-id";
 import { useDebouncedCallback } from "use-debounce";
-
-export type History<D = any> = {
-  id: string;
-  data: D;
-};
+import { History } from "../types";
+import { generateId } from "./generate-id";
 
 export type HistoryStore<D = any> = {
   // Exposed via usePuck
@@ -25,9 +21,9 @@ export type HistoryStore<D = any> = {
   setHistoryIndex: (index: number) => void;
 };
 
-const EMPTY_HISTORY_INDEX = -1;
+const EMPTY_HISTORY_INDEX = 0;
 
-export function useHistoryStore<D = any>(initialHistory?: {
+export function useHistoryStore<D = any>(initialHistory: {
   histories: History<any>[];
   index: number;
 }): HistoryStore<D> {

--- a/packages/core/lib/use-history-store.ts
+++ b/packages/core/lib/use-history-store.ts
@@ -48,9 +48,9 @@ export function useHistoryStore<D = any>(initialHistory: {
   const nextHistory = hasFuture ? histories[index + 1] : null;
   const prevHistory = hasPast ? histories[index - 1] : null;
 
-  const record = useDebouncedCallback((data: D) => {
+  const record = useDebouncedCallback((state: D) => {
     const history: History = {
-      data,
+      state,
       id: generateId("history"),
     };
 

--- a/packages/core/lib/use-puck-history.ts
+++ b/packages/core/lib/use-puck-history.ts
@@ -24,7 +24,7 @@ export function usePuckHistory({
     if (historyStore.hasPast) {
       dispatch({
         type: "set",
-        state: historyStore.prevHistory?.data || initialAppState,
+        state: historyStore.prevHistory?.state || initialAppState,
       });
 
       historyStore.back();
@@ -33,7 +33,7 @@ export function usePuckHistory({
 
   const forward = () => {
     if (historyStore.nextHistory) {
-      dispatch({ type: "set", state: historyStore.nextHistory.data });
+      dispatch({ type: "set", state: historyStore.nextHistory.state });
 
       historyStore.forward();
     }
@@ -43,7 +43,7 @@ export function usePuckHistory({
     // dispatch the last history index or initial state
     dispatch({
       type: "set",
-      state: histories[histories.length - 1]?.data || initialAppState,
+      state: histories[histories.length - 1]?.state || initialAppState,
     });
 
     historyStore.setHistories(histories);
@@ -53,7 +53,7 @@ export function usePuckHistory({
     if (historyStore.histories.length > index) {
       dispatch({
         type: "set",
-        state: historyStore.histories[index]?.data || initialAppState,
+        state: historyStore.histories[index]?.state || initialAppState,
       });
 
       historyStore.setHistoryIndex(index);

--- a/packages/core/lib/use-puck-history.ts
+++ b/packages/core/lib/use-puck-history.ts
@@ -1,7 +1,7 @@
-import type { AppState } from "../types";
+import type { AppState, History } from "../types";
 import { PuckAction } from "../reducer";
 import { useHotkeys } from "react-hotkeys-hook";
-import { History, HistoryStore } from "./use-history-store";
+import { HistoryStore } from "./use-history-store";
 
 export type PuckHistory = {
   back: VoidFunction;

--- a/packages/core/types/API/index.ts
+++ b/packages/core/types/API/index.ts
@@ -30,10 +30,21 @@ export type History<D = any> = {
   id?: string;
 };
 
-export type InitialHistory<AS = AppState> = {
+type InitialHistoryAppend<AS = AppState> = {
   histories: History<AS>[];
   index: number;
+  appendData?: true;
 };
+
+type InitialHistoryNoAppend<AS = AppState> = {
+  histories: [History<AS>, ...History<AS>[]]; // Array with minimum length of 1
+  index: number;
+  appendData?: false;
+};
+
+export type InitialHistory<AS = AppState> =
+  | InitialHistoryAppend<AS>
+  | InitialHistoryNoAppend<AS>;
 
 export * from "./Viewports";
 

--- a/packages/core/types/API/index.ts
+++ b/packages/core/types/API/index.ts
@@ -30,19 +30,19 @@ export type History<D = any> = {
   id?: string;
 };
 
-type InitialHistoryAppend<AS = AppState> = {
+type InitialHistoryAppend<AS = Partial<AppState>> = {
   histories: History<AS>[];
   index: number;
   appendData?: true;
 };
 
-type InitialHistoryNoAppend<AS = AppState> = {
+type InitialHistoryNoAppend<AS = Partial<AppState>> = {
   histories: [History<AS>, ...History<AS>[]]; // Array with minimum length of 1
   index: number;
   appendData?: false;
 };
 
-export type InitialHistory<AS = AppState> =
+export type InitialHistory<AS = Partial<AppState>> =
   | InitialHistoryAppend<AS>
   | InitialHistoryNoAppend<AS>;
 

--- a/packages/core/types/API/index.ts
+++ b/packages/core/types/API/index.ts
@@ -32,13 +32,13 @@ export type History<D = any> = {
 
 type InitialHistoryAppend<AS = Partial<AppState>> = {
   histories: History<AS>[];
-  index: number;
+  index?: number;
   appendData?: true;
 };
 
 type InitialHistoryNoAppend<AS = Partial<AppState>> = {
   histories: [History<AS>, ...History<AS>[]]; // Array with minimum length of 1
-  index: number;
+  index?: number;
   appendData?: false;
 };
 

--- a/packages/core/types/API/index.ts
+++ b/packages/core/types/API/index.ts
@@ -25,6 +25,16 @@ export type Plugin = {
   overrides: Partial<Overrides>;
 };
 
+export type History<D = any> = {
+  data: D;
+  id: string;
+};
+
+export type InitialHistory<AS = AppState> = {
+  histories: History<AS>[];
+  index: number;
+};
+
 export * from "./Viewports";
 
 export type { Overrides };

--- a/packages/core/types/API/index.ts
+++ b/packages/core/types/API/index.ts
@@ -26,7 +26,7 @@ export type Plugin = {
 };
 
 export type History<D = any> = {
-  data: D;
+  state: D;
   id?: string;
 };
 

--- a/packages/core/types/API/index.ts
+++ b/packages/core/types/API/index.ts
@@ -27,7 +27,7 @@ export type Plugin = {
 
 export type History<D = any> = {
   data: D;
-  id: string;
+  id?: string;
 };
 
 export type InitialHistory<AS = AppState> = {


### PR DESCRIPTION
Rework the history store to ensure intialHistories API works as expected. Previously, the historyStore would assume that `data` was the first item in history, and all history was additive. This PR reverses the logic, placing `data` at the end of the history to enable injection of custom histories.

Changes:

* Make `initialHistories` mandatory internally when using the `useHistoryStore` hook 
* Set `EMPTY_HISTORY_INDEX` to `0` instead of `-1`, since some history always exists
* Set the last history item to the `data` prop
* Remove unnecessary `id` parameter in `History` type
* Fix an issue preventing viewports from resizing when changed programatically (encountered when testing history)

## Before

Default history store:

```ts
[]
```

Injecting history via `initialHistories` prop API

```ts
[
  {
    data: {} // custom history as injected by `initialHistories ` prop
  }
]
```

## After

Default history store

```ts
[
  {
    data: {} // `data` prop passed in via user
  } 
]
```

or when injecting via API

```ts
[
  {
    data: {} // custom history as injected by `initialHistories ` prop
  },
  {
    data: {} // `data` prop passed in via user
  } 
]
```

---

@mkilpatrick I think this should help with your challenges in #562. You can test this via [0.16.0-canary.464aa1e](https://www.npmjs.com/package/@measured/puck/v/0.16.0-canary.464aa1e). I'd love to get this in ASAP as this API is now one of the things blocking release of v0.16.