### PR TITLE
fix: don't jump to end of textarea fields during change

### DIFF
--- a/packages/core/components/AutoField/index.tsx
+++ b/packages/core/components/AutoField/index.tsx
@@ -173,7 +173,10 @@ function AutoFieldInternal<
 
   const onFocus = useCallback(
     (e: React.FocusEvent) => {
-      if (mergedProps.name && e.target.nodeName === "INPUT") {
+      if (
+        mergedProps.name &&
+        (e.target.nodeName === "INPUT" || e.target.nodeName === "TEXTAREA")
+      ) {
         e.stopPropagation();
 
         dispatch({


### PR DESCRIPTION
Closes #813 