### PR TITLE
Enhance ExternalInput: Pass filters to mapProp for custom data mapping

### DIFF
--- a/packages/core/components/ExternalInput/index.tsx
+++ b/packages/core/components/ExternalInput/index.tsx
@@ -31,7 +31,7 @@ export const ExternalInput = ({
   readOnly?: boolean;
 }) => {
   const {
-    mapProp = (val: any) => val,
+    mapProp = (val: any,filters: object) => val,
     mapRow = (val: any) => val,
     filterFields,
   } = field || {};
@@ -244,7 +244,7 @@ export const ExternalInput = ({
                         style={{ whiteSpace: "nowrap" }}
                         className={getClassNameModal("tr")}
                         onClick={() => {
-                          onChange(mapProp(data[i]));
+                          onChange(mapProp(data[i],filters));
 
                           setOpen(false);
                         }}

--- a/packages/core/components/ExternalInput/index.tsx
+++ b/packages/core/components/ExternalInput/index.tsx
@@ -41,8 +41,8 @@ export const ExternalInput = ({
   const [isLoading, setIsLoading] = useState(true);
 
   const hasFilterFields = !!filterFields;
-
-  const [filters, setFilters] = useState(field.initialFilters || {});
+  // @ts-ignore
+  const [filters, setFilters] = useState(field.initialFilters || value?.[name] || {});
   const [filtersToggled, setFiltersToggled] = useState(hasFilterFields);
 
   const mappedData = useMemo(() => {

--- a/packages/core/types/Fields.ts
+++ b/packages/core/types/Fields.ts
@@ -90,7 +90,7 @@ export type ExternalField<
     query: string;
     filters: Record<string, any>;
   }) => Promise<any[] | null>;
-  mapProp?: (value: any) => Props;
+  mapProp?: (value: any,filters:any) => Props;
   mapRow?: (value: any) => Record<string, string | number>;
   getItemSummary?: (item: Props, index?: number) => string;
   showSearch?: boolean;


### PR DESCRIPTION
Enhance ExternalInput: Pass filters to mapProp for custom data mapping

- Updated `mapProp` function to accept filters as an argument.
- Modified `ExternalInput` component to pass current filters when selecting data from the table.
- Enabled dynamic data mapping based on filters for better flexibility.
