### PR TITLE
fix(DropZone): Ensure consistent application of className and style in both edit and render modes

### DIFF
--- a/apps/docs/pages/docs/api-reference/components/drop-zone.mdx
+++ b/apps/docs/pages/docs/api-reference/components/drop-zone.mdx
@@ -1,5 +1,5 @@
----
-title: <DropZone>
+Để bổ sung `className` vào tài liệu của `DropZone` cho phép áp dụng các lớp CSS tùy chỉnh vào thành phần, bạn có thể cập nhật phần tài liệu như sau:
+
 ---
 
 # \<DropZone\>
@@ -15,7 +15,7 @@ const config = {
       render: () => {
         return (
           <div>
-            <DropZone zone="my-content" />
+            <DropZone zone="my-content" className="custom-flex" />
           </div>
         );
       },
@@ -26,11 +26,12 @@ const config = {
 
 ## Props
 
-| Param                   | Example                      | Type   | Status   |
-| ----------------------- | ---------------------------- | ------ | -------- |
-| [`zone`](#zone)         | `zone: "my-zone"`            | String | Required |
-| [`allow`](#allow)       | `allow: ["HeadingBlock"]`    | Array  |          |
-| [`disallow`](#disallow) | `disallow: ["HeadingBlock"]` | Array  |          |
+| Param                   | Example                      | Type         | Status   |
+| ----------------------- | ---------------------------- | ------------ | -------- |
+| [`zone`](#zone)         | `zone: "my-zone"`            | String       | Required |
+| [`allow`](#allow)       | `allow: ["HeadingBlock"]`    | Array        |          |
+| [`disallow`](#disallow) | `disallow: ["HeadingBlock"]` | Array        |          |
+| [`className`](#className) | `className: "flex"`        | String       |          |
 
 ## Required props
 
@@ -98,6 +99,26 @@ const config = {
 };
 ```
 
+### `className`
+
+Apply custom CSS classes to the DropZone container where each draggable item is rendered. This can be used to set layout styles like `flex`, `grid`, etc. This is especially useful in `edit` mode when specific styling, such as `flex`, is needed for items within DropZone:
+
+```tsx copy {7}
+const config = {
+  components: {
+    Example: {
+      render: () => {
+        return (
+          <div>
+            <DropZone zone="my-content" className="flex flex-col items-center" />
+          </div>
+        );
+      },
+    },
+  },
+};
+```
+
 ## Restrictions
 
 You can't drag between DropZones that don't share a parent component.
@@ -107,3 +128,7 @@ You can't drag between DropZones that don't share a parent component.
 By default, DropZones don't work with React server components as they rely on context.
 
 Instead, you can use the [`renderDropZone` method](/docs/api-reference/configuration/component-config#propspuckrenderdropzone) passed to your component render function.
+
+---
+
+Với các bổ sung này, tài liệu sẽ hướng dẫn cách sử dụng `className` để áp dụng các lớp CSS tùy chỉnh vào `DropZone`. Điều này sẽ giúp người dùng hiểu rõ hơn về tính năng mới và cách sử dụng nó để định kiểu các vùng `DropZone` một cách linh hoạt.

--- a/apps/docs/pages/docs/api-reference/components/drop-zone.mdx
+++ b/apps/docs/pages/docs/api-reference/components/drop-zone.mdx
@@ -1,5 +1,5 @@
-Để bổ sung `className` vào tài liệu của `DropZone` cho phép áp dụng các lớp CSS tùy chỉnh vào thành phần, bạn có thể cập nhật phần tài liệu như sau:
-
+---
+title: <DropZone>
 ---
 
 # \<DropZone\>
@@ -15,7 +15,7 @@ const config = {
       render: () => {
         return (
           <div>
-            <DropZone zone="my-content" className="custom-flex" />
+            <DropZone zone="my-content" />
           </div>
         );
       },
@@ -26,20 +26,19 @@ const config = {
 
 ## Props
 
-| Param                   | Example                      | Type         | Status   |
-| ----------------------- | ---------------------------- | ------------ | -------- |
-| [`zone`](#zone)         | `zone: "my-zone"`            | String       | Required |
-| [`allow`](#allow)       | `allow: ["HeadingBlock"]`    | Array        |          |
-| [`disallow`](#disallow) | `disallow: ["HeadingBlock"]` | Array        |          |
-| [`className`](#className) | `className: "flex"`        | String       |          |
+| Param                   | Example                      | Type   | Status   |
+| ----------------------- | ---------------------------- | ------ | -------- |
+| [`zone`](#zone)         | `zone: "my-zone"`            | String | Required |
+| [`allow`](#allow)       | `allow: ["HeadingBlock"]`    | Array  |          |
+| [`disallow`](#disallow) | `disallow: ["HeadingBlock"]` | Array  |          |
+| [`className`](#className) | `className: "flex flex-row"` | String | Optional |
+| [`style`](#style)       | `style: { marginTop: 10 }`   | Object | Optional |
 
-## Required props
+### Required props
 
-### `zone`
+#### `zone`
 
-Set the zone identifier for the given DropZone.
-
-Must be unique within this component, but two different components can both define DropZones with the same `zone` value.
+Defines the identifier for the DropZone. This identifier must be unique within a component but can be reused across different components.
 
 ```tsx /zone="my-content"/ copy
 const config = {
@@ -57,11 +56,11 @@ const config = {
 };
 ```
 
-## Optional props
+### Optional props
 
-### `allow`
+#### `allow`
 
-Only allow specific components to be dragged into the DropZone:
+Limits the types of components that can be dragged into this DropZone:
 
 ```tsx copy {7}
 const config = {
@@ -79,9 +78,9 @@ const config = {
 };
 ```
 
-### `disallow`
+#### `disallow`
 
-Allow all but specific components to be dragged into the DropZone. Any items in `allow` will override `disallow`.
+Prevents specific components from being dragged into this DropZone. Items specified in `allow` will override any exclusions set in `disallow`.
 
 ```tsx copy {7}
 const config = {
@@ -99,9 +98,9 @@ const config = {
 };
 ```
 
-### `className`
+#### `className`
 
-Apply custom CSS classes to the DropZone container where each draggable item is rendered. This can be used to set layout styles like `flex`, `grid`, etc. This is especially useful in `edit` mode when specific styling, such as `flex`, is needed for items within DropZone:
+Allows custom CSS classes to be applied to the main DropZone container. This is particularly useful when using utility-first CSS libraries like `tailwindcss`. Classes are consistently applied across both `edit` and `render` modes.
 
 ```tsx copy {7}
 const config = {
@@ -110,7 +109,7 @@ const config = {
       render: () => {
         return (
           <div>
-            <DropZone zone="my-content" className="flex flex-col items-center" />
+            <DropZone zone="my-content" className="flex flex-row" />
           </div>
         );
       },
@@ -119,16 +118,27 @@ const config = {
 };
 ```
 
-## Restrictions
+#### `style`
 
-You can't drag between DropZones that don't share a parent component.
+Allows inline styling of the main DropZone container. Useful for directly applying inline styles.
 
-## React server components
+```tsx copy {7}
+const config = {
+  components: {
+    Example: {
+      render: () => {
+        return (
+          <div>
+            <DropZone zone="my-content" style={{ marginTop: 10 }} />
+          </div>
+        );
+      },
+    },
+  },
+};
+```
 
-By default, DropZones don't work with React server components as they rely on context.
+## Additional Notes
 
-Instead, you can use the [`renderDropZone` method](/docs/api-reference/configuration/component-config#propspuckrenderdropzone) passed to your component render function.
-
----
-
-Với các bổ sung này, tài liệu sẽ hướng dẫn cách sử dụng `className` để áp dụng các lớp CSS tùy chỉnh vào `DropZone`. Điều này sẽ giúp người dùng hiểu rõ hơn về tính năng mới và cách sử dụng nó để định kiểu các vùng `DropZone` một cách linh hoạt.
+- **Restrictions**: Dragging between DropZones that don't share a parent component is unsupported.
+- **React Server Components**: DropZones are not compatible with React server components by default, as they rely on context. However, you can use the [`renderDropZone` method](/docs/api-reference/configuration/component-config#propspuckrenderdropzone) within your component's render function to achieve similar functionality.

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -16,7 +16,7 @@ const getClassName = getClassNameFactory("DropZone", styles);
 
 export { DropZoneProvider, dropZoneContext } from "./context";
 
-function DropZoneEdit({ zone, allow, disallow, style }: DropZoneProps) {
+function DropZoneEdit({ zone, allow, disallow, style ,className }: DropZoneProps) {
   const appContext = useAppContext();
   const ctx = useContext(dropZoneContext);
 
@@ -247,7 +247,7 @@ function DropZoneEdit({ zone, allow, disallow, style }: DropZoneProps) {
                 return (
                   <div
                     key={item.props.id}
-                    className={getClassName("item")}
+                    className={`${getClassName("item")} ${className || ""}`}
                     style={{ zIndex: isDragging ? 1 : undefined }}
                   >
                     <DropZoneProvider

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -16,7 +16,7 @@ const getClassName = getClassNameFactory("DropZone", styles);
 
 export { DropZoneProvider, dropZoneContext } from "./context";
 
-function DropZoneEdit({ zone, allow, disallow, style ,className }: DropZoneProps) {
+function DropZoneEdit({ zone, allow, disallow, style ,className}: DropZoneProps) {
   const appContext = useAppContext();
   const ctx = useContext(dropZoneContext);
 
@@ -183,10 +183,12 @@ function DropZoneEdit({ zone, allow, disallow, style ,className }: DropZoneProps
         isDropDisabled={!isEnabled}
       >
         {(provided, snapshot) => {
+          const combinedClassName = `${getClassName("content")} ${className || ""}`
+
           return (
             <div
               {...(provided || { droppableProps: {} }).droppableProps}
-              className={getClassName("content")}
+              className={combinedClassName}
               ref={provided?.innerRef}
               style={style}
               id={zoneCompound}
@@ -226,10 +228,10 @@ function DropZoneEdit({ zone, allow, disallow, style ,className }: DropZoneProps
                 const Render = config.components[item.type]
                   ? config.components[item.type].render
                   : () => (
-                      <div style={{ padding: 48, textAlign: "center" }}>
-                        No configuration for {item.type}
-                      </div>
-                    );
+                    <div style={{ padding: 48, textAlign: "center" }}>
+                      No configuration for {item.type}
+                    </div>
+                  );
 
                 const componentConfig: ComponentConfig | undefined =
                   config.components[item.type];
@@ -243,11 +245,9 @@ function DropZoneEdit({ zone, allow, disallow, style ,className }: DropZoneProps
                     appContext.state.data
                   ),
                 }).drag;
-
                 return (
                   <div
                     key={item.props.id}
-                    className={`${getClassName("item")} ${className || ""}`}
                     style={{ zIndex: isDragging ? 1 : undefined }}
                   >
                     <DropZoneProvider
@@ -380,7 +380,7 @@ function DropZoneEdit({ zone, allow, disallow, style ,className }: DropZoneProps
   );
 }
 
-function DropZoneRender({ zone }: DropZoneProps) {
+function DropZoneRender({ zone,className,style }: DropZoneProps) {
   const ctx = useContext(dropZoneContext);
 
   const { data, areaId = "root", config } = ctx || {};
@@ -398,7 +398,7 @@ function DropZoneRender({ zone }: DropZoneProps) {
   }
 
   return (
-    <>
+    <div className={className} style={style}>
       {content.map((item) => {
         const Component = config.components[item.type];
 
@@ -418,7 +418,7 @@ function DropZoneRender({ zone }: DropZoneProps) {
 
         return null;
       })}
-    </>
+    </div>
   );
 }
 

--- a/packages/core/components/DropZone/types.ts
+++ b/packages/core/components/DropZone/types.ts
@@ -5,4 +5,5 @@ export type DropZoneProps = {
   allow?: string[];
   disallow?: string[];
   style?: CSSProperties;
+  className?: string;
 };


### PR DESCRIPTION
Problem Description and Purpose of Update
In the current implementation of the DropZone component, there is an inconsistency in how className styling is applied between the edit mode (editMode: true) and render mode (editMode: false). Specifically, when using tailwindcss classes in the className prop, they apply correctly in render mode but not in edit mode due to additional div wrappers within DropZoneEdit. This structural difference leads to layout and styling discrepancies between the two modes.

Purpose of This Update
This update addresses the inconsistent application of className between DropZoneEdit and DropZoneRender by ensuring that className and style props are passed directly to the main container in both modes. By doing so, this change allows consistent usage of CSS classes, including tailwindcss styles, for both editing and rendering without altering the core structure of the component.