### PR TITLE
fix: prevent all fields in `params.changed` from being `true` on initialization in `resolveData`

### DIFF
--- a/packages/core/lib/resolve-component-data.ts
+++ b/packages/core/lib/resolve-component-data.ts
@@ -34,6 +34,12 @@ export const resolveComponentData = async (
 ) => {
   const configForItem = config.components[item.type];
   if (configForItem.resolveData) {
+    if (!cache.lastChange[item.props.id]) {
+      cache.lastChange[item.props.id] = {
+        item: item,
+      };
+    }
+
     const { item: oldItem = null, resolved = {} } =
       cache.lastChange[item.props.id] || {};
 


### PR DESCRIPTION
In this PR, the issue where all fields in `params.changed` were incorrectly set to `true` during initialization in the `resolveData` method has been fixed. This prevented unnecessary code execution on component mount.

Closes: #963