### PR TITLE
refactor: don't prevent pointerup propagation when no drag

### DIFF
--- a/packages/core/lib/dnd/PointerSensor.ts
+++ b/packages/core/lib/dnd/PointerSensor.ts
@@ -272,6 +272,10 @@ export class PointerSensor extends Sensor<
   }
 
   private handlePointerUp(event: PointerEvent) {
+    if (!this.source) {
+      return;
+    }
+
     // Prevent the default behaviour of the event
     event.preventDefault();
     event.stopPropagation();


### PR DESCRIPTION
The pointerup event handler was preventing propagation, even if the user was not currently dragging.

Fixed by adding a check to the sensor. Also moving fix upstream to https://github.com/clauderic/dnd-kit/pull/1566.

Closes #769 