### PR TITLE
Reset lastFields on component change

### DIFF
--- a/apps/demo/config/components/Layout/index.tsx
+++ b/apps/demo/config/components/Layout/index.tsx
@@ -54,7 +54,7 @@ export const layoutField: ObjectField<LayoutFieldProps> = {
   },
 };
 
-export const Layout = forwardRef<HTMLDivElement, LayoutProps>(
+const Layout = forwardRef<HTMLDivElement, LayoutProps>(
   ({ children, className, layout, style }, ref) => {
     return (
       <div
@@ -78,6 +78,10 @@ export const Layout = forwardRef<HTMLDivElement, LayoutProps>(
     );
   }
 );
+
+Layout.displayName = "Layout";
+
+export { Layout };
 
 export function withLayout<
   Props extends DefaultComponentProps = DefaultComponentProps

--- a/packages/core/components/Puck/components/Fields/index.tsx
+++ b/packages/core/components/Puck/components/Fields/index.tsx
@@ -150,10 +150,12 @@ const useResolvedFields = (): [FieldsType, boolean] => {
 
           setFieldsLoading(false);
         });
-      } else {
-        setResolvedFields(defaultFields);
+
+        return;
       }
     }
+
+    setResolvedFields(defaultFields);
   }, [
     data,
     defaultFields,


### PR DESCRIPTION
`lastFields` was not clearing inside nested components when selecting a new component.

This bug was introduced in 37cfc43156e75f20f91899660a9a9bfa1dd2bc23 (and equivalent in 0.17.2).