### PR TITLE
refactor: handle null when provided to text/textarea/number fields

### DIFF
--- a/packages/core/components/AutoField/fields/DefaultField/index.tsx
+++ b/packages/core/components/AutoField/fields/DefaultField/index.tsx
@@ -9,12 +9,14 @@ export const DefaultField = ({
   field,
   onChange,
   readOnly,
-  value,
+  value: _value,
   name,
   label,
   Label,
   id,
 }: FieldPropsInternal) => {
+  const value = _value as string | number | undefined | null;
+
   return (
     <Label
       label={label || name}
@@ -32,7 +34,7 @@ export const DefaultField = ({
         type={field.type}
         title={label || name}
         name={name}
-        value={typeof value === "undefined" ? "" : value.toString()}
+        value={value?.toString ? value.toString() : ""}
         onChange={(e) => {
           if (field.type === "number") {
             const numberValue = Number(e.currentTarget.value);

--- a/packages/core/lib/__tests__/use-resolved-permissions.spec.tsx
+++ b/packages/core/lib/__tests__/use-resolved-permissions.spec.tsx
@@ -1,14 +1,5 @@
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
-import {
-  AppState,
-  ComponentConfig,
-  ComponentData,
-  Config,
-  Data,
-} from "../../types";
-import { useResolvedData } from "../use-resolved-data";
-import { SetAction, SetDataAction } from "../../reducer";
-import { cache } from "../resolve-component-data";
+import { AppState, ComponentData, Config, Data } from "../../types";
 import { defaultAppState } from "../../components/Puck/context";
 import { useResolvedPermissions } from "../use-resolved-permissions";
 

--- a/packages/core/lib/use-resolved-permissions.ts
+++ b/packages/core/lib/use-resolved-permissions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { flattenData } from "./flatten-data";
 import { ComponentData, Config, Permissions, UserGenerics } from "../types";
 import { getChanged } from "./get-changed";


### PR DESCRIPTION
Puck was handling `undefined` but not `null` in the DefaultField. This adds stricter typing (which would have caught it), and addresses the underlying issue.

Also does some unrelated tidy up.

Will be released in 0.17.4 (e778246). This implementation if for 0.18.

Closes #775 