### PR TITLE
Ensure root DropZone fills container

### DIFF
--- a/apps/demo/config/root.tsx
+++ b/apps/demo/config/root.tsx
@@ -4,13 +4,13 @@ import { Header } from "./components/Header";
 
 export type RootProps = DefaultRootProps;
 
-function Root({ children, puck }: RootProps) {
+function Root({ puck }: RootProps) {
   return (
     <div
       style={{ display: "flex", flexDirection: "column", minHeight: "100vh" }}
     >
       <Header editMode={puck.isEditing} />
-      {children}
+      <DropZone zone="default-zone" style={{ flexGrow: 1 }} />
       <Footer>
         <Footer.List title="Section">
           <Footer.Link href="#">Label</Footer.Link>

--- a/packages/core/styles.css
+++ b/packages/core/styles.css
@@ -3,5 +3,6 @@
 @import "./styles/typography.css";
 
 #frame-root {
+  height: 1px; /* Enables DropZone to inherit min-height */
   min-height: 100vh;
 }


### PR DESCRIPTION
This was originally implemented in 3d93f46 as part of this release, but the implementation was incomplete.