### PR TITLE
fix: ensure ctrl+i interactive toggle hotkey works on Windows

### DIFF
--- a/apps/docs/pages/docs/api-reference/app-state.mdx
+++ b/apps/docs/pages/docs/api-reference/app-state.mdx
@@ -93,7 +93,7 @@ The mode for the preview area, controlling whether or not the user can interact 
 - **`"edit"` (default)**: Components can be dragged and modified. An overlay prevents interaction with the underlying component.
 - **`"interactive"`**: Editing functionality is disabled. The user can interact with the underlying component.
 
-Puck does not currently provide the UI to control this value, but it can be toggled via the `meta+i` hotkey.
+Puck does not currently provide the UI to control this value, but it can be toggled via the `cmd+i` or `ctrl+i` hotkeys.
 
 ---
 

--- a/packages/core/lib/use-preview-mode-hotkeys.ts
+++ b/packages/core/lib/use-preview-mode-hotkeys.ts
@@ -31,4 +31,10 @@ export const usePreviewModeHotkeys = (
     preventDefault: true,
     document: resolvedFrame,
   });
+  // For Windows
+  useHotkeys("ctrl+i", toggleInteractive, { preventDefault: true });
+  useHotkeys("ctrl+i", toggleInteractiveIframe, {
+    preventDefault: true,
+    document: resolvedFrame,
+  });
 };


### PR DESCRIPTION
@FedericoBonel would you mind testing this now I've added an explicit hotkey? If this doesn't work, we can try a new binding.

Closes #851 