### PR TITLE
feat: array field element duplicate functionality

### DIFF
--- a/packages/core/components/AutoField/fields/ArrayField/index.tsx
+++ b/packages/core/components/AutoField/fields/ArrayField/index.tsx
@@ -221,6 +221,35 @@ export const ArrayField = ({
                                   <div className={getClassNameItem("action")}>
                                     <IconButton
                                       type="button"
+                                      disabled={!!addDisabled}
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+
+                                        const existingValue = [
+                                          ...(value || []),
+                                        ];
+
+                                        existingValue.splice(
+                                          i,
+                                          0,
+                                          existingValue[i]
+                                        );
+
+                                        onChange(
+                                          existingValue,
+                                          mapArrayStateToUi(
+                                            regenerateArrayState(existingValue)
+                                          )
+                                        );
+                                      }}
+                                      title="Duplicate"
+                                    >
+                                      <Copy size={16} />
+                                    </IconButton>
+                                  </div>
+                                  <div className={getClassNameItem("action")}>
+                                    <IconButton
+                                      type="button"
                                       disabled={
                                         field.min !== undefined &&
                                         field.min >=
@@ -250,29 +279,6 @@ export const ArrayField = ({
                                       title="Delete"
                                     >
                                       <Trash size={16} />
-                                    </IconButton>
-                                  </div>
-                                  <div className={getClassNameItem("action")}>
-                                    <IconButton
-                                      type="button"
-                                      disabled={!!addDisabled}
-                                      onClick={(e) => {
-                                        e.stopPropagation();
-
-                                        const existingValue = [
-                                          ...(value || []),
-                                        ];
-
-                                        existingValue.splice(i, 0, existingValue[i]);
-
-                                        onChange(
-                                          existingValue,
-                                          mapArrayStateToUi(regenerateArrayState(existingValue))
-                                        );
-                                      }}
-                                      title="Duplicate"
-                                    >
-                                      <Copy size={16} />
                                     </IconButton>
                                   </div>
                                 </div>

--- a/packages/core/components/AutoField/fields/ArrayField/index.tsx
+++ b/packages/core/components/AutoField/fields/ArrayField/index.tsx
@@ -270,7 +270,7 @@ export const ArrayField = ({
                                           mapArrayStateToUi(regenerateArrayState(existingValue))
                                         );
                                       }}
-                                      title="Copy"
+                                      title="Duplicate"
                                     >
                                       <Copy size={16} />
                                     </IconButton>

--- a/packages/core/components/AutoField/fields/ArrayField/index.tsx
+++ b/packages/core/components/AutoField/fields/ArrayField/index.tsx
@@ -1,6 +1,6 @@
 import getClassNameFactory from "../../../../lib/get-class-name-factory";
 import styles from "./styles.module.css";
-import { List, Plus, Trash } from "lucide-react";
+import { Copy, List, Plus, Trash } from "lucide-react";
 import { AutoFieldPrivate, FieldPropsInternal } from "../..";
 import { IconButton } from "../../../IconButton";
 import { reorder, replace } from "../../../../lib";
@@ -250,6 +250,29 @@ export const ArrayField = ({
                                       title="Delete"
                                     >
                                       <Trash size={16} />
+                                    </IconButton>
+                                  </div>
+                                  <div className={getClassNameItem("action")}>
+                                    <IconButton
+                                      type="button"
+                                      disabled={!!addDisabled}
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+
+                                        const existingValue = [
+                                          ...(value || []),
+                                        ];
+
+                                        existingValue.splice(i, 0, existingValue[i]);
+
+                                        onChange(
+                                          existingValue,
+                                          mapArrayStateToUi(regenerateArrayState(existingValue))
+                                        );
+                                      }}
+                                      title="Copy"
+                                    >
+                                      <Copy size={16} />
                                     </IconButton>
                                   </div>
                                 </div>


### PR DESCRIPTION
First of all, thanks for such awesome library.

For some purposes it's useful to have duplicate functionality not only for the whole component but also for Array field element itself.

<img width="249" alt="image" src="https://github.com/user-attachments/assets/fbcc4754-f13a-45c0-a741-289a2013fd8a">
