### PR TITLE
Fix remaining field label issues

### DIFF
--- a/apps/docs/pages/docs/api-reference/components/puck-fields.mdx
+++ b/apps/docs/pages/docs/api-reference/components/puck-fields.mdx
@@ -35,4 +35,24 @@ export function Editor() {
 
 ## Props
 
-This component doesn't accept any props.
+| Param                       | Example             | Type    | Status |
+| --------------------------- | ------------------- | ------- | ------ |
+| [`wrapFields`](#wrapfields) | `wrapFields: false` | boolean | -      |
+
+## Optional props
+
+### `wrapFields`
+
+Whether or not the top-level fields should be padded and separated by a a border. Defaults to `true`.
+
+```tsx {6} copy
+import { Puck } from "@measured/puck";
+
+export function Editor() {
+  return (
+    <Puck>
+      <Puck.Fields wrapFields={false} />
+    </Puck>
+  );
+}
+```

--- a/packages/core/components/AutoField/styles.module.css
+++ b/packages/core/components/AutoField/styles.module.css
@@ -1,25 +1,4 @@
-.InputWrapper {
-  color: var(--puck-color-grey-04);
-  padding: 16px;
-  padding-bottom: 12px;
-  display: block;
-}
-
 .InputWrapper + .InputWrapper {
-  border-top: 1px solid var(--puck-color-grey-09);
-  margin-top: 8px;
-}
-
-.Input .InputWrapper {
-  padding: 0px;
-}
-
-.Input * {
-  box-sizing: border-box;
-}
-
-.Input .InputWrapper + .InputWrapper {
-  border-top: 0px;
   margin-top: 12px;
 }
 

--- a/packages/core/components/Puck/components/Fields/index.tsx
+++ b/packages/core/components/Puck/components/Fields/index.tsx
@@ -166,7 +166,7 @@ const useResolvedFields = (): [FieldsType, boolean] => {
   return [resolvedFields, fieldsLoading];
 };
 
-export const Fields = () => {
+export const Fields = ({ wrapFields = true }: { wrapFields?: boolean }) => {
   const {
     selectedItem,
     state,
@@ -196,7 +196,7 @@ export const Fields = () => {
 
   return (
     <form
-      className={getClassName({ wrapFields:true })}
+      className={getClassName({ wrapFields })}
       onSubmit={(e) => {
         e.preventDefault();
       }}

--- a/packages/core/components/Puck/components/Fields/index.tsx
+++ b/packages/core/components/Puck/components/Fields/index.tsx
@@ -196,7 +196,7 @@ export const Fields = () => {
 
   return (
     <form
-      className={getClassName()}
+      className={getClassName({ wrapFields:true })}
       onSubmit={(e) => {
         e.preventDefault();
       }}
@@ -292,15 +292,16 @@ export const Fields = () => {
             const id = `${selectedItem.props.id}_${field.type}_${fieldName}`;
 
             return (
-              <AutoFieldPrivate
-                key={id}
-                field={field}
-                name={fieldName}
-                id={id}
-                readOnly={!edit || readOnly[fieldName]}
-                value={selectedItem.props[fieldName]}
-                onChange={onChange}
-              />
+              <div key={id} className={getClassName("field")}>
+                <AutoFieldPrivate
+                  field={field}
+                  name={fieldName}
+                  id={id}
+                  readOnly={!edit || readOnly[fieldName]}
+                  value={selectedItem.props[fieldName]}
+                  onChange={onChange}
+                />
+              </div>
             );
           } else {
             const readOnly = (data.root.readOnly || {}) as Record<
@@ -314,15 +315,16 @@ export const Fields = () => {
             const id = `root_${field.type}_${fieldName}`;
 
             return (
-              <AutoFieldPrivate
-                key={id}
-                field={field}
-                name={fieldName}
-                id={id}
-                readOnly={!edit || readOnly[fieldName]}
-                value={(rootProps as Record<string, any>)[fieldName]}
-                onChange={onChange}
-              />
+              <div key={id} className={getClassName("field")}>
+                <AutoFieldPrivate
+                  field={field}
+                  name={fieldName}
+                  id={id}
+                  readOnly={!edit || readOnly[fieldName]}
+                  value={(rootProps as Record<string, any>)[fieldName]}
+                  onChange={onChange}
+                />
+              </div>
             );
           }
         })}

--- a/packages/core/components/Puck/components/Fields/styles.module.css
+++ b/packages/core/components/Puck/components/Fields/styles.module.css
@@ -28,3 +28,19 @@
   position: sticky;
   top: 0;
 }
+
+.PuckFields-field * {
+  box-sizing: border-box;
+}
+
+.PuckFields--wrapFields .PuckFields-field {
+  color: var(--puck-color-grey-04);
+  padding: 16px;
+  padding-bottom: 12px;
+  display: block;
+}
+
+.PuckFields--wrapFields .PuckFields-field + .PuckFields-field {
+  border-top: 1px solid var(--puck-color-grey-09);
+  margin-top: 8px;
+}


### PR DESCRIPTION
When trying to solve [this issue](https://discord.com/channels/1153376562259951687/1328683387514261504/1329067870931652688) using existing field overrides and APIs, I noticed that it was impossible to achieve the desired styles due to an implementation of padding and border on FieldLabel.

Having these styles on FieldLabel has caused issues before (see #666).

This PR moves these wrapping styles to `<Puck.Fields>`, which can now be toggled via the `wrapFields` prop in custom interfaces.  This is the correct place to define these styles, as the wrapping should only ever occur when used within the default `<Puck.Fields>` component.