### PR TITLE
Provide updated props to resolveFields

### DIFF
--- a/packages/core/lib/__tests__/use-resolved-fields.spec.tsx
+++ b/packages/core/lib/__tests__/use-resolved-fields.spec.tsx
@@ -182,7 +182,7 @@ describe("use-resolved-fields", () => {
       expect(mockResolveFields).toHaveBeenCalledWith(
         {
           props: {},
-          readOnly: undefined,
+          readOnly: {},
         },
         {
           appState: {
@@ -230,7 +230,7 @@ describe("use-resolved-fields", () => {
         expect(mockResolveFields).toHaveBeenCalledWith(
           {
             props: {},
-            readOnly: undefined,
+            readOnly: {},
           },
           {
             appState: {
@@ -280,7 +280,7 @@ describe("use-resolved-fields", () => {
       expect(result.current[1]).toBe(false);
       expect(mockResolveFields).toHaveBeenCalledTimes(2);
       expect(mockResolveFields.mock.calls[1]).toEqual([
-        { props: { foo: "bar" }, readOnly: undefined },
+        { props: { foo: "bar" }, readOnly: {} },
         {
           appState: {
             data: { content: [], root: { props: { foo: "bar" } } }, // props changed
@@ -288,7 +288,7 @@ describe("use-resolved-fields", () => {
           },
           changed: { foo: true }, // track changed
           fields: { title: { type: "text" } },
-          lastData: { props: {}, readOnly: undefined },
+          lastData: { props: {}, readOnly: {} },
           lastFields: { title: { type: "textarea" } }, // track previous fields due to re-render
           parent: null,
         },

--- a/packages/core/lib/use-resolved-fields.ts
+++ b/packages/core/lib/use-resolved-fields.ts
@@ -55,9 +55,13 @@ export const useResolvedFields = (): [FieldsType, boolean] => {
     }
   ) => defaultFields;
 
-  const componentData: ComponentOrRootData = selectedItem
-    ? selectedItem
-    : { props: rootProps, readOnly: data.root.readOnly };
+  const componentData: ComponentOrRootData = useMemo(
+    () =>
+      selectedItem
+        ? selectedItem
+        : { props: rootProps, readOnly: data.root.readOnly },
+    [selectedItem, rootProps, data.root.readOnly]
+  );
 
   const hasComponentResolver = selectedItem && componentConfig?.resolveFields;
   const hasRootResolver = !selectedItem && config.root?.resolveFields;
@@ -131,7 +135,13 @@ export const useResolvedFields = (): [FieldsType, boolean] => {
       }
     }
     setResolvedFields(defaultFields);
-  }, [defaultFields, state.ui.itemSelector, hasResolver, parent]);
+  }, [
+    defaultFields,
+    state.ui.itemSelector,
+    hasResolver,
+    parent,
+    resolveFields,
+  ]);
 
   useOnValueChange<ItemSelector | null>(
     state.ui.itemSelector,

--- a/packages/core/lib/use-resolved-fields.ts
+++ b/packages/core/lib/use-resolved-fields.ts
@@ -59,7 +59,7 @@ export const useResolvedFields = (): [FieldsType, boolean] => {
     () =>
       selectedItem
         ? selectedItem
-        : { props: rootProps, readOnly: data.root.readOnly },
+        : { props: rootProps, readOnly: data.root.readOnly || {} },
     [selectedItem, rootProps, data.root.readOnly]
   );
 


### PR DESCRIPTION
The [resolveFields refactor](#808) and test coverage missed a critical feature: providing the updated props to the `resolveFields` method.

Closes #850 