### PR TITLE
chore: prevent infinite loop when setting defaultFields

### DIFF
--- a/packages/core/components/Puck/components/Fields/index.tsx
+++ b/packages/core/components/Puck/components/Fields/index.tsx
@@ -46,10 +46,13 @@ const useResolvedFields = (): [FieldsType, boolean] => {
     ? config.components[selectedItem.type]
     : null;
 
-  const defaultFields =
-    (selectedItem
-      ? (componentConfig?.fields as Record<string, Field<any>>)
-      : rootFields) || {};
+  const defaultFields = useMemo(
+    () =>
+      (selectedItem
+        ? (componentConfig?.fields as Record<string, Field<any>>)
+        : rootFields) || {},
+    [selectedItem, rootFields, componentConfig?.fields]
+  );
 
   // DEPRECATED
   const rootProps = data.root.props || data.root;


### PR DESCRIPTION
Setting this as an empty object `{}` meant that each render would cause the value to change, since `{}` would be reinstatiated. This would cause the `useEffect` dependent on `defaultFields` to trigger on each render.