### PR TITLE
Always update fields when resolveData runs

### DIFF
--- a/apps/demo/config/blocks/Columns/index.tsx
+++ b/apps/demo/config/blocks/Columns/index.tsx
@@ -4,6 +4,7 @@ import styles from "./styles.module.css";
 import { getClassNameFactory } from "@/core/lib";
 import { DropZone } from "@/core/components/DropZone";
 import { Section } from "../../components/Section";
+import { generateId } from "@/core/lib/generate-id";
 
 const getClassName = getClassNameFactory("Columns", styles);
 
@@ -11,10 +12,27 @@ export type ColumnsProps = {
   distribution: "auto" | "manual";
   columns: {
     span?: number;
+    id?: string;
   }[];
 };
 
 export const Columns: ComponentConfig<ColumnsProps> = {
+  // Dynamically generate an ID for each column
+  resolveData: ({ props }, { lastData }) => {
+    if (lastData?.props.columns.length === props.columns.length) {
+      return { props };
+    }
+
+    return {
+      props: {
+        ...props,
+        columns: props.columns.map((column) => ({
+          ...column,
+          id: column.id ?? generateId(),
+        })),
+      },
+    };
+  },
   fields: {
     distribution: {
       type: "radio",
@@ -31,10 +49,10 @@ export const Columns: ComponentConfig<ColumnsProps> = {
     },
     columns: {
       type: "array",
-      getItemSummary: (col, id = -1) =>
-        `Column ${id + 1}, span ${
+      getItemSummary: (col) =>
+        `Column (span ${
           col.span ? Math.max(Math.min(col.span, 12), 1) : "auto"
-        }`,
+        })`,
       arrayFields: {
         span: {
           label: "Span (1-12)",
@@ -61,9 +79,9 @@ export const Columns: ComponentConfig<ColumnsProps> = {
                 : `repeat(${columns.length}, 1fr)`,
           }}
         >
-          {columns.map(({ span }, idx) => (
+          {columns.map(({ span, id }, idx) => (
             <div
-              key={idx}
+              key={id ?? idx}
               style={{
                 display: "flex",
                 flexDirection: "column",
@@ -74,7 +92,7 @@ export const Columns: ComponentConfig<ColumnsProps> = {
               }}
             >
               <DropZone
-                zone={`column-${idx}`}
+                zone={`column-${id ?? idx}`}
                 disallow={["Hero", "Logos", "Stats"]}
               />
             </div>

--- a/apps/demo/config/index.tsx
+++ b/apps/demo/config/index.tsx
@@ -131,7 +131,11 @@ export const initialData: Record<string, UserData> = {
       {
         type: "Columns",
         props: {
-          columns: [{}, {}, {}],
+          columns: [
+            { id: "aed487d8-640d-4788-834f-39d282b48dbe" },
+            { id: "b225c7ba-c90c-4290-9faf-46809aeb2469" },
+            { id: "0059e9d0-1bd2-4262-afd8-841b7099cbaa" },
+          ],
           distribution: "auto",
           id: "Columns-2d650a8ceb081a2c04f3a2d17a7703ca6efb0d06",
         },
@@ -226,12 +230,12 @@ export const initialData: Record<string, UserData> = {
         type: "Columns",
         props: {
           columns: [
-            { span: 4 },
-            { span: 4 },
-            { span: 4 },
-            { span: 4 },
-            { span: 4 },
-            { span: 4 },
+            { span: 4, id: "f6baf6a3-3702-427f-a427-81c14855ad7f" },
+            { span: 4, id: "2d7e1c2e-5b50-4412-9aee-27441e99bc1e" },
+            { span: 4, id: "a23fcb9d-e0c4-4f07-9c03-d30f901d87c4" },
+            { span: 4, id: "ec906bd1-fce6-4386-893b-1840dfa8c3df" },
+            { span: 4, id: "812e374a-a5e0-4c45-95b4-0f9494d3d473" },
+            { span: 4, id: "71c77d92-2a30-4e0c-86d9-8dbdb017ee89" },
           ],
           id: "Columns-3c2ca5b045ee26535fcdf0eddf409a6308764634",
           distribution: "manual",
@@ -293,120 +297,129 @@ export const initialData: Record<string, UserData> = {
     ],
     root: { props: { title: "Puck Example" } },
     zones: {
-      "Columns-2d650a8ceb081a2c04f3a2d17a7703ca6efb0d06:column-0": [
-        {
-          type: "Card",
-          props: {
-            title: "Built for content teams",
-            description:
-              "Puck enables content teams to make changes to their content without a developer or breaking the UI.",
-            icon: "pen-tool",
-            mode: "flat",
-            id: "Card-0d9077e00e0ad66c34c62ab6986967e1ce04f9e4",
+      "Columns-2d650a8ceb081a2c04f3a2d17a7703ca6efb0d06:column-aed487d8-640d-4788-834f-39d282b48dbe":
+        [
+          {
+            type: "Card",
+            props: {
+              title: "Built for content teams",
+              description:
+                "Puck enables content teams to make changes to their content without a developer or breaking the UI.",
+              icon: "pen-tool",
+              mode: "flat",
+              id: "Card-0d9077e00e0ad66c34c62ab6986967e1ce04f9e4",
+            },
           },
-        },
-      ],
-      "Columns-2d650a8ceb081a2c04f3a2d17a7703ca6efb0d06:column-1": [
-        {
-          type: "Card",
-          props: {
-            title: "Easy to integrate",
-            description:
-              "Front-end developers can easily integrate their own components using a familiar React API.",
-            icon: "git-merge",
-            mode: "flat",
-            id: "Card-978bef5d136d4b0d9855f5272429986ceb22e5a6",
+        ],
+      "Columns-2d650a8ceb081a2c04f3a2d17a7703ca6efb0d06:column-b225c7ba-c90c-4290-9faf-46809aeb2469":
+        [
+          {
+            type: "Card",
+            props: {
+              title: "Easy to integrate",
+              description:
+                "Front-end developers can easily integrate their own components using a familiar React API.",
+              icon: "git-merge",
+              mode: "flat",
+              id: "Card-978bef5d136d4b0d9855f5272429986ceb22e5a6",
+            },
           },
-        },
-      ],
-      "Columns-2d650a8ceb081a2c04f3a2d17a7703ca6efb0d06:column-2": [
-        {
-          type: "Card",
-          props: {
-            title: "No vendor lock-in",
-            description:
-              "Completely open-source, Puck is designed to be integrated into your existing React application.",
-            icon: "github",
-            mode: "flat",
-            id: "Card-133a61826f0019841aec6f0aec011bf07e6bc6de",
+        ],
+      "Columns-2d650a8ceb081a2c04f3a2d17a7703ca6efb0d06:column-0059e9d0-1bd2-4262-afd8-841b7099cbaa":
+        [
+          {
+            type: "Card",
+            props: {
+              title: "No vendor lock-in",
+              description:
+                "Completely open-source, Puck is designed to be integrated into your existing React application.",
+              icon: "github",
+              mode: "flat",
+              id: "Card-133a61826f0019841aec6f0aec011bf07e6bc6de",
+            },
           },
-        },
-      ],
-      "Columns-3c2ca5b045ee26535fcdf0eddf409a6308764634:column-0": [
-        {
-          type: "Card",
-          props: {
-            title: "plugin-heading-analyzer",
-            description:
-              "Analyze the document structure and identify WCAG 2.1 issues with your heading hierarchy.",
-            icon: "align-left",
-            mode: "card",
-            id: "Card-e2e757b0b4a579d5f87564dfa9b4442f9794b45b",
+        ],
+      "Columns-3c2ca5b045ee26535fcdf0eddf409a6308764634:column-f6baf6a3-3702-427f-a427-81c14855ad7f":
+        [
+          {
+            type: "Card",
+            props: {
+              title: "plugin-heading-analyzer",
+              description:
+                "Analyze the document structure and identify WCAG 2.1 issues with your heading hierarchy.",
+              icon: "align-left",
+              mode: "card",
+              id: "Card-e2e757b0b4a579d5f87564dfa9b4442f9794b45b",
+            },
           },
-        },
-      ],
-      "Columns-3c2ca5b045ee26535fcdf0eddf409a6308764634:column-1": [
-        {
-          type: "Card",
-          props: {
-            title: "External data",
-            description:
-              "Connect your components with an existing data source, like Strapi.js.",
-            icon: "feather",
-            mode: "card",
-            id: "Card-4eea28543d13c41c30934c3e4c4c95a75017a89c",
+        ],
+      "Columns-3c2ca5b045ee26535fcdf0eddf409a6308764634:column-2d7e1c2e-5b50-4412-9aee-27441e99bc1e":
+        [
+          {
+            type: "Card",
+            props: {
+              title: "External data",
+              description:
+                "Connect your components with an existing data source, like Strapi.js.",
+              icon: "feather",
+              mode: "card",
+              id: "Card-4eea28543d13c41c30934c3e4c4c95a75017a89c",
+            },
           },
-        },
-      ],
-      "Columns-3c2ca5b045ee26535fcdf0eddf409a6308764634:column-2": [
-        {
-          type: "Card",
-          props: {
-            title: "Custom plugins",
-            description:
-              "Create your own plugin to extend Puck for your use case using React.",
-            icon: "feather",
-            mode: "card",
-            id: "Card-3314e8b24aa52843ce22ab7424b8f3b8064acfdf",
+        ],
+      "Columns-3c2ca5b045ee26535fcdf0eddf409a6308764634:column-a23fcb9d-e0c4-4f07-9c03-d30f901d87c4":
+        [
+          {
+            type: "Card",
+            props: {
+              title: "Custom plugins",
+              description:
+                "Create your own plugin to extend Puck for your use case using React.",
+              icon: "feather",
+              mode: "card",
+              id: "Card-3314e8b24aa52843ce22ab7424b8f3b8064acfdf",
+            },
           },
-        },
-      ],
-      "Columns-3c2ca5b045ee26535fcdf0eddf409a6308764634:column-3": [
-        {
-          type: "Card",
-          props: {
-            title: "Title",
-            description: "Description",
-            icon: "feather",
-            mode: "card",
-            id: "Card-49b11940784cfe8dc1a2b2facc5ac2bcf797792f",
+        ],
+      "Columns-3c2ca5b045ee26535fcdf0eddf409a6308764634:column-ec906bd1-fce6-4386-893b-1840dfa8c3df":
+        [
+          {
+            type: "Card",
+            props: {
+              title: "Title",
+              description: "Description",
+              icon: "feather",
+              mode: "card",
+              id: "Card-49b11940784cfe8dc1a2b2facc5ac2bcf797792f",
+            },
           },
-        },
-      ],
-      "Columns-3c2ca5b045ee26535fcdf0eddf409a6308764634:column-4": [
-        {
-          type: "Card",
-          props: {
-            title: "Title",
-            description: "Description",
-            icon: "feather",
-            mode: "card",
-            id: "Card-efb0a1ed06cc4152a7861376aafbe62b0445382d",
+        ],
+      "Columns-3c2ca5b045ee26535fcdf0eddf409a6308764634:column-812e374a-a5e0-4c45-95b4-0f9494d3d473":
+        [
+          {
+            type: "Card",
+            props: {
+              title: "Title",
+              description: "Description",
+              icon: "feather",
+              mode: "card",
+              id: "Card-efb0a1ed06cc4152a7861376aafbe62b0445382d",
+            },
           },
-        },
-      ],
-      "Columns-3c2ca5b045ee26535fcdf0eddf409a6308764634:column-5": [
-        {
-          type: "Card",
-          props: {
-            title: "Title",
-            description: "Description",
-            icon: "feather",
-            mode: "card",
-            id: "Card-513cfb17d07ba4b6e0212d931571c0760839f029",
+        ],
+      "Columns-3c2ca5b045ee26535fcdf0eddf409a6308764634:column-71c77d92-2a30-4e0c-86d9-8dbdb017ee89":
+        [
+          {
+            type: "Card",
+            props: {
+              title: "Title",
+              description: "Description",
+              icon: "feather",
+              mode: "card",
+              id: "Card-513cfb17d07ba4b6e0212d931571c0760839f029",
+            },
           },
-        },
-      ],
+        ],
     },
   },
   "/pricing": {

--- a/apps/docs/pages/docs/api-reference/app-state.mdx
+++ b/apps/docs/pages/docs/api-reference/app-state.mdx
@@ -16,6 +16,7 @@ The current state of the Puck editor interface.
 | ----------------------------------------------- | ----------------------------------------------------- | ------- |
 | [`arrayState`](#uiarraystate)                   | `{}`                                                  | Object  |
 | [`componentList`](#uicomponentlist)             | `{ typography: { components: [ "HeadingBlock" ] } }`  | Object  |
+| [`field.focus`](#fieldfocus)                    | `"title"`                                             | String  |
 | [`isDragging`](#isdragging)                     | `false`                                               | Boolean |
 | [`itemSelector`](#uiitemselector)               | `{ index: 0, zone: "my-content" }`                    | Object  |
 | [`leftSideBarVisible`](#uileftsidebarvisible)   | `false`                                               | Boolean |
@@ -49,6 +50,12 @@ Whether or not the category is visible in the side bar
 #### `ui.componentList[key].expanded`
 
 Whether or not the category is expanded in the side bar
+
+---
+
+### `ui.field.focus`
+
+The name of the currently focused field.
 
 ---
 

--- a/packages/core/components/AutoField/fields/ArrayField/index.tsx
+++ b/packages/core/components/AutoField/fields/ArrayField/index.tsx
@@ -137,12 +137,16 @@ export const ArrayField = ({
               event.destination?.index
             );
 
-            onChange(newValue, {
+            const newUi = {
               arrayState: {
                 ...state.ui.arrayState,
                 [id]: { ...arrayState, items: newArrayStateItems },
               },
-            });
+            };
+
+            setUi(newUi, false);
+
+            onChange(newValue, newUi);
 
             setLocalState({
               value: newValue,

--- a/packages/core/components/AutoField/index.tsx
+++ b/packages/core/components/AutoField/index.tsx
@@ -236,12 +236,10 @@ export function AutoFieldPrivate<
     Label?: React.FC<FieldLabelPropsInternal>;
   }
 ) {
+  const { state } = useAppContext();
   const { value, onChange } = props;
 
   const [localValue, setLocalValue] = useState(value);
-
-  const [recentlyChanged, setRecentlyChanged] = useState(false);
-  const timeoutRef = useRef<NodeJS.Timeout>();
 
   const onChangeDb = useDebouncedCallback(
     (val, ui) => {
@@ -254,19 +252,12 @@ export function AutoFieldPrivate<
   const onChangeLocal = useCallback((val: any, ui?: Partial<UiState>) => {
     setLocalValue(val);
 
-    setRecentlyChanged(true);
-
-    clearTimeout(timeoutRef.current);
-
-    timeoutRef.current = setTimeout(() => {
-      setRecentlyChanged(false);
-    }, RECENT_CHANGE_TIMEOUT);
-
     onChangeDb(val, ui);
   }, []);
 
   useEffect(() => {
-    if (!recentlyChanged) {
+    // Prevent global state from setting local state if this field is focused
+    if (state.ui.field.focus !== props.name) {
       setLocalValue(value);
     }
   }, [value]);

--- a/packages/core/components/AutoField/styles.module.css
+++ b/packages/core/components/AutoField/styles.module.css
@@ -1,11 +1,16 @@
-.Input {
+.InputWrapper {
   color: var(--puck-color-grey-04);
   padding: 16px;
   padding-bottom: 12px;
   display: block;
 }
 
-.Input .Input {
+.InputWrapper + .InputWrapper {
+  border-top: 1px solid var(--puck-color-grey-09);
+  margin-top: 8px;
+}
+
+.Input .InputWrapper {
   padding: 0px;
 }
 
@@ -13,12 +18,7 @@
   box-sizing: border-box;
 }
 
-.Input + .Input {
-  border-top: 1px solid var(--puck-color-grey-09);
-  margin-top: 8px;
-}
-
-.Input .Input + .Input {
+.Input .InputWrapper + .InputWrapper {
   border-top: 0px;
   margin-top: 12px;
 }

--- a/packages/core/components/Puck/context.tsx
+++ b/packages/core/components/Puck/context.tsx
@@ -46,6 +46,7 @@ export const defaultAppState: AppState = {
       options: [],
       controlsVisible: true,
     },
+    field: { focus: null },
   },
 };
 

--- a/packages/core/lib/__tests__/use-resolved-data.spec.tsx
+++ b/packages/core/lib/__tests__/use-resolved-data.spec.tsx
@@ -143,6 +143,9 @@ describe("use-resolved-data", () => {
           "ui": {
             "arrayState": {},
             "componentList": {},
+            "field": {
+              "focus": null,
+            },
             "isDragging": false,
             "itemSelector": null,
             "leftSideBarVisible": true,

--- a/packages/core/types/AppState.tsx
+++ b/packages/core/types/AppState.tsx
@@ -32,6 +32,7 @@ export type UiState = {
     controlsVisible: boolean;
     options: Viewport[];
   };
+  field: { focus?: string | null };
 };
 
 export type AppState<UserData extends Data = Data> = {


### PR DESCRIPTION
61260407c5c87cc8c5c4fe925835f2d0d2a6f9ff resulted in an issue when running resolveData, as the field would not re-render after a quick resolveData run.

A timeout was always a poor solution for this issue, so this PR tracks the currently focused field on the app state, and replaces the timeout with a condition that the current field cannot be focused to be updated externally.

This PR also improves the columns demo by generating IDs dynamically, so they can actually be reordered. Attempting to implement this docs improvement is what exposed the underlying issue.