### PR TITLE
feat: autocomplete subprops and allow string values for readOnly in resolveData

### DIFF
--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -1,7 +1,7 @@
 import { Fields } from "./Fields";
 import { ComponentData, RootData } from "./Data";
 
-import { AsFieldProps, WithId, WithPuckProps } from "./Utils";
+import { AsFieldProps, DotBranch, WithId, WithPuckProps } from "./Utils";
 import { AppState } from "./AppState";
 import { DefaultComponentProps, DefaultRootRenderProps } from "./Props";
 import { Permissions } from "./API";
@@ -33,17 +33,17 @@ export type ComponentConfig<
   resolveData?: (
     data: DataShape,
     params: {
-      changed: Partial<Record<keyof FieldProps, boolean>>;
+      changed: Partial<Record<DotBranch<FieldProps>, boolean>>;
       lastData: DataShape | null;
     }
   ) =>
     | Promise<{
         props?: Partial<FieldProps>;
-        readOnly?: Partial<Record<keyof FieldProps, boolean>>;
+        readOnly?: Partial<Record<DotBranch<FieldProps>, boolean | string>>;
       }>
     | {
         props?: Partial<FieldProps>;
-        readOnly?: Partial<Record<keyof FieldProps, boolean>>;
+        readOnly?: Partial<Record<DotBranch<FieldProps>, boolean | string>>;
       };
   resolvePermissions?: (
     data: DataShape,

--- a/packages/core/types/Data.tsx
+++ b/packages/core/types/Data.tsx
@@ -1,10 +1,10 @@
 import { DefaultComponentProps, DefaultRootFieldProps } from "./Props";
-import { AsFieldProps, WithId } from "./Utils";
+import { AsFieldProps, DotBranch, WithId } from "./Utils";
 
 export type BaseData<
   Props extends { [key: string]: any } = { [key: string]: any }
 > = {
-  readOnly?: Partial<Record<keyof Props, boolean>>;
+  readOnly?: Partial<Record<DotBranch<Props>, boolean | string>>;
 };
 
 export type RootDataWithProps<

--- a/packages/core/types/Fields.ts
+++ b/packages/core/types/Fields.ts
@@ -107,7 +107,7 @@ export type CustomField<Props extends any = {}> = BaseField & {
     id: string;
     value: Props;
     onChange: (value: Props) => void;
-    readOnly?: boolean;
+    readOnly?: boolean | string;
   }) => ReactElement;
 };
 
@@ -136,5 +136,5 @@ export type FieldProps<ValueType = any, F = Field<any>> = {
   value: ValueType;
   id?: string;
   onChange: (value: ValueType, uiState?: Partial<UiState>) => void;
-  readOnly?: boolean;
+  readOnly?: boolean | string;
 };

--- a/packages/core/types/Utils.tsx
+++ b/packages/core/types/Utils.tsx
@@ -52,3 +52,53 @@ export type UserGenerics<
   UserAppState: UserAppState;
   UserComponentData: UserComponentData;
 };
+
+// Helper type to increment depth (tuple length)
+type IncrementDepth<D extends any[]> = [...D, any];
+
+// Maximum depth to prevent infinite recursion
+type MaxDepth = [any, any, any, any, any]; // Adjust the length to set the maximum depth
+
+// Joins two strings with dot notation
+export type DotJoin<A extends string, B extends string> = A extends ""
+  ? B
+  : `${A}.${B}`;
+
+// Recursively finds all keys of a Record
+export type DeepKeys<O extends Record<string, any>> = {
+  [K in Extract<keyof O, string>]: O[K] extends Record<string, any>
+    ? K | DotJoin<K, DeepKeys<O[K]>>
+    : K;
+}[Extract<keyof O, string>];
+
+/**
+ * Returns keys of an object in dot notation.
+ *
+ * ```
+ * type Foo: {
+ *  a: {
+ *    b: string;
+ *    c: {
+ *      d: string;
+ *      e: string;
+ *    }
+ *  }
+ *  f: string;
+ * }
+ * ```
+ *
+ * type Result = DotBranch<Foo> // "a" | "a.b" | "a.c" | "a.c.d" | "a.c.e" | "f"
+ */
+
+export type DotBranch<
+  O extends Record<string, any>,
+  P extends string = "",
+  D extends any[] = [],
+  K extends string = Extract<keyof O, string>
+> = D["length"] extends MaxDepth["length"]
+  ? DotJoin<P, K>
+  : K extends keyof O
+  ? O[K] extends Record<string, any>
+    ? DotBranch<O[K], DotJoin<P, K>, IncrementDepth<D>> | DotJoin<P, K>
+    : DotJoin<P, K>
+  : never;


### PR DESCRIPTION
This updates the TS types of resolveData such that:

`readOnly` can now return a boolean OR a string. Supporting string is helpful when you have a 'custom' field defined for a level which contains multiple fields underneath, rather than using objectFields. resolveData can pass a string value of the subfield being set for readOnly.

As an example, given this type:
```
type MyProps = {
  foo: {
    bar: {
      id: string;
      value: string;
  }
}
```
and I want to create a custom Puck field at the `bar` level, I have id and value as subprops. resolveData works at the level of `bar`, so if you wanted to set value as readOnly, that is not possible with
```
resolveData: () => {
  return {
    readOnly: { 'foo.bar': true }
  }
}
```
we do this instead now
```
resolveData: () => {
  return {
    readOnly: { 'foo.bar': 'value' }
  }
}
```
and then in the field's `render` function the `readOnly` prop would have a value of 'value'.


The `readOnly` acceptable values now autocomplete to any valid subfield. Prior to this change only the top-level fields were enumerated by the type. Given the MyProps example above:
```
resolveData: () => {
  return {
    readOnly: { 'HERE': 'value' } 
  }
}
```
`HERE` would autocomplete as: 'foo'

Now it autocompletes as : 'foo' | 'foo.bar' | 'foo.bar.id' | 'foo.bar.value'

More context around these changes can be found [here](https://discord.com/channels/1153376562259951687/1286455244036771942/1286455244036771942).