### PR TITLE
refactor: don't wipe out style.backgroundColor on DropZone

### DIFF
--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -247,7 +247,9 @@ const DropZoneEdit = forwardRef<HTMLDivElement, DropZoneProps>(
           {
             ...style,
             "--min-empty-height": `${minEmptyHeight}px`,
-            backgroundColor: RENDER_DEBUG ? getRandomColor() : undefined,
+            backgroundColor: RENDER_DEBUG
+              ? getRandomColor()
+              : style?.backgroundColor,
           } as CSSProperties
         }
       >


### PR DESCRIPTION
This was a bug introduced when optimising performance and adding the render debug mode.