### PR TITLE
fix: prevent unintended CSS inheritance on DropZone content

### DIFF
--- a/apps/docs/pages/docs/api-reference/components/drop-zone.mdx
+++ b/apps/docs/pages/docs/api-reference/components/drop-zone.mdx
@@ -36,6 +36,7 @@ const config = {
 | [`minEmptyHeight`](#minemptyheight) | `minEmptyHeight: 256`        | Number        | -        |
 | [`ref`](#ref)                       | `ref: ref`                   | Ref           | -        |
 | [`style`](#style)                   | `style: {display: "flex"}`   | CSSProperties | -        |
+| [`as`](#as)                         | `as: "section"`              | ElementType   | -        |
 
 ## Required props
 
@@ -210,6 +211,26 @@ const config = {
         return (
           <div>
             <DropZone zone="my-content" style={{ display: "flex" }} />
+          </div>
+        );
+      },
+    },
+  },
+};
+```
+
+### `as`
+
+Change the underlying HTML element of the DropZone. Defaults to `div`.
+
+```tsx copy {7}
+const config = {
+  components: {
+    Example: {
+      render: () => {
+        return (
+          <div>
+            <DropZone zone="my-content" as="section" />
           </div>
         );
       },

--- a/apps/docs/pages/docs/api-reference/components/drop-zone.mdx
+++ b/apps/docs/pages/docs/api-reference/components/drop-zone.mdx
@@ -30,13 +30,13 @@ const config = {
 | ----------------------------------- | ---------------------------- | ------------- | -------- |
 | [`zone`](#zone)                     | `zone: "my-zone"`            | String        | Required |
 | [`allow`](#allow)                   | `allow: ["HeadingBlock"]`    | Array         | -        |
+| [`as`](#as)                         | `as: "section"`              | ElementType   | -        |
 | [`className`](#classname)           | `className: "MyClass"`       | String        | -        |
 | [`collisionAxis`](#collisionaxis)   | `collisionAxis: "x"`         | String        | -        |
 | [`disallow`](#disallow)             | `disallow: ["HeadingBlock"]` | Array         | -        |
 | [`minEmptyHeight`](#minemptyheight) | `minEmptyHeight: 256`        | Number        | -        |
 | [`ref`](#ref)                       | `ref: ref`                   | Ref           | -        |
 | [`style`](#style)                   | `style: {display: "flex"}`   | CSSProperties | -        |
-| [`as`](#as)                         | `as: "section"`              | ElementType   | -        |
 
 ## Required props
 
@@ -76,6 +76,26 @@ const config = {
         return (
           <div>
             <DropZone zone="my-content" allow={["HeadingBlock"]} />
+          </div>
+        );
+      },
+    },
+  },
+};
+```
+
+### `as`
+
+Change the underlying HTML element of the DropZone. Defaults to `div`.
+
+```tsx copy {7}
+const config = {
+  components: {
+    Example: {
+      render: () => {
+        return (
+          <div>
+            <DropZone zone="my-content" as="section" />
           </div>
         );
       },
@@ -211,26 +231,6 @@ const config = {
         return (
           <div>
             <DropZone zone="my-content" style={{ display: "flex" }} />
-          </div>
-        );
-      },
-    },
-  },
-};
-```
-
-### `as`
-
-Change the underlying HTML element of the DropZone. Defaults to `div`.
-
-```tsx copy {7}
-const config = {
-  components: {
-    Example: {
-      render: () => {
-        return (
-          <div>
-            <DropZone zone="my-content" as="section" />
           </div>
         );
       },

--- a/packages/core/components/DropZone/types.ts
+++ b/packages/core/components/DropZone/types.ts
@@ -1,7 +1,7 @@
-import { CSSProperties } from "react";
+import { CSSProperties, ElementType } from "react";
 import { DragAxis } from "../../types";
 
-export type DropZoneProps = {
+export type DropZoneProps<T extends ElementType = "div"> = {
   zone: string;
   allow?: string[];
   disallow?: string[];
@@ -9,4 +9,5 @@ export type DropZoneProps = {
   minEmptyHeight?: number;
   className?: string;
   collisionAxis?: DragAxis;
+  as?: T;
 };


### PR DESCRIPTION
This pull request addresses a potential styling issue introduced by the recent change where DropZones are now wrapped in a `<div>`.  Previously, users could directly style the container element of a component that included a DropZone (e.g., `<section className="sectionBlock"><DropZone /></section>`).  The new wrapping `<div>` can cause unexpected inheritance of styles from parent elements, breaking existing layouts.

**Problem:**

With the new `<div>` wrapper, CSS rules targeting the parent container (e.g., `section.sectionBlock`) now also apply to the wrapping `<div>` and subsequently, to the content rendered within the DropZone. This can lead to unintended styling changes.

**Example:**

Consider the following component configuration:

```jsx
const config = {
  components: {
    ComponentA: {
      render() {
        return <section className="sectionBlock"><DropZone zone="component-a-zone" /></section>;
      }
    },
    ComponentB: {
      render() {
        return <div>ComponentB</div>;
      }
    }
  }
};
```

**Old Puck Version (Correct Behavior):**

```html
<section class="sectionBlock">
  <div>ComponentB</div>
</section>
```

**New Puck Version (Incorrect Behavior - Unintended Styling):**

```html
<section class="sectionBlock">
  <div>  <!-- New wrapping div -->
    <div>ComponentB</div>
  </div>
</section>
```

In the new version, styles applied to `section.sectionBlock` might unintentionally affect the content within the DropZone due to the intermediate `<div>`.

**Solution:**

This pull request introduces the `as` prop to the DropZone component.  This prop allows users to specify the HTML element to be used as the DropZone's container. By setting `as="section"`, users can maintain the original structure and prevent unintended style inheritance.

**Example Usage:**

```jsx
<DropZone zone="component-a-zone" as="section" />
```

This change allows users to have more control over the styling of their DropZones and ensures backward compatibility with existing component configurations.  It avoids breaking existing layouts that rely on specific CSS rules targeting parent containers.