### PR TITLE
SSR issues still on render with new dnd engine

### DIFF
--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -394,7 +394,11 @@ const DropZoneRender = forwardRef<HTMLDivElement, DropZoneProps>(
               >
                 <Component.render
                   {...item.props}
-                  puck={{ renderDropZone: DropZoneRender }}
+                  puck={{
+                    renderDropZone: (props: DropZoneProps) => (
+                      <DropZoneRender {...props} />
+                    ),
+                  }}
                 />
               </DropZoneProvider>
             );


### PR DESCRIPTION
This is in relation to Issue #778 and PR #790 

Whilst #790 solved the issue for renderDropZone in the puck editor. The same issue was still in the RSC render function.

This seems to fix that, I've tested on both a RSC implementation and the puck demo app.