### PR TITLE
Fix wording of delete permission documentation

### DIFF
--- a/apps/docs/pages/docs/api-reference/permissions.mdx
+++ b/apps/docs/pages/docs/api-reference/permissions.mdx
@@ -31,7 +31,7 @@ Permissions enable the [toggling of Puck features](/docs/integrating-puck/featur
 
 ### `delete`
 
-Enable duplication of components.
+Enable deletion of components.
 
 ### `drag`
 


### PR DESCRIPTION
Noticed that the word "duplication" had duplicated itself.