### PR TITLE
fix: tidy up stale items during fast drags or cancellation

### DIFF
--- a/packages/core/components/DragDropContext/index.tsx
+++ b/packages/core/components/DragDropContext/index.tsx
@@ -357,6 +357,14 @@ const DragDropContextClient = ({
                   fn(event, manager);
                 });
 
+                dispatch({
+                  type: "setUi",
+                  ui: {
+                    itemSelector: null,
+                    isDragging: false,
+                  },
+                });
+
                 return;
               }
 


### PR DESCRIPTION
Some lifecycle tidy up was missed as part of the DropZone performance improvements (#795) and subsequent bug fixes (#814), resulting in cancelled drags not removing the preview item.

Closes #863.