### PR TITLE
fix: adds condition check for number values in select

### DIFF
--- a/packages/core/components/AutoField/fields/DefaultField/index.tsx
+++ b/packages/core/components/AutoField/fields/DefaultField/index.tsx
@@ -30,6 +30,7 @@ export const DefaultField = ({
         className={getClassName("input")}
         autoComplete="off"
         type={field.type}
+        title={label || name}
         name={name}
         value={typeof value === "undefined" ? "" : value.toString()}
         onChange={(e) => {

--- a/packages/core/components/AutoField/fields/RadioField/index.tsx
+++ b/packages/core/components/AutoField/fields/RadioField/index.tsx
@@ -2,8 +2,7 @@ import getClassNameFactory from "../../../../lib/get-class-name-factory";
 import styles from "../../styles.module.css";
 import { CheckCircle } from "lucide-react";
 import { FieldPropsInternal } from "../..";
-import {safeJsonParse } from "../../../../lib/safe-json-parse"
-
+import { safeJsonParse } from "../../../../lib/safe-json-parse";
 
 const getClassName = getClassNameFactory("Input", styles);
 
@@ -39,7 +38,9 @@ export const RadioField = ({
               className={getClassName("radioInput")}
               value={option.value as string | number}
               name={name}
-              onChange={({ target: { value } }) => onChange(safeJsonParse(value) || value)}
+              onChange={({ target: { value } }) =>
+                onChange(safeJsonParse(value) || value)
+              }
               disabled={readOnly}
               checked={value === option.value}
             />

--- a/packages/core/components/AutoField/fields/RadioField/index.tsx
+++ b/packages/core/components/AutoField/fields/RadioField/index.tsx
@@ -39,7 +39,7 @@ export const RadioField = ({
               className={getClassName("radioInput")}
               value={option.value as string | number}
               name={name}
-              onChange={({ target: { value } }) => safeJsonParse(value) ? onChange(JSON.parse(value)) : onChange(value)}
+              onChange={({ target: { value } }) => onChange(safeJsonParse(value) || value)}
               disabled={readOnly}
               checked={value === option.value}
             />

--- a/packages/core/components/AutoField/fields/RadioField/index.tsx
+++ b/packages/core/components/AutoField/fields/RadioField/index.tsx
@@ -2,6 +2,8 @@ import getClassNameFactory from "../../../../lib/get-class-name-factory";
 import styles from "../../styles.module.css";
 import { CheckCircle } from "lucide-react";
 import { FieldPropsInternal } from "../..";
+import {safeJsonParse } from "../../../../lib/safe-json-parse"
+
 
 const getClassName = getClassNameFactory("Input", styles);
 
@@ -37,17 +39,7 @@ export const RadioField = ({
               className={getClassName("radioInput")}
               value={option.value as string | number}
               name={name}
-              onChange={(e) => {
-                if (
-                  e.currentTarget.value === "true" ||
-                  e.currentTarget.value === "false"
-                ) {
-                  onChange(JSON.parse(e.currentTarget.value));
-                  return;
-                }
-
-                onChange(e.currentTarget.value);
-              }}
+              onChange={({ target: { value } }) => safeJsonParse(value) ? onChange(JSON.parse(value)) : onChange(value)}
               disabled={readOnly}
               checked={value === option.value}
             />

--- a/packages/core/components/AutoField/fields/SelectField/index.tsx
+++ b/packages/core/components/AutoField/fields/SelectField/index.tsx
@@ -27,18 +27,20 @@ export const SelectField = ({
     >
       <select
         id={id}
+        title={label || name}
         className={getClassName("input")}
         disabled={readOnly}
-        onChange={(e) => {
+        onChange={({ target: { value } }) => {
           if (
-            e.currentTarget.value === "true" ||
-            e.currentTarget.value === "false"
+          value === "true" ||
+          value === "false" ||
+          typeof value === "number"
           ) {
-            onChange(JSON.parse(e.currentTarget.value));
+            onChange(JSON.parse(value));
             return;
           }
 
-          onChange(e.currentTarget.value);
+          onChange(value);
         }}
         value={value}
       >

--- a/packages/core/components/AutoField/fields/SelectField/index.tsx
+++ b/packages/core/components/AutoField/fields/SelectField/index.tsx
@@ -31,18 +31,7 @@ export const SelectField = ({
         title={label || name}
         className={getClassName("input")}
         disabled={readOnly}
-        onChange={({ target: { value } }) => {
-          if (
-          value === "true" ||
-          value === "false" ||
-          typeof safeJsonParse(value) === "number"
-          ) {
-            onChange(JSON.parse(value));
-            return;
-          }
-
-          onChange(value);
-        }}
+        onChange={({ target: { value } }) => safeJsonParse(value) ? onChange(JSON.parse(value)) : onChange(value)}
         value={value}
       >
         {field.options.map((option) => (

--- a/packages/core/components/AutoField/fields/SelectField/index.tsx
+++ b/packages/core/components/AutoField/fields/SelectField/index.tsx
@@ -2,7 +2,7 @@ import getClassNameFactory from "../../../../lib/get-class-name-factory";
 import styles from "../../styles.module.css";
 import { ChevronDown } from "lucide-react";
 import { FieldPropsInternal } from "../..";
-import {safeJsonParse } from "../../../../lib/safe-json-parse"
+import { safeJsonParse } from "../../../../lib/safe-json-parse";
 
 const getClassName = getClassNameFactory("Input", styles);
 
@@ -31,7 +31,9 @@ export const SelectField = ({
         title={label || name}
         className={getClassName("input")}
         disabled={readOnly}
-        onChange={({ target: { value } }) => onChange(safeJsonParse(value) || value)}
+        onChange={({ target: { value } }) =>
+          onChange(safeJsonParse(value) || value)
+        }
         value={value}
       >
         {field.options.map((option) => (

--- a/packages/core/components/AutoField/fields/SelectField/index.tsx
+++ b/packages/core/components/AutoField/fields/SelectField/index.tsx
@@ -2,6 +2,7 @@ import getClassNameFactory from "../../../../lib/get-class-name-factory";
 import styles from "../../styles.module.css";
 import { ChevronDown } from "lucide-react";
 import { FieldPropsInternal } from "../..";
+import {safeJsonParse } from "../../../../lib/safe-json-parse"
 
 const getClassName = getClassNameFactory("Input", styles);
 
@@ -34,7 +35,7 @@ export const SelectField = ({
           if (
           value === "true" ||
           value === "false" ||
-          typeof value === "number"
+          typeof safeJsonParse(value) === "number"
           ) {
             onChange(JSON.parse(value));
             return;

--- a/packages/core/components/AutoField/fields/SelectField/index.tsx
+++ b/packages/core/components/AutoField/fields/SelectField/index.tsx
@@ -31,7 +31,7 @@ export const SelectField = ({
         title={label || name}
         className={getClassName("input")}
         disabled={readOnly}
-        onChange={({ target: { value } }) => safeJsonParse(value) ? onChange(JSON.parse(value)) : onChange(value)}
+        onChange={({ target: { value } }) => onChange(safeJsonParse(value) || value)}
         value={value}
       >
         {field.options.map((option) => (

--- a/packages/core/lib/safe-json-parse.ts
+++ b/packages/core/lib/safe-json-parse.ts
@@ -1,0 +1,8 @@
+export const safeJsonParse = <T>(str: string) => {
+  try {
+    const jsonValue: T = JSON.parse(str);
+    return jsonValue;
+  } catch {
+    return undefined;
+  }
+};

--- a/packages/core/lib/safe-json-parse.ts
+++ b/packages/core/lib/safe-json-parse.ts
@@ -3,6 +3,6 @@ export const safeJsonParse = <T>(str: string) => {
     const jsonValue: T = JSON.parse(str);
     return jsonValue;
   } catch {
-    return undefined;
+    return str;
   }
 };


### PR DESCRIPTION
https://github.com/measuredco/puck/issues/713

- Aims to fix For when select boxes that have number values  this PR adds a check and JSON.parse the value.
- (also sneakily adds a title attr for added accessibility)

An alternative approach might be to safely JSON parse all values and should that fail just return the value as is or an empty string. https://gist.github.com/jswhisperer/ec7c99dab7ca8549f40cbd1e853399ae