### PR TITLE
fix: booleans type in select/radio fields

### DIFF
--- a/packages/core/components/AutoField/fields/RadioField/index.tsx
+++ b/packages/core/components/AutoField/fields/RadioField/index.tsx
@@ -47,7 +47,7 @@ export const RadioField = ({
               name={name}
               onChange={(e) => {
                 const jsonValue =
-                  safeJsonParse(e.target.value) || e.target.value;
+                  safeJsonParse(e.target.value) ?? e.target.value;
 
                 if (flatOptions.indexOf(jsonValue) > -1) {
                   onChange(jsonValue);

--- a/packages/core/components/AutoField/fields/SelectField/index.tsx
+++ b/packages/core/components/AutoField/fields/SelectField/index.tsx
@@ -39,7 +39,7 @@ export const SelectField = ({
         className={getClassName("input")}
         disabled={readOnly}
         onChange={(e) => {
-          const jsonValue = safeJsonParse(e.target.value) || e.target.value;
+          const jsonValue = safeJsonParse(e.target.value) ?? e.target.value;
 
           if (flatOptions.indexOf(jsonValue) > -1) {
             onChange(jsonValue);


### PR DESCRIPTION
`safeJsonParse(false)` returns `false` so `const jsonValue` will be `"false"` and cannot be found in `flatOptions`.

We need to check for `undefined` and not for `false`.