### PR TITLE
fix: always record history on component insert

### DIFF
--- a/apps/docs/pages/docs/integrating-puck/dynamic-props.mdx
+++ b/apps/docs/pages/docs/integrating-puck/dynamic-props.mdx
@@ -63,6 +63,8 @@ const config = {
 }}
 />
 
+> When inserting components with `resolveData`, the Puck state will update twice - once for the initial insert, and once more when the method resolves, if it changes the data. This will be reflected in the undo/redo history.
+
 ### Setting fields as read-only
 
 [`resolveData`](/docs/api-reference/configuration/component-config#resolvedatadata-params) also allows us to mark fields as read-only using the [`readOnly` parameter](/docs/api-reference/configuration/component-config#datareadonly-1).

--- a/packages/core/lib/__tests__/insert-component.spec.tsx
+++ b/packages/core/lib/__tests__/insert-component.spec.tsx
@@ -74,7 +74,7 @@ describe("use-insert-component", () => {
         destinationZone: rootDroppableId,
         destinationIndex: 0,
         id: expect.stringContaining("MyComponent-"),
-        recordHistory: false,
+        recordHistory: true,
       });
     });
 

--- a/packages/core/lib/insert-component.ts
+++ b/packages/core/lib/insert-component.ts
@@ -35,7 +35,11 @@ export const insertComponent = (
   // Dispatch the insert, immediately
   dispatch({
     ...insertActionData, // Dispatch insert rather set, as user's may rely on this via onAction
-    recordHistory: false,
+
+    // We must always record history here so the insert is added to user history
+    // If the user has defined a resolveData method, they will end up with 2 history
+    // entries on insert - one for the initial insert, and one when the data resolves
+    recordHistory: true,
   });
 
   const itemSelector = {


### PR DESCRIPTION
This will result in duplicate history entries if the item has a resolveData method. This is difficult to prevent without a deferredDispatch method, similar to that being explored in #598.