### PR TITLE
fix: ensure nested drag-and-drop works in Firefox

### DIFF
--- a/packages/core/components/Puck/components/Preview/index.tsx
+++ b/packages/core/components/Puck/components/Preview/index.tsx
@@ -27,7 +27,15 @@ const useBubbleIframeEvents = (ref: RefObject<HTMLIFrameElement | null>) => {
         extends PointerEvent
         implements BubbledPointerEvent
       {
-        originalTarget: EventTarget | null;
+        _originalTarget: EventTarget | null = null;
+
+        set originalTarget(target: EventTarget | null) {
+          this._originalTarget = target;
+        }
+
+        get originalTarget() {
+          return this._originalTarget;
+        }
 
         constructor(
           type: string,


### PR DESCRIPTION
Nested components in 0.18 aren't working in Firefox.