### PR TITLE
fix: ensure parent is not null on first render in resolveFields

### DIFF
--- a/packages/core/components/Puck/components/Fields/index.tsx
+++ b/packages/core/components/Puck/components/Fields/index.tsx
@@ -126,22 +126,38 @@ const useResolvedFields = (): [FieldsType, boolean] => {
         lastData,
       });
     },
-    [data, config, componentData, selectedItem, resolvedFields, state]
+    [data, config, componentData, selectedItem, resolvedFields, state, parent]
   );
 
+  const [hasParent, setHasParent] = useState(false);
+
   useEffect(() => {
-    if (hasResolver) {
-      setFieldsLoading(true);
+    setHasParent(!!parent);
+  }, [parent]);
 
-      resolveFields(defaultFields).then((fields) => {
-        setResolvedFields(fields || {});
+  useEffect(() => {
+    // Must either be in root zone, or have parent
+    if (!state.ui.itemSelector?.zone || hasParent) {
+      if (hasResolver) {
+        setFieldsLoading(true);
 
-        setFieldsLoading(false);
-      });
-    } else {
-      setResolvedFields(defaultFields);
+        resolveFields(defaultFields).then((fields) => {
+          setResolvedFields(fields || {});
+
+          setFieldsLoading(false);
+        });
+      } else {
+        setResolvedFields(defaultFields);
+      }
     }
-  }, [data, defaultFields, selectedItem, hasResolver]);
+  }, [
+    data,
+    defaultFields,
+    state.ui.itemSelector,
+    selectedItem,
+    hasResolver,
+    hasParent,
+  ]);
 
   return [resolvedFields, fieldsLoading];
 };


### PR DESCRIPTION
Parent does not exist on first render, but the resolver would only run on first render.

This defers rendering of the resolver until after the parent exists, unless the item is not inside another element.

Closes #777 