### PR TITLE
fix: fix plugin-emotion-cache style sync when using initialData

### DIFF
--- a/packages/plugin-emotion-cache/index.tsx
+++ b/packages/plugin-emotion-cache/index.tsx
@@ -13,14 +13,17 @@ const createEmotionCachePlugin = (key: string): Plugin => {
 
         // eslint-disable-next-line react-hooks/rules-of-hooks
         useEffect(() => {
-          if (document) {
-            setCache(
-              createCache({
-                key,
-                container: document.head,
-              })
-            );
-          }
+          // Defer until next render
+          setTimeout(() => {
+            if (document) {
+              setCache(
+                createCache({
+                  key,
+                  container: document.head,
+                })
+              );
+            }
+          }, 0);
         }, [document, key]);
 
         if (cache) {


### PR DESCRIPTION
See [Discord thread](https://discord.com/channels/1153376562259951687/1322960022757445672/1323240307533287445). Using the emotion cache plugin with `initialData` was preventing styles from loading. Adding a timeout of 0ms addresses it. 