### PR TITLE
Address issue with pathData not resolving

### DIFF
--- a/packages/core/components/DragDropContext/index.tsx
+++ b/packages/core/components/DragDropContext/index.tsx
@@ -326,6 +326,19 @@ const DragDropContextClient = ({
     [data, setPathData]
   );
 
+  const unregisterPath = useCallback(
+    (id: string) => {
+      setPathData((latestPathData = {}) => {
+        const newPathData = { ...latestPathData };
+
+        delete newPathData[id];
+
+        return newPathData;
+      });
+    },
+    [data, setPathData]
+  );
+
   const initialSelector = useRef<{ zone: string; index: number }>(undefined);
 
   return (
@@ -578,6 +591,7 @@ const DragDropContextClient = ({
                 areaId: "root",
                 depth: 0,
                 registerPath,
+                unregisterPath,
                 pathData,
                 path: [],
               }}

--- a/packages/core/components/DragDropContext/index.tsx
+++ b/packages/core/components/DragDropContext/index.tsx
@@ -305,13 +305,7 @@ const DragDropContextClient = ({
   const dragMode = useRef<"new" | "existing" | null>(null);
 
   const registerPath = useCallback(
-    (selector: ItemSelector) => {
-      const item = getItem(selector, data);
-
-      if (!item) {
-        return;
-      }
-
+    (id: string, selector: ItemSelector, label: string) => {
       const [area] = getZoneId(selector.zone);
 
       setPathData((latestPathData = {}) => {
@@ -319,12 +313,12 @@ const DragDropContextClient = ({
 
         return {
           ...latestPathData,
-          [item.props.id]: {
+          [id]: {
             path: [
               ...parentPathData.path,
               ...(selector.zone ? [selector.zone] : []),
             ],
-            label: item.type as string,
+            label: label,
           },
         };
       });

--- a/packages/core/components/DraggableComponent/index.tsx
+++ b/packages/core/components/DraggableComponent/index.tsx
@@ -298,13 +298,15 @@ export const DraggableComponent = ({
   }, [ref.current]);
 
   useEffect(() => {
-    if (isSelected) {
-      ctx?.registerPath!({
+    ctx?.registerPath!(
+      id,
+      {
         index,
         zone: zoneCompound,
-      });
-    }
-  }, [isSelected]);
+      },
+      componentType
+    );
+  }, [id, zoneCompound, index, componentType]);
 
   const CustomActionBar = useMemo(
     () => overrides.actionBar || DefaultActionBar,

--- a/packages/core/components/DraggableComponent/index.tsx
+++ b/packages/core/components/DraggableComponent/index.tsx
@@ -306,6 +306,10 @@ export const DraggableComponent = ({
       },
       componentType
     );
+
+    return () => {
+      ctx?.unregisterPath?.(id);
+    };
   }, [id, zoneCompound, index, componentType]);
 
   const CustomActionBar = useMemo(

--- a/packages/core/components/DropZone/context.tsx
+++ b/packages/core/components/DropZone/context.tsx
@@ -32,7 +32,7 @@ export type DropZoneContext<UserConfig extends Config = Config> = {
   unregisterZone?: (zoneCompound: string) => void;
   activeZones?: Record<string, boolean>;
   pathData?: PathData;
-  registerPath?: (selector: ItemSelector) => void;
+  registerPath?: (id: string, selector: ItemSelector, label: string) => void;
   mode?: "edit" | "render";
   depth: number;
   registerLocalZone?: (zone: string, active: boolean) => void; // A zone as it pertains to the current area

--- a/packages/core/components/DropZone/context.tsx
+++ b/packages/core/components/DropZone/context.tsx
@@ -33,6 +33,7 @@ export type DropZoneContext<UserConfig extends Config = Config> = {
   activeZones?: Record<string, boolean>;
   pathData?: PathData;
   registerPath?: (id: string, selector: ItemSelector, label: string) => void;
+  unregisterPath?: (id: string) => void;
   mode?: "edit" | "render";
   depth: number;
   registerLocalZone?: (zone: string, active: boolean) => void; // A zone as it pertains to the current area


### PR DESCRIPTION
Addresses issues where selecting an item nested within a component that has not yet been selected does not receive the path.

This only affects 0.18. Moving to a slot API (via #255) should eliminate zone flushing and registering, as the zone data will be statically deterministic, rather than only known at runtime.

## Steps to reproduce

1. Go to https://demo.puckeditor.com/debug/edit
2. Drag in a flex component
3. Nest another flex component inside the first one
4. Drag in a heading inside the flex component
5. Publish the page
6. Refresh
7. Immediately select the heading component, without selecting anything else

## What happened

No "Flex" breadcrumb is not visible in the top right, with only the "Heading" title shown, indicating the path data is not known. Equally, the fields are not resolved (see both grid and flex fields under Layout object field).

## What I expected to happen

The breadcrumb to show a "Flex" breadcrumb to the left of the "Heading" title, and the fields to be resolved so only the flex fields appear under the Layout object field.