### PR TITLE
fix: use of `UsePuckStoreContext` is not compatible with previous react versions (<19)

### DIFF
--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -341,7 +341,9 @@ function PuckProvider<
 
   return (
     <appStoreContext.Provider value={appStore}>
-      <UsePuckStoreContext value={uPuckStore}>{children}</UsePuckStoreContext>
+      <UsePuckStoreContext.Provider value={uPuckStore}>
+        {children}
+      </UsePuckStoreContext.Provider>
     </appStoreContext.Provider>
   );
 }


### PR DESCRIPTION
While testing the canary release, I encountered the issue below in our project.

![image](https://github.com/user-attachments/assets/9cab9238-ae07-460f-b6cb-41575c6e5a7f)

[Context as Provider](https://react.dev/blog/2024/12/05/react-19#context-as-a-provider) is only available in React 19.
