### PR TITLE
fix(canvas): add `maxWidth` and safe initial `height` styles to `Canvas`.

### DIFF
--- a/packages/core/components/Puck/components/Canvas/index.tsx
+++ b/packages/core/components/Puck/components/Canvas/index.tsx
@@ -168,7 +168,8 @@ export const Canvas = () => {
           className={getClassName("root")}
           style={{
             width: iframe.enabled ? ui.viewports.current.width : "100%",
-            height: zoomConfig.rootHeight,
+            maxWidth: "100%",
+            height: zoomConfig.rootHeight || "auto",
             transform: iframe.enabled ? `scale(${zoomConfig.zoom})` : undefined,
             transition: showTransition
               ? "width 150ms ease-out, height 150ms ease-out, transform 150ms ease-out"


### PR DESCRIPTION
I tried to use the `Puck` component within a legacy Javascript application I work with, and found that when mounting the component the `Canvas` was broken on the initial render. For some reason the initial side-effects that should appropriately configure `zoomConfig` weren't throwing and so `zoomConfig.rootHeight`, i.e. the height of canvas, was set to `0`.

Likewise, while the width should have been set to `1280px` per my viewport (and was showing as such in the styles within Inspector Tools), it _still_ seemed like the canvas was breaking out of the parent container.

These two changes fixed the issue on my end, and should prevent them from happening for others! 
- By setting the `maxWidth` to `100%` we avoid breaking out of the parent regardless of what we programmatically need to set the width to by viewport.
- By checking to see if `zoomConfig.rootHeight` is falsey, we can set it to `"auto"`, in which case it will simply fill its available space on initial render and then re-zoomed on window resize events.