### PR TITLE
Add issue template for bug reports on GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,11 +1,11 @@
 ---
 name: "Bug Report 🐛"
-about: Report a problem with Puck. Please provide enough information to reproduce
+about:
+  Report a problem with Puck. Please provide enough information to reproduce
   the problem.
-title: 'Bug: '
-labels: ''
-assignees: ''
-
+title: "Bug: "
+labels: ""
+assignees: ""
 ---
 
 ## Description
@@ -36,9 +36,11 @@ assignees: ''
 ## Steps to reproduce
 
 1. Render the `<X />` component in a grid layout...
-  ```tsx
-  //... your code example
-  ```
+
+```tsx
+//... your code example
+```
+
 2. Run in the application in development mode...
 3. Navigate to the page where the component is rendered...
 
@@ -46,7 +48,7 @@ assignees: ''
   Provide clear steps with code examples so that we can verify the bug.
   Avoid adding dependencies other than Puck.
 
-  Issues without reproduction steps or code examples may be immediately 
+  Issues without reproduction steps or code examples may be immediately
   closed as not actionable.
 -->
 
@@ -55,7 +57,7 @@ Link to code example: [Your link here]
 <!--
   If possible, provide a CodeSandbox (https://codesandbox.io/s/new), a link to a
   repository on GitHub, or provide a minimal code example that demonstrates the
-  problem. 
+  problem.
 
   Screenshots or recordings are welcome if they help clarify the problem.
 
@@ -67,7 +69,7 @@ Link to code example: [Your link here]
 [Example: "A white screen appears and the editor does not load..."]
 
 <!--
-  State what is the result of the steps above. 
+  State what is the result of the steps above.
   Keep the explanation short and clear.
 -->
 
@@ -83,6 +85,6 @@ Link to code example: [Your link here]
 ## Additional Media
 
 <!--
-  Include any screenshots, videos, or other relevant media that may help 
+  Include any screenshots, videos, or other relevant media that may help
   visualize the issue or demonstrate the behavior.
 -->

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,88 @@
+---
+name: "Bug report 🐛"
+about: Report a problem with Puck. Please provide enough information to reproduce
+  the problem.
+title: 'Bug: '
+labels: ''
+assignees: ''
+
+---
+
+## Description
+
+[Example: "The `<Puck />` component doesn't render correctly inside a CSS grid layout..."]
+
+<!--
+  Provide a clear and concise description of the bug.
+  Don't assume we know anything about your repository or codebase.
+  Keep it centered around Puck—avoid detailing your use case unless
+  it directly helps explain the issue.
+  Test the issue using the latest version of Puck to confirm it hasn’t
+  already been fixed.
+  Include screenshots or videos if helpful.
+-->
+
+## Environment
+
+- Puck version: [e.g. 0.19.0, 1.0.0...]
+- Browser version: [e.g. Chrome 135 (desktop), Firefox 133 (mobile)...]
+- Additional environment info: [e.g. bundler, OS, device type...]
+
+<!--
+  Include relevant environment details such as Puck version, browser,
+  bundling tools, operating system, or anything else that might be relevant.
+-->
+
+## Steps to reproduce
+
+1. Render the `<X />` component in a grid layout...
+  ```tsx
+  //... your code example
+  ```
+2. Run in the application in development mode...
+3. Navigate to the page where the component is rendered...
+
+<!--
+  Provide clear steps with code examples so that we can verify the bug.
+  Avoid adding dependencies other than Puck.
+
+  Issues without reproduction steps or code examples may be immediately 
+  closed as not actionable.
+-->
+
+Link to code example: [Your link here]
+
+<!--
+  If possible, provide a CodeSandbox (https://codesandbox.io/s/new), a link to a
+  repository on GitHub, or provide a minimal code example that demonstrates the
+  problem. 
+
+  Screenshots or recordings are welcome if they help clarify the problem.
+
+  For help on providing minimal, reproducible examples: https://stackoverflow.com/help/mcve
+-->
+
+## What happens
+
+[Example: "A white screen appears and the editor does not load..."]
+
+<!--
+  State what is the result of the steps above. 
+  Keep the explanation short and clear.
+-->
+
+## What I expect to happen
+
+[Example: "The Puck component should be rendered in any CSS layout..."]
+
+<!--
+  State what was the result you expected from the steps above.
+  Keep the explanation short and clear.
+-->
+
+## Additional Media
+
+<!--
+  Include any screenshots, videos, or other relevant media that may help 
+  visualize the issue or demonstrate the behavior.
+-->

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,5 +1,5 @@
 ---
-name: "Bug report 🐛"
+name: "Bug Report 🐛"
 about: Report a problem with Puck. Please provide enough information to reproduce
   the problem.
 title: 'Bug: '

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+    - name: Guidance - Discord 👾
+      url: https://discord.gg/V9mDAhuxyZ
+      about: This issue tracker is not for guidance. Please refer to the Discord server for live help and general guidance.
+    - name: Questions and Help - Github Discussions 💬
+      url: https://github.com/measuredco/puck/discussions
+      about: This issue tracker is not for support questions. Please open a discussion for that.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,39 @@
+---
+name: "Feature Request ✨"
+about: "Share ideas for new features."
+title: "Feat: "
+labels: ""
+assignees: ""
+---
+
+## Description
+
+[Example: "Currently, the `text` field doesn’t support validation for maximum and minimum lengths. However, in many cases, you need to limit user input to specific constraints..."]
+
+<!--
+  Describe the expected outcome and why you want that outcome.
+  Don’t provide implementation details, save that for the 'Proposals' section.
+  Assume the person reading this has zero context about your problem or use case.
+-->
+
+## Considerations
+
+- This might be related to field validation, which is currently being tracked in issue:...
+- The file implementing the `text` field lives at...
+
+<!--
+  List any special considerations for this feature that might help or make the changes more difficult.
+  List any other issues that might be related or affected by this feature.
+-->
+
+## Proposals
+
+### Proposal 1
+
+[Example: "Introduce `min` and `max` props for the field configuration object and the `<AutoField />` component..."]
+
+<!--
+  Add a high-level description of how you'd like to see the feature implemented.
+  Include code examples if appropriate.
+  Discuss the pros and cons of the approach where necessary.
+-->


### PR DESCRIPTION
This PR adds helpful links to Discord and GitHub Discussions for questions and support, and also introduces an issue template specifically for reporting bugs.