### PR TITLE
refactor: ensure DropZones can still capture pointer event

### DIFF
--- a/packages/core/components/DraggableComponent/styles.css
+++ b/packages/core/components/DraggableComponent/styles.css
@@ -12,7 +12,7 @@
   -webkit-user-select: none;
 }
 
-[data-puck-dnd] {
+[data-puck-dropzone] {
   pointer-events: auto !important; /* Ensure DropZones still capture pointer events inside data-puck-components so elementsFromPoint triggers */
 }
 


### PR DESCRIPTION
Previous commit addressed a bug related to the data- attributes being overwritten when using `dragRef` with a DropZone, but failed to address the underlying CSS styles that enable the DropZone to capture the necessary pointer events to trigger the NestedDroppablePlugin.