### PR TITLE
feat: change default  FieldLabel el from `label` to `div` (breaking change)

### DIFF
--- a/packages/core/components/AutoField/index.tsx
+++ b/packages/core/components/AutoField/index.tsx
@@ -72,7 +72,7 @@ export const FieldLabelInternal = ({
   children,
   icon,
   label,
-  el = "div",
+  el = "label",
   readOnly,
 }: FieldLabelPropsInternal) => {
   const { overrides } = useAppContext();

--- a/packages/core/components/AutoField/index.tsx
+++ b/packages/core/components/AutoField/index.tsx
@@ -31,7 +31,7 @@ export const FieldLabel = ({
   children,
   icon,
   label,
-  el = "label",
+  el = "div",
   readOnly,
   className,
 }: {
@@ -72,7 +72,7 @@ export const FieldLabelInternal = ({
   children,
   icon,
   label,
-  el = "label",
+  el = "div",
   readOnly,
 }: FieldLabelPropsInternal) => {
   const { overrides } = useAppContext();


### PR DESCRIPTION
### steps to reproduce
>
>1-go to docs > Api refrence > Fields > [Array](https://puckeditor.com/docs/api-reference/fields/array)
>
>2- click on any of the array items and you will notice it will cause a deletion as if you clicked on delete button

fixs [#528](https://github.com/measuredco/puck/issues/528)