### PR TITLE
fix: broken link in <Render/> component docs

### DIFF
--- a/apps/docs/pages/docs/api-reference/components/render.mdx
+++ b/apps/docs/pages/docs/api-reference/components/render.mdx
@@ -25,7 +25,7 @@ export function Example() {
 
 ### `config`
 
-An object describing the available components, fields and more. See the [`Config` docs](/docs/api-reference/config) for a full reference.
+An object describing the available components, fields and more. See the [`Config` docs](/docs/api-reference/configuration/config) for a full reference.
 
 ```tsx {4-17} copy
 export function Example() {


### PR DESCRIPTION
### Steps to reproduce
1. Go to [https://puckeditor.com/docs/api-reference/components/render#required-props](https://puckeditor.com/docs/api-reference/components/render#required-props)
2. Click "Config docs" link