### PR TITLE
Fix radio buttons in arrays

### DIFF
--- a/packages/core/components/AutoField/index.tsx
+++ b/packages/core/components/AutoField/index.tsx
@@ -217,7 +217,17 @@ function AutoFieldInternal<
   const Render = render[field.type] as (props: FieldProps) => ReactElement;
 
   return (
-    <div className={getClassNameWrapper()} onFocus={onFocus} onBlur={onBlur}>
+    <div
+      className={getClassNameWrapper()}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      onClick={(e) => {
+        // Prevent propagation of any click events to parent field.
+        // For example, a field within an array may bubble an event
+        // and fail to stop propagation.
+        e.stopPropagation();
+      }}
+    >
       <Render {...mergedProps}>{children}</Render>
     </div>
   );

--- a/packages/core/components/AutoField/index.tsx
+++ b/packages/core/components/AutoField/index.tsx
@@ -233,9 +233,6 @@ function AutoFieldInternal<
   );
 }
 
-// Don't let external value changes update this if it's changed manually in the last X ms
-const RECENT_CHANGE_TIMEOUT = 200;
-
 type FieldNoLabel<Props extends any = any> = Omit<Field<Props>, "label">;
 
 export function AutoFieldPrivate<


### PR DESCRIPTION
Because the radio button implementation uses a sibling `div` element, the click event was bubbling up to the `array` parent, where `preventDefault` would be called before the event could change the `input`.

The `preventDefault` is necessary to prevent arrays from misbehaving when used inside a `label` element, which would cause one of the array actions (delete/duplicate) to trigger when the array item summary was clicked.

The bubbling here is slightly confusing, because of the sibling nature of the radio field.

Fix is to stop propagation of the event. This could be done on the sibling `div` element, but better in the `AutoField` component to prevent the same bug from impacting custom field implementations.

Closes #723 
