### PR TITLE
Breadcrumb label use block label if available

### DIFF
--- a/packages/core/lib/use-breadcrumbs.ts
+++ b/packages/core/lib/use-breadcrumbs.ts
@@ -1,10 +1,10 @@
 import { useContext, useMemo } from "react";
-import { dropZoneContext, PathData } from "../components/DropZone/context";
+import { DropZoneContext, dropZoneContext, PathData } from "../components/DropZone/context";
 import { useAppContext } from "../components/Puck/context";
 import { getZoneId } from "./get-zone-id";
 import { rootDroppableId } from "./root-droppable-id";
 import { ItemSelector } from "./get-item";
-import { Data, MappedItem } from "../types";
+import { Config, Data, MappedItem } from "../types";
 
 export type Breadcrumb = {
   label: string;
@@ -14,10 +14,12 @@ export type Breadcrumb = {
 
 export const convertPathDataToBreadcrumbs = (
   selectedItem: MappedItem | undefined,
-  pathData: PathData | undefined,
-  data: Data
+  context: DropZoneContext<Config>  | undefined,
+  data: Data,
 ) => {
   const id = selectedItem ? selectedItem?.props.id : "";
+
+  const { pathData, config } = context || {};
 
   const currentPathData =
     pathData && id && pathData[id]
@@ -63,10 +65,12 @@ export const convertPathDataToBreadcrumbs = (
       return acc;
     }
 
+    const label = config?.components?.[item.type]?.label || item.type.toString();
+
     return [
       ...acc,
       {
-        label: item.type.toString(),
+        label,
         selector: {
           index: itemIndex,
           zone: parentZoneCompound,
@@ -87,8 +91,8 @@ export const useBreadcrumbs = (renderCount?: number) => {
   return useMemo<Breadcrumb[]>(() => {
     const breadcrumbs = convertPathDataToBreadcrumbs(
       selectedItem,
-      dzContext?.pathData,
-      data
+      dzContext,
+      data,
     );
 
     if (renderCount) {


### PR DESCRIPTION
# Breadcrumb: Use Block Label if Available  

## 🙏 Huge Thanks to the Puck Team!  
First off, I just want to say that I **love** this project—big thanks to the Puck team for building such an awesome tool! ❤️  

## Summary  
This change enhances the breadcrumb functionality by allowing it to use the **block label** when available, instead of defaulting only to the block type.  

## Why?  
Currently, the breadcrumb always displays the block type, which limits flexibility in certain scenarios. While Puck **doesn't natively support i18n**, I'm working on a **workaround** to introduce some level of localization. This change makes my workaround a bit more **robust** by allowing the breadcrumb to display a translated block label instead of just the block type.  

## Changes  
- Modified breadcrumb logic to prefer the **block label** over the **block type** if available.  
- Ensured fallback to the block type when no label is present.  

## Impact  
- Enables more **flexibility** for custom implementations.  
- Makes my **i18n workaround** more reliable.  

## Testing  
- ✅ Verified that block label is used when present.  
- ✅ Ensured fallback to block type when no label exists.  

## Screenshots
Bellow a usage example, the component type is Flex with a label in Portuguese (Linha)

<img width="1098" alt="Screenshot 2025-03-18 at 8 53 09 PM" src="https://github.com/user-attachments/assets/617db24c-0844-45f8-8964-17c355fd0e88" />


