### PR TITLE
refactor: handle case where preview state updates before data

### DIFF
--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -282,11 +282,13 @@ const DropZoneEdit = forwardRef<HTMLDivElement, DropZoneProps>(
 
           let label = componentConfig?.["label"] ?? item.type.toString();
 
-          if (item.type === "preview" && preview) {
-            componentType = preview.componentType;
+          if (item.type === "preview") {
+            componentType = preview?.componentType ?? "__preview";
 
             label =
-              config.components[componentType]?.label ?? preview.componentType;
+              config.components[componentType]?.label ??
+              componentType ??
+              "Preview";
 
             function Preview() {
               return (


### PR DESCRIPTION
When dropping in a new component, the "No configuration for preview" would appear momentarily, before the component is rendered. This is due to a race condition introduced in #767, as the preview is kept in Zustand, which triggers a render before the data updates (which kept in context).

Might be able to refactor this once all state moves to zustand as part of #644.