### PR TITLE
fix:defaultActionBar actions left border in RTL mode

### DIFF
--- a/packages/core/components/ActionBar/styles.module.css
+++ b/packages/core/components/ActionBar/styles.module.css
@@ -27,7 +27,7 @@
 }
 
 .ActionBar-group {
-  border-left: 0.5px solid var(--puck-color-grey-05); /* Fractional value required due to scaling */
+  border-inline-start: 0.5px solid var(--puck-color-grey-05); /* Fractional value required due to scaling */
   display: flex;
   padding-left: 4px;
   padding-right: 4px;


### PR DESCRIPTION
![puck_rtl_bug](https://github.com/user-attachments/assets/77cf3383-fecd-48ac-9e62-399385a771e6)

 fixs little visual bug where the actions's left border of the default action bar would look weird in RTL mode
 
 ### steps to reproduce
 set the `direction` of the iframe's html element (or the root html if you disabled iframe) to `rtl` and select any of the components in the preview