### PR TITLE
fix: input file on component type array not working

### DIFF
--- a/packages/core/components/AutoField/fields/ArrayField/index.tsx
+++ b/packages/core/components/AutoField/fields/ArrayField/index.tsx
@@ -160,9 +160,6 @@ export const ArrayField = ({
             hasItems: Array.isArray(value) && value.length > 0,
             addDisabled,
           })}
-          onClick={(e) => {
-            e.preventDefault();
-          }}
         >
           <div className={getClassName("inner")} data-dnd-container>
             {localState.arrayState.items.map((item, i) => {


### PR DESCRIPTION
This PR is intended to fix a bug with the file-type field.

It's possible that `e.preventDefault()` in onClick was addressing some issue, but during local testing, I didn't notice any changes in the behavior of the array-type field. Clicking on the file-type field works as expected.

Closes #933 