### PR TITLE
Support passing rootProps to resolveData

### DIFF
--- a/apps/demo/config/blocks/Hero/index.tsx
+++ b/apps/demo/config/blocks/Hero/index.tsx
@@ -173,7 +173,7 @@ export const Hero: ComponentConfig<HeroProps> = {
    *
    * For example, requesting a third-party API for the latest content.
    */
-  resolveData: async ({ props }, { changed }) => {
+  resolveData: async ({ props }, { changed,rootProps }) => {
     if (!props.quote)
       return { props, readOnly: { title: false, description: false } };
 

--- a/packages/core/lib/resolve-all-data.ts
+++ b/packages/core/lib/resolve-all-data.ts
@@ -34,7 +34,8 @@ export async function resolveAllData<
       zones[zoneKey],
       config,
       onResolveStart,
-      onResolveEnd
+      onResolveEnd,
+      dynamicRoot.props
     )) as Content<Props>;
   }
 
@@ -45,7 +46,8 @@ export async function resolveAllData<
       defaultedData.content,
       config,
       onResolveStart,
-      onResolveEnd
+      onResolveEnd,
+      dynamicRoot.props
     )) as Content<Props>,
     zones: resolvedZones,
   } as Data<Props, RootProps>;

--- a/packages/core/lib/resolve-component-data.ts
+++ b/packages/core/lib/resolve-component-data.ts
@@ -1,4 +1,4 @@
-import { ComponentData, Config, MappedItem } from "../types";
+import { AsFieldProps, ComponentData, Config, DefaultRootFieldProps, MappedItem } from "../types";
 import { getChanged } from "./get-changed";
 
 export const cache: {
@@ -24,11 +24,7 @@ export const resolveAllComponentData = async (
 };
 
 export const resolveComponentData = async (
-  item: ComponentData,
-  config: Config,
-  onResolveStart?: (item: MappedItem) => void,
-  onResolveEnd?: (item: MappedItem) => void
-) => {
+  item: ComponentData, config: Config, onResolveStart?: (item: MappedItem) => void, onResolveEnd?: (item: MappedItem) => void, rootProps?: Record<string, any>) => {
   const configForItem = config.components[item.type];
   if (configForItem.resolveData) {
     const { item: oldItem = null, resolved = {} } =
@@ -45,7 +41,7 @@ export const resolveComponentData = async (
     }
 
     const { props: resolvedProps, readOnly = {} } =
-      await configForItem.resolveData(item, { changed, lastData: oldItem });
+      await configForItem.resolveData(item, { changed, lastData: oldItem ,rootProps});
 
     const { readOnly: existingReadOnly = {} } = item || {};
 

--- a/packages/core/lib/resolve-component-data.ts
+++ b/packages/core/lib/resolve-component-data.ts
@@ -9,7 +9,8 @@ export const resolveAllComponentData = async (
   content: MappedItem[],
   config: Config,
   onResolveStart?: (item: MappedItem) => void,
-  onResolveEnd?: (item: MappedItem) => void
+  onResolveEnd?: (item: MappedItem) => void,
+  rootProps?: Record<string, any>
 ) => {
   return await Promise.all(
     content.map(async (item) => {
@@ -17,7 +18,8 @@ export const resolveAllComponentData = async (
         item,
         config,
         onResolveStart,
-        onResolveEnd
+        onResolveEnd,
+        rootProps
       );
     })
   );

--- a/packages/core/lib/use-resolved-data.ts
+++ b/packages/core/lib/use-resolved-data.ts
@@ -47,7 +47,7 @@ export const useResolvedData = (
   const runResolvers = async () => {
     // Flatten zones
     const newData = newAppState.data;
-
+    const rootProps = newData.root?.props || {};
     const flatContent = flattenData(newData).filter(
       (item) => !!config.components[item.type]?.resolveData
     );
@@ -111,7 +111,8 @@ export const useResolvedData = (
               deferredSetStates[item.props.id];
 
               _setComponentLoading(item.props.id, false);
-            }
+            },
+            rootProps
           );
 
           const dynamicDataMap = { [item.props.id]: dynamicData };

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -36,6 +36,7 @@ export type ComponentConfig<
     params: {
       changed: Partial<Record<keyof FieldProps, boolean>>;
       lastData: DataShape | null;
+      rootProps?: Record<string, any>;
     }
   ) =>
     | Promise<{


### PR DESCRIPTION
### Summary
This PR adds support for passing `rootProps` from `newData.root.props` into `resolveData` to enable dynamic configuration based on root-level properties.

### Changes
- Modified `useResolvedData` to extract `rootProps` from `newData.root.props`.
- Updated `resolveComponentData` to accept and pass `rootProps` into `resolveData`.
- Enhanced `Hero` component to demonstrate usage of `rootProps`.
- Updated type definitions in `Config.tsx` to include `rootProps`.

### Testing
- Verified that `rootProps` are correctly passed to components.
- Ensured backward compatibility with existing workflows.

