### PR TITLE
feat: add renderFooter option in external field

### DIFF
--- a/apps/demo/config/blocks/Hero/index.tsx
+++ b/apps/demo/config/blocks/Hero/index.tsx
@@ -35,17 +35,7 @@ export const Hero: ComponentConfig<HeroProps> = {
       showSearch: false,
       renderFooter: (data) => {
         return (
-          <div
-            style={{
-              textAlign: "end",
-              padding: "16px",
-              backgroundColor: "var(--puck-color-grey-12)",
-              color: "var(--puck-color-grey-04)",
-              borderTop: "1px solid var(--puck-color-grey-09)",
-              fontSize: "14px",
-              fontWeight: "500",
-            }}
-          >
+          <div>
             {data.length} result{data.length === 1 ? "" : "s"}
           </div>
         );

--- a/apps/demo/config/blocks/Hero/index.tsx
+++ b/apps/demo/config/blocks/Hero/index.tsx
@@ -33,10 +33,10 @@ export const Hero: ComponentConfig<HeroProps> = {
       type: "external",
       placeholder: "Select a quote",
       showSearch: false,
-      renderFooter: (data) => {
+      renderFooter: ({ items }) => {
         return (
           <div>
-            {data.length} result{data.length === 1 ? "" : "s"}
+            {items.length} result{items.length === 1 ? "" : "s"}
           </div>
         );
       },

--- a/apps/demo/config/blocks/Hero/index.tsx
+++ b/apps/demo/config/blocks/Hero/index.tsx
@@ -32,7 +32,24 @@ export const Hero: ComponentConfig<HeroProps> = {
     quote: {
       type: "external",
       placeholder: "Select a quote",
-      showSearch: true,
+      showSearch: false,
+      renderFooter: (data) => {
+        return (
+          <div
+            style={{
+              textAlign: "end",
+              padding: "16px",
+              backgroundColor: "var(--puck-color-grey-12)",
+              color: "var(--puck-color-grey-04)",
+              borderTop: "1px solid var(--puck-color-grey-09)",
+              fontSize: "14px",
+              fontWeight: "500",
+            }}
+          >
+            {data.length} result{data.length === 1 ? "" : "s"}
+          </div>
+        );
+      },
       filterFields: {
         author: {
           type: "select",

--- a/apps/docs/pages/docs/api-reference/fields/external.mdx
+++ b/apps/docs/pages/docs/api-reference/fields/external.mdx
@@ -63,7 +63,7 @@ const config = {
 | [`mapRow()`](#maprowitem)                 | `mapRow: async ({ title }) => title`         | Function   | -        |
 | [`placeholder`](#placeholder)             | `placeholder: "Select content"`              | String     | -        |
 | [`showSearch`](#showsearch)               | `showSearch: true`                           | Boolean    | -        |
-| [`renderFooter()`](#renderfooterdata)     | `renderFooter: (props) => <p>Hello</p>`      | Function   | -        |
+| [`renderFooter()`](#renderfooterprops)    | `renderFooter: (props) => <p>Hello</p>`      | Function   | -        |
 
 ## Required params
 

--- a/apps/docs/pages/docs/api-reference/fields/external.mdx
+++ b/apps/docs/pages/docs/api-reference/fields/external.mdx
@@ -63,7 +63,7 @@ const config = {
 | [`mapRow()`](#maprowitem)                 | `mapRow: async ({ title }) => title`         | Function   | -        |
 | [`placeholder`](#placeholder)             | `placeholder: "Select content"`              | String     | -        |
 | [`showSearch`](#showsearch)               | `showSearch: true`                           | Boolean    | -        |
-| [`renderFooter()`](#renderfooterdata)     | `renderFooter: (data) => <p>Hello</p>`       | Function   | -        |
+| [`renderFooter()`](#renderfooterdata)     | `renderFooter: (props) => <p>Hello</p>`      | Function   | -        |
 
 ## Required params
 
@@ -612,7 +612,7 @@ const config = {
 }}
 />
 
-### `renderFooter(data)`
+### `renderFooter(props)`
 
 Customize what will be displayed in the footer of the modal.
 
@@ -629,7 +629,7 @@ const config = {
               { title: "Goodbye, world", description: "Lorem ipsum 2" },
             ];
           },
-          renderFooter: (data) => <span>Hello, footer</span>,
+          renderFooter: ({ items }) => <span>{items.length} results</span>,
         },
       },
       render: ({ data }) => {
@@ -653,7 +653,7 @@ const config = {
             { title: "Goodbye, world", description: "Lorem ipsum 2" },
           ];
         },
-        renderFooter: (data) => <span>Hello, footer</span>,
+        renderFooter: ({ items }) => <span>{items.length} results</span>,
       },
     },
     render: ({ data }) => {

--- a/apps/docs/pages/docs/api-reference/fields/external.mdx
+++ b/apps/docs/pages/docs/api-reference/fields/external.mdx
@@ -63,6 +63,7 @@ const config = {
 | [`mapRow()`](#mappropitem)                | `mapRow: async ({ title }) => title`         | Function   | -        |
 | [`placeholder`](#placeholder)             | `placeholder: "Select content"`              | String     | -        |
 | [`showSearch`](#showsearch)               | `showSearch: true`                           | Boolean    | -        |
+| [`renderFooter`](#renderfooter)           | `renderFooter: (data) => <p>Hello</p>`       | Function   | -        |
 
 ## Required params
 
@@ -609,6 +610,56 @@ const config = {
     },
 
 }}
+/>
+
+### `renderFooter(data)`
+
+Customize what will be displayed in the footer of the modal.
+
+```tsx {13} copy
+const config = {
+  components: {
+    Example: {
+      fields: {
+        data: {
+          type: "external",
+          fetchList: async () => {
+            return [
+              { title: "Hello, world", description: "Lorem ipsum 1" },
+              { title: "Goodbye, world", description: "Lorem ipsum 2" },
+            ];
+          },
+          renderFooter: (data) => <span>Hello, footer</span>,
+        },
+      },
+      render: ({ data }) => {
+        return <p>{data || "No data selected"}</p>;
+      },
+      // ...
+    },
+  },
+};
+```
+
+<ConfigPreview
+  label="Example"
+  componentConfig={{
+    fields: {
+      data: {
+        type: "external",
+        fetchList: async () => {
+          return [
+            { title: "Hello, world", description: "Lorem ipsum 1" },
+            { title: "Goodbye, world", description: "Lorem ipsum 2" },
+          ];
+        },
+        renderFooter: (data) => <span>Hello, footer</span>,
+      },
+    },
+    render: ({ data }) => {
+      return <p>{data?.title || "No data selected"}</p>;
+    },
+  }}
 />
 
 <div id="puck-portal-root" />

--- a/apps/docs/pages/docs/api-reference/fields/external.mdx
+++ b/apps/docs/pages/docs/api-reference/fields/external.mdx
@@ -62,8 +62,8 @@ const config = {
 | [`mapProp()`](#mappropitem)               | `mapProp: async ({ title }) => title`        | Function   | -        |
 | [`mapRow()`](#maprowitem)                 | `mapRow: async ({ title }) => title`         | Function   | -        |
 | [`placeholder`](#placeholder)             | `placeholder: "Select content"`              | String     | -        |
-| [`showSearch`](#showsearch)               | `showSearch: true`                           | Boolean    | -        |
 | [`renderFooter()`](#renderfooterprops)    | `renderFooter: (props) => <p>Hello</p>`      | Function   | -        |
+| [`showSearch`](#showsearch)               | `showSearch: true`                           | Boolean    | -        |
 
 ## Required params
 
@@ -542,6 +542,58 @@ const config = {
   }}
 />
 
+### `renderFooter(props)`
+
+Customize what will be displayed in the footer of the modal.
+
+```tsx {13} copy
+const config = {
+  components: {
+    Example: {
+      fields: {
+        data: {
+          type: "external",
+          fetchList: async () => {
+            return [
+              { title: "Hello, world", description: "Lorem ipsum 1" },
+              { title: "Goodbye, world", description: "Lorem ipsum 2" },
+            ];
+          },
+          renderFooter: ({ items }) => (
+            <b>Custom footer with {items.length} results</b>
+          ),
+        },
+      },
+      render: ({ data }) => {
+        return <p>{data || "No data selected"}</p>;
+      },
+      // ...
+    },
+  },
+};
+```
+
+<ConfigPreview
+  label="Example"
+  componentConfig={{
+    fields: {
+      data: {
+        type: "external",
+        fetchList: async () => {
+          return [
+            { title: "Hello, world", description: "Lorem ipsum 1" },
+            { title: "Goodbye, world", description: "Lorem ipsum 2" },
+          ];
+        },
+        renderFooter: ({ items }) => <span>{items.length} results</span>,
+      },
+    },
+    render: ({ data }) => {
+      return <p>{data?.title || "No data selected"}</p>;
+    },
+  }}
+/>
+
 ### `showSearch`
 
 Show a search input, the value of which will be passed to `fetchList` as the `query` param.
@@ -610,56 +662,6 @@ const config = {
     },
 
 }}
-/>
-
-### `renderFooter(props)`
-
-Customize what will be displayed in the footer of the modal.
-
-```tsx {13} copy
-const config = {
-  components: {
-    Example: {
-      fields: {
-        data: {
-          type: "external",
-          fetchList: async () => {
-            return [
-              { title: "Hello, world", description: "Lorem ipsum 1" },
-              { title: "Goodbye, world", description: "Lorem ipsum 2" },
-            ];
-          },
-          renderFooter: ({ items }) => <span>{items.length} results</span>,
-        },
-      },
-      render: ({ data }) => {
-        return <p>{data || "No data selected"}</p>;
-      },
-      // ...
-    },
-  },
-};
-```
-
-<ConfigPreview
-  label="Example"
-  componentConfig={{
-    fields: {
-      data: {
-        type: "external",
-        fetchList: async () => {
-          return [
-            { title: "Hello, world", description: "Lorem ipsum 1" },
-            { title: "Goodbye, world", description: "Lorem ipsum 2" },
-          ];
-        },
-        renderFooter: ({ items }) => <span>{items.length} results</span>,
-      },
-    },
-    render: ({ data }) => {
-      return <p>{data?.title || "No data selected"}</p>;
-    },
-  }}
 />
 
 <div id="puck-portal-root" />

--- a/apps/docs/pages/docs/api-reference/fields/external.mdx
+++ b/apps/docs/pages/docs/api-reference/fields/external.mdx
@@ -60,10 +60,10 @@ const config = {
 | [`initialFilters`](#initialfilters)       | `{ "rating": 1 }`                            | Object     | -        |
 | [`initialQuery`](#initialquery)           | `initialQuery: "Hello, world"`               | String     | -        |
 | [`mapProp()`](#mappropitem)               | `mapProp: async ({ title }) => title`        | Function   | -        |
-| [`mapRow()`](#mappropitem)                | `mapRow: async ({ title }) => title`         | Function   | -        |
+| [`mapRow()`](#maprowitem)                 | `mapRow: async ({ title }) => title`         | Function   | -        |
 | [`placeholder`](#placeholder)             | `placeholder: "Select content"`              | String     | -        |
 | [`showSearch`](#showsearch)               | `showSearch: true`                           | Boolean    | -        |
-| [`renderFooter()`](#renderfooter)         | `renderFooter: (data) => <p>Hello</p>`       | Function   | -        |
+| [`renderFooter()`](#renderfooterdata)     | `renderFooter: (data) => <p>Hello</p>`       | Function   | -        |
 
 ## Required params
 

--- a/apps/docs/pages/docs/api-reference/fields/external.mdx
+++ b/apps/docs/pages/docs/api-reference/fields/external.mdx
@@ -63,7 +63,7 @@ const config = {
 | [`mapRow()`](#mappropitem)                | `mapRow: async ({ title }) => title`         | Function   | -        |
 | [`placeholder`](#placeholder)             | `placeholder: "Select content"`              | String     | -        |
 | [`showSearch`](#showsearch)               | `showSearch: true`                           | Boolean    | -        |
-| [`renderFooter`](#renderfooter)           | `renderFooter: (data) => <p>Hello</p>`       | Function   | -        |
+| [`renderFooter()`](#renderfooter)         | `renderFooter: (data) => <p>Hello</p>`       | Function   | -        |
 
 ## Required params
 

--- a/packages/core/components/ExternalInput/index.tsx
+++ b/packages/core/components/ExternalInput/index.tsx
@@ -265,13 +265,15 @@ export const ExternalInput = ({
               </div>
             </div>
           </div>
-          {field.renderFooter ? (
-            field.renderFooter(mappedData)
-          ) : (
-            <div className={getClassNameModal("footer")}>
-              {mappedData.length} result{mappedData.length === 1 ? "" : "s"}
-            </div>
-          )}
+          <div className={getClassNameModal("footerContainer")}>
+            {field.renderFooter ? (
+              field.renderFooter(mappedData)
+            ) : (
+              <span className={getClassNameModal("footer")}>
+                {mappedData.length} result{mappedData.length === 1 ? "" : "s"}
+              </span>
+            )}
+          </div>
         </form>
       </Modal>
     </div>

--- a/packages/core/components/ExternalInput/index.tsx
+++ b/packages/core/components/ExternalInput/index.tsx
@@ -265,10 +265,13 @@ export const ExternalInput = ({
               </div>
             </div>
           </div>
-
-          <div className={getClassNameModal("footer")}>
-            {mappedData.length} result{mappedData.length === 1 ? "" : "s"}
-          </div>
+          {field.renderFooter ? (
+            field.renderFooter(mappedData)
+          ) : (
+            <div className={getClassNameModal("footer")}>
+              {mappedData.length} result{mappedData.length === 1 ? "" : "s"}
+            </div>
+          )}
         </form>
       </Modal>
     </div>

--- a/packages/core/components/ExternalInput/index.tsx
+++ b/packages/core/components/ExternalInput/index.tsx
@@ -84,6 +84,18 @@ export const ExternalInput = ({
     [id, field]
   );
 
+  const Footer = useCallback(
+    (props: { items: any[] }) =>
+      field.renderFooter ? (
+        field.renderFooter(props)
+      ) : (
+        <span className={getClassNameModal("footer")}>
+          {props.items.length} result{props.items.length === 1 ? "" : "s"}
+        </span>
+      ),
+    [field.renderFooter]
+  );
+
   useEffect(() => {
     search(searchQuery, filters);
   }, []);
@@ -266,13 +278,7 @@ export const ExternalInput = ({
             </div>
           </div>
           <div className={getClassNameModal("footerContainer")}>
-            {field.renderFooter ? (
-              field.renderFooter(mappedData)
-            ) : (
-              <span className={getClassNameModal("footer")}>
-                {mappedData.length} result{mappedData.length === 1 ? "" : "s"}
-              </span>
-            )}
+            <Footer items={mappedData} />
           </div>
         </form>
       </Modal>

--- a/packages/core/components/ExternalInput/styles.module.css
+++ b/packages/core/components/ExternalInput/styles.module.css
@@ -327,12 +327,15 @@
   align-self: center;
 }
 
-.ExternalInputModal-footer {
+.ExternalInputModal-footerContainer {
   background-color: var(--puck-color-grey-12);
   border-top: 1px solid var(--puck-color-grey-09);
   color: var(--puck-color-grey-04);
+  padding: 16px;
+}
+
+.ExternalInputModal-footer {
   font-weight: 500;
   font-size: 14px;
-  padding: 16px;
   text-align: right;
 }

--- a/packages/core/types/Fields.ts
+++ b/packages/core/types/Fields.ts
@@ -94,6 +94,7 @@ export type ExternalField<
   mapRow?: (value: any) => Record<string, string | number>;
   getItemSummary?: (item: Props, index?: number) => string;
   showSearch?: boolean;
+  renderFooter?: (data: any[]) => ReactElement;
   initialQuery?: string;
   filterFields?: Record<string, Field>;
   initialFilters?: Record<string, any>;

--- a/packages/core/types/Fields.ts
+++ b/packages/core/types/Fields.ts
@@ -94,7 +94,7 @@ export type ExternalField<
   mapRow?: (value: any) => Record<string, string | number>;
   getItemSummary?: (item: Props, index?: number) => string;
   showSearch?: boolean;
-  renderFooter?: (data: any[]) => ReactElement;
+  renderFooter?: (props: { items: any[] }) => ReactElement;
   initialQuery?: string;
   filterFields?: Record<string, Field>;
   initialFilters?: Record<string, any>;


### PR DESCRIPTION
## Description
Adds a new optional property to external fields, `renderFooter`. This property accepts a function resolving to a `ReactElement` in place of the default footer, with a prop provided for `items` representing the `mappedData`. 

## Screenshots

![CleanShot 2024-11-07 at 12 31 32](https://github.com/user-attachments/assets/9759c3e4-2fbf-4aa4-be43-7519b38b346d)



## Motivation
We're using the `external` field to allow the user to select an image from a set of images provided by our external service. We'd like to be able to display a "Manage Images" link in the footer to provide the user with a clear path to add/remove any of the image options displayed in the modal. 

