### PR TITLE
feat: allow react elements in external field mapRow

### DIFF
--- a/apps/demo/config/blocks/Hero/index.tsx
+++ b/apps/demo/config/blocks/Hero/index.tsx
@@ -77,7 +77,10 @@ export const Hero: ComponentConfig<HeroProps> = {
             }
           });
       },
-      mapRow: (item) => ({ title: item.title, description: item.description }),
+      mapRow: (item) => ({
+        title: item.title,
+        description: <span>{item.description}</span>,
+      }),
       mapProp: (result) => {
         return { index: result.index, label: result.description };
       },

--- a/packages/core/components/ExternalInput/index.tsx
+++ b/packages/core/components/ExternalInput/index.tsx
@@ -1,4 +1,10 @@
-import { useMemo, useEffect, useState, useCallback } from "react";
+import {
+  useMemo,
+  useEffect,
+  useState,
+  useCallback,
+  isValidElement,
+} from "react";
 import styles from "./styles.module.css";
 import getClassNameFactory from "../../lib/get-class-name-factory";
 import { ExternalField } from "../../types";
@@ -54,7 +60,11 @@ export const ExternalInput = ({
 
     for (const item of mappedData) {
       for (const key of Object.keys(item)) {
-        if (typeof item[key] === "string" || typeof item[key] === "number") {
+        if (
+          typeof item[key] === "string" ||
+          typeof item[key] === "number" ||
+          isValidElement(item[key])
+        ) {
           validKeys.add(key);
         }
       }

--- a/packages/core/types/Fields.ts
+++ b/packages/core/types/Fields.ts
@@ -91,7 +91,7 @@ export type ExternalField<
     filters: Record<string, any>;
   }) => Promise<any[] | null>;
   mapProp?: (value: any) => Props;
-  mapRow?: (value: any) => Record<string, string | number>;
+  mapRow?: (value: any) => Record<string, string | number | ReactElement>;
   getItemSummary?: (item: Props, index?: number) => string;
   showSearch?: boolean;
   initialQuery?: string;


### PR DESCRIPTION
## Description
- Adds support for `mapRow` items of type `ReactElement` (previously just `string | number`)
- Resolves #506 

## Screenshots
![image](https://github.com/user-attachments/assets/973bcdcf-d73f-4407-bc1d-a7b6c8cc3cd7)

```
       mapRow: (item) => ({
        img: (
          <img src="https://placehold.co/600x400" height="40" width="60" />
        ),
        title: item.title,
        description: item.description,
      }),
```