### PR TITLE
fix: don't cache /edit route in Next recipe

### DIFF
--- a/recipes/next/app/puck/[...puckPath]/page.tsx
+++ b/recipes/next/app/puck/[...puckPath]/page.tsx
@@ -38,3 +38,5 @@ export default async function Page({
 
   return <Client path={path} data={data || {}} />;
 }
+
+export const dynamic = "force-dynamic";

--- a/recipes/next/app/puck/page.tsx
+++ b/recipes/next/app/puck/page.tsx
@@ -1,1 +1,1 @@
-export { default, generateMetadata } from "./[...puckPath]/page";
+export { default, generateMetadata, dynamic } from "./[...puckPath]/page";


### PR DESCRIPTION
Next.js cache was interfering with the dynamic `/puck` route in the next recipe. Note, the regular route is behaving as expected.

This fix forces the /edit route to use dynamic rendering.

## Steps to reproduce

1. Clone the repo
2. Run yarn to install dependencies
3. Run yarn build to generate a build
4. Run yarn start to run the production build
5. Navigate to page editor
6. Reload the page
7. Make changes and hit the publish button
8. Reload the page 

## What happened

The old data was shown

## Wha I expected to happen

The new data to be shown