### PR TITLE
fix: when updating a field in one array item, other items unexpectedly reset or change

### DIFF
--- a/packages/core/components/AutoField/index.tsx
+++ b/packages/core/components/AutoField/index.tsx
@@ -261,11 +261,14 @@ export function AutoFieldPrivate<
 
   const [localValue, setLocalValue] = useState(value);
 
-  const onChangeLocal = useCallback((val: any, ui?: Partial<UiState>) => {
-    setLocalValue(val);
+  const onChangeLocal = useCallback(
+    (val: any, ui?: Partial<UiState>) => {
+      setLocalValue(val);
 
-    onChange(val, ui);
-  }, [onChange]);
+      onChange(val, ui);
+    },
+    [onChange]
+  );
 
   useEffect(() => {
     // Prevent global state from setting local state if this field is focused

--- a/packages/core/components/AutoField/index.tsx
+++ b/packages/core/components/AutoField/index.tsx
@@ -265,7 +265,7 @@ export function AutoFieldPrivate<
     setLocalValue(val);
 
     onChange(val, ui);
-  }, []);
+  }, [onChange]);
 
   useEffect(() => {
     // Prevent global state from setting local state if this field is focused


### PR DESCRIPTION
When modifying array elements, values were reset in some cases.

Closes #951

https://github.com/user-attachments/assets/312b0ef6-cbce-4901-ab39-331c4c43c14c