### PR TITLE
feat: include context data in config

### DIFF
--- a/apps/demo/app/custom-ui/[...puckPath]/client.tsx
+++ b/apps/demo/app/custom-ui/[...puckPath]/client.tsx
@@ -10,6 +10,7 @@ import { useDemoData } from "../../../lib/use-demo-data";
 import { IconButton, createUsePuck } from "@/core";
 import { ReactNode, useEffect, useRef, useState } from "react";
 import { Drawer } from "@/core/components/Drawer";
+import { getComponentConfig } from "@/core/lib/get-component-config";
 import { ChevronUp, ChevronDown, Globe, Lock, Unlock } from "lucide-react";
 
 const usePuck = createUsePuck<UserConfig>();
@@ -312,7 +313,7 @@ const CustomDrawer = () => {
           gap: 8,
         }}
       >
-        {Object.keys(config.components).map((componentKey, componentIndex) => {
+        {Object.keys(config.components).map((componentKey) => {
           const canInsert = getPermissions({
             type: componentKey as keyof UserConfig["components"],
           }).insert;
@@ -344,10 +345,12 @@ export function Client({ path, isEdit }: { path: string; isEdit: boolean }) {
     ...config,
     components: {
       ...Object.keys(config.components).reduce((acc, componentKey) => {
+        const componentConfig = getComponentConfig(config, componentKey);
+
         return {
           ...acc,
           [componentKey]: {
-            ...acc[componentKey as keyof UserConfig["components"]],
+            ...componentConfig,
             resolvePermissions: (data: any, { permissions }: any) => {
               if (lockedComponents[data.props.id]) {
                 return {

--- a/apps/demo/config/blocks/Button/index.tsx
+++ b/apps/demo/config/blocks/Button/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { ComponentConfig } from "@/core/types";
+import { ComponentConfigFunction } from "@/core/types";
 import { Button as _Button } from "@/core/components/Button";
+import { Context } from "../../index";
 
 export type ButtonProps = {
   label: string;
@@ -8,7 +9,9 @@ export type ButtonProps = {
   variant: "primary" | "secondary";
 };
 
-export const Button: ComponentConfig<ButtonProps> = {
+export const Button: ComponentConfigFunction<ButtonProps, Context> = (
+  context
+) => ({
   label: "Button",
   fields: {
     label: { type: "text", placeholder: "Lorem ipsum..." },
@@ -22,7 +25,7 @@ export const Button: ComponentConfig<ButtonProps> = {
     },
   },
   defaultProps: {
-    label: "Button",
+    label: context?.package ?? "Button",
     href: "#",
     variant: "primary",
   },
@@ -40,4 +43,4 @@ export const Button: ComponentConfig<ButtonProps> = {
       </div>
     );
   },
-};
+});

--- a/apps/demo/config/index.tsx
+++ b/apps/demo/config/index.tsx
@@ -27,16 +27,24 @@ export type Props = {
   Space: SpaceProps;
 };
 
+export type Context = {
+  package: string;
+};
+
 export type UserConfig = Config<
   Props,
   RootProps,
-  "layout" | "typography" | "interactive"
+  "layout" | "typography" | "interactive",
+  Context
 >;
 
 export type UserData = Data<Props, RootProps>;
 
 // We avoid the name config as next gets confused
 export const conf: UserConfig = {
+  context: {
+    package: "@measured/puck",
+  },
   root: {
     defaultProps: {
       title: "My Page",

--- a/apps/docs/pages/docs/api-reference/configuration/config.mdx
+++ b/apps/docs/pages/docs/api-reference/configuration/config.mdx
@@ -26,6 +26,7 @@ const config = {
 | [`components`](#components) | `components: { HeadingBlock: {{ render: () => <h1 /> } }`      | Object                                                                  | Required |
 | [`root`](#root)             | `root: { render: () => <div /> }`                              | [`ComponentConfig`](/docs/api-reference/configuration/component-config) | -        |
 | [`categories`](#categories) | `categories: { typography: { components: ["HeadingBlock"] } }` | Object                                                                  | -        |
+| [`context`](#context)       | `context: { package: "@measured/puck" }`                       | Any                                                                     | -        |
 
 ## Required params
 
@@ -46,6 +47,31 @@ const config = {
         return <h1>{children}</h1>;
       },
     },
+  },
+};
+```
+
+Alternatively, a component can be defined as a function that returns a [`ComponentConfig` API](/docs/api-reference/configuration/component-config).
+This approach enables access to the [`context`](#context) provided during initialization.
+
+```tsx {6-18} copy showLineNumbers
+const config = {
+  context: {
+    package: "@measured/puck",
+    version: "x.x.x",
+  },
+  components: {
+    HeadingBlock: (context) => ({
+      fields: {
+        title: {
+          type: "text",
+        },
+      },
+      defaultProps: {
+        title: `${context.package} v${context.version}`,
+      },
+      render: ({ title }) => <h1>{title}</h1>,
+    }),
   },
 };
 ```
@@ -106,3 +132,17 @@ A boolean describing whether or not the category should be expanded by default i
 #### `categories["other"]`
 
 The default category for all uncategorized components. Receives all other categories params.
+
+### `context`
+
+Allows you to define any type of data that can be passed to create a [`component`](#components).
+
+```tsx {2-6} copy showLineNumbers
+const config = {
+  context: {
+    package: "@measured/puck",
+    version: "x.x.x",
+  },
+  // ...
+};
+```

--- a/apps/docs/pages/docs/index.mdx
+++ b/apps/docs/pages/docs/index.mdx
@@ -16,6 +16,7 @@ Puck is also licensed under MIT, making it suitable for both internal systems an
 | ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | [Component Configuration](/docs/integrating-puck/component-configuration) | Integrate your own components with Puck by providing render functions and configuring fields that map to your props. |
 | [Root Configuration](/docs/integrating-puck/root-configuration)           | Customize the root component that wraps all other Puck components.                                                   |
+| [Context](/docs/integrating-puck/context)                                 | Pass additional data when creating the component.                                                                    |
 | [Multi-column Layouts](/docs/integrating-puck/multi-column-layouts)       | Create multi-column layouts using nested components. Now supports advanced CSS layouts.                              |
 | [Categories](/docs/integrating-puck/categories)                           | Group your components in the side bar.                                                                               |
 | [Dynamic Props](/docs/integrating-puck/dynamic-props)                     | Dynamically set props after user input and mark fields as read-only                                                  |

--- a/apps/docs/pages/docs/integrating-puck/_meta.js
+++ b/apps/docs/pages/docs/integrating-puck/_meta.js
@@ -1,6 +1,7 @@
 const menu = {
   "component-configuration": {},
   "root-configuration": {},
+  context: {},
   "multi-column-layouts": {},
   categories: {},
   "dynamic-props": {},

--- a/apps/docs/pages/docs/integrating-puck/context.mdx
+++ b/apps/docs/pages/docs/integrating-puck/context.mdx
@@ -1,0 +1,54 @@
+# Context
+
+`context` is a property that can be defined in [`Config`](/docs/api-reference/configuration/config).
+
+## Passing the context
+
+```tsx {2-6} copy showLineNumbers
+const config = {
+  context: {
+    package: "@measured/puck",
+    version: "x.x.x",
+  },
+  // ...
+};
+```
+
+## Usage
+
+Once defined, the `context` can be accessed by components during their creation.
+
+```tsx
+const config = {
+  context: {
+    package: "@measured/puck",
+    version: "x.x.x",
+  },
+  components: {
+    HeadingBlock: (context) => ({
+      fields: {
+        title: {
+          type: "text",
+        },
+      },
+      defaultProps: {
+        title: `${context.package} v${context.version}`,
+      },
+      render: ({ title }) => <h1>{title}</h1>,
+    }),
+  },
+};
+```
+
+## TypeScript
+
+You can specify the type of `context` in `Config` when using TypeScript. It can accept any type based on your needs, such as `string`, `number`, `object`, and more.
+
+```tsx copy {3}
+import type { Config } from "@measured/puck";
+
+const config: Config<{}, {}, string, string[]> = {
+  context: ["Hello", "World"],
+  // ...
+};
+```

--- a/apps/docs/pages/docs/integrating-puck/context.mdx
+++ b/apps/docs/pages/docs/integrating-puck/context.mdx
@@ -16,9 +16,9 @@ const config = {
 
 ## Usage
 
-Once defined, the `context` can be accessed by components during their creation.
+Once defined, the `context` can be accessed by [`components`](/docs/api-reference/configuration/config#components) during their creation.
 
-```tsx
+```tsx {6-18} copy showLineNumbers
 const config = {
   context: {
     package: "@measured/puck",

--- a/packages/core/components/ComponentList/index.tsx
+++ b/packages/core/components/ComponentList/index.tsx
@@ -4,6 +4,7 @@ import { ReactNode } from "react";
 import { useAppStore } from "../../store";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { Drawer } from "../Drawer";
+import { getComponentConfig } from "../../lib/get-component-config";
 
 const getClassName = getClassNameFactory("ComponentList", styles);
 
@@ -82,7 +83,8 @@ const ComponentList = ({
                 <ComponentListItem
                   key={componentKey}
                   label={
-                    config.components[componentKey]["label"] ?? componentKey
+                    getComponentConfig(config, componentKey)["label"] ??
+                    componentKey
                   }
                   name={componentKey}
                 />

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -38,6 +38,7 @@ import { useDragAxis } from "./lib/use-drag-axis";
 import { useContextStore } from "../../lib/use-context-store";
 import { useShallow } from "zustand/react/shallow";
 import { renderContext } from "../Render";
+import { getComponentConfig } from "../../lib/get-component-config";
 
 const getClassName = getClassNameFactory("DropZone", styles);
 
@@ -109,9 +110,7 @@ const DropZoneChild = ({
       ? { type: preview.componentType, props: preview.props }
       : null);
 
-  const componentConfig = useAppStore((s) =>
-    item?.type ? s.config.components[item.type] : null
-  );
+  const config = useAppStore((s) => s.config);
   const overrides = useAppStore((s) => s.overrides);
   const isLoading = useAppStore(
     (s) => s.componentState[componentId]?.loadingCount > 0
@@ -119,6 +118,10 @@ const DropZoneChild = ({
   const isSelected = useAppStore(
     (s) => s.selectedItem?.props.id === componentId || false
   );
+
+  const componentConfig = item?.type
+    ? getComponentConfig(config, item.type)
+    : null;
 
   let label = componentConfig?.label ?? item?.type.toString() ?? "Component";
 
@@ -456,7 +459,7 @@ const DropZoneRender = forwardRef<HTMLDivElement, DropZoneProps>(
     return (
       <div className={className} style={style} ref={ref}>
         {content.map((item) => {
-          const Component = config.components[item.type];
+          const Component = getComponentConfig(config, item.type);
           if (Component) {
             return (
               <DropZoneProvider

--- a/packages/core/components/LayerTree/index.tsx
+++ b/packages/core/components/LayerTree/index.tsx
@@ -12,6 +12,7 @@ import { getZoneId } from "../../lib/get-zone-id";
 import { getFrame } from "../../lib/get-frame";
 import { onScrollEnd } from "../../lib/on-scroll-end";
 import { useAppStore } from "../../store";
+import { getComponentConfig } from "../../lib/get-component-config";
 
 const getClassName = getClassNameFactory("LayerTree", styles);
 const getClassNameLayer = getClassNameFactory("Layer", styles);
@@ -82,7 +83,7 @@ export const LayerTree = ({
             }) ?? false;
 
           const componentConfig: ComponentConfig | undefined =
-            config.components[item.type];
+            getComponentConfig(config, item.type);
           const label = componentConfig?.["label"] ?? item.type.toString();
 
           return (

--- a/packages/core/components/Puck/components/Fields/index.tsx
+++ b/packages/core/components/Puck/components/Fields/index.tsx
@@ -17,6 +17,7 @@ import { ItemSelector } from "../../../../lib/get-item";
 import { useRegisterFieldsSlice } from "../../../../store/slices/fields";
 import { useShallow } from "zustand/react/shallow";
 import { StoreApi } from "zustand";
+import { getComponentConfig } from "../../../../lib/get-component-config";
 
 const getClassName = getClassNameFactory("PuckFields", styles);
 
@@ -75,7 +76,7 @@ const createOnChange =
       };
 
       // If the component has a resolveData method, we let resolveData run and handle the dispatch once it's done
-      if (config.components[selectedItem.type]?.resolveData) {
+      if (getComponentConfig(config, selectedItem.type)?.resolveData) {
         resolveData(setAction(state, setActionData));
       } else {
         dispatch({

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -68,6 +68,7 @@ import {
   UsePuckStoreContext,
   useRegisterUsePuckStore,
 } from "../../lib/use-puck";
+import { getComponentConfig } from "../../lib/get-component-config";
 
 const getClassName = getClassNameFactory("Puck", styles);
 const getLayoutClassName = getClassNameFactory("PuckLayout", styles);
@@ -75,7 +76,7 @@ const getLayoutClassName = getClassNameFactory("PuckLayout", styles);
 const FieldSideBar = () => {
   const title = useAppStore((s) =>
     s.selectedItem
-      ? s.config.components[s.selectedItem.type]?.["label"] ??
+      ? getComponentConfig(s.config, s.selectedItem.type)?.["label"] ??
         s.selectedItem.type.toString()
       : "Page"
   );

--- a/packages/core/components/ServerRender/index.tsx
+++ b/packages/core/components/ServerRender/index.tsx
@@ -6,6 +6,7 @@ import {
 } from "../../lib/root-droppable-id";
 import { setupZone } from "../../lib/setup-zone";
 import { Config, Data, Metadata, UserGenerics } from "../../types";
+import { getComponentConfig } from "../../lib/get-component-config";
 
 type DropZoneRenderProps = {
   zone: string;
@@ -38,7 +39,7 @@ function DropZoneRender({
   return (
     <>
       {content.map((item) => {
-        const Component = config.components[item.type];
+        const Component = getComponentConfig(config, item.type);
 
         if (Component) {
           return (

--- a/packages/core/lib/get-component-config.ts
+++ b/packages/core/lib/get-component-config.ts
@@ -1,0 +1,9 @@
+import { Config } from "../types";
+
+export const getComponentConfig = (config: Config, type: string | number) => {
+  const component = config.components[type];
+
+  return typeof component === "function"
+    ? component(config.context)
+    : component;
+};

--- a/packages/core/lib/get-component-config.ts
+++ b/packages/core/lib/get-component-config.ts
@@ -1,6 +1,8 @@
-import { Config } from "../types";
+import { Config, DefaultComponentProps } from "../types";
 
-export const getComponentConfig = (config: Config, type: string | number) => {
+export const getComponentConfig = <
+  Props extends DefaultComponentProps = DefaultComponentProps
+>(config: Config<Props>, type: string | number) => {
   const component = config.components[type];
 
   return typeof component === "function"

--- a/packages/core/lib/get-component-config.ts
+++ b/packages/core/lib/get-component-config.ts
@@ -2,7 +2,10 @@ import { Config, DefaultComponentProps } from "../types";
 
 export const getComponentConfig = <
   Props extends DefaultComponentProps = DefaultComponentProps
->(config: Config<Props>, type: string | number) => {
+>(
+  config: Config<Props>,
+  type: string | number
+) => {
   const component = config.components[type];
 
   return typeof component === "function"

--- a/packages/core/lib/resolve-component-data.ts
+++ b/packages/core/lib/resolve-component-data.ts
@@ -1,5 +1,6 @@
 import { ComponentData, Config, MappedItem, Metadata } from "../types";
 import { getChanged } from "./get-changed";
+import { getComponentConfig } from "./get-component-config";
 
 export const cache: {
   lastChange: Record<string, any>;
@@ -32,7 +33,7 @@ export const resolveComponentData = async (
   onResolveStart?: (item: MappedItem) => void,
   onResolveEnd?: (item: MappedItem) => void
 ) => {
-  const configForItem = config.components[item.type];
+  const configForItem = getComponentConfig(config, item.type);
   if (configForItem.resolveData) {
     const { item: oldItem = null, resolved = {} } =
       cache.lastChange[item.props.id] || {};

--- a/packages/core/lib/resolve-data.ts
+++ b/packages/core/lib/resolve-data.ts
@@ -5,6 +5,7 @@ import { resolveRootData } from "./resolve-root-data";
 import { flattenData } from "./flatten-data";
 import { AppStore } from "../store";
 import fdeq from "fast-deep-equal";
+import { getComponentConfig } from "./get-component-config";
 
 export const resolveData = (newAppState: AppState, appStoreData: AppStore) => {
   const {
@@ -47,7 +48,7 @@ export const resolveData = (newAppState: AppState, appStoreData: AppStore) => {
     const newData = newAppState.data;
 
     const flatContent = flattenData(newData).filter(
-      (item) => !!config.components[item.type]?.resolveData
+      (item) => !!getComponentConfig(config, item.type)?.resolveData
     );
 
     const applyIfChange = (

--- a/packages/core/lib/resolve-permissions.ts
+++ b/packages/core/lib/resolve-permissions.ts
@@ -1,12 +1,12 @@
 import {
   AppState,
-  ComponentData,
   Config,
   Data,
   ExtractPropsFromConfig,
   ExtractRootPropsFromConfig,
   Permissions,
 } from "../types";
+import { getComponentConfig } from "./get-component-config";
 
 export const resolvePermissions = <
   UserConfig extends Config = Config,
@@ -33,7 +33,7 @@ export const resolvePermissions = <
   permissions: Partial<Permissions>;
   appState: AppState<UserData>;
 }) => {
-  const componentConfig = data ? config.components[data.type] : null;
+  const componentConfig = data ? getComponentConfig(config, data.type) : null;
 
   if (data && lastData && componentConfig?.resolvePermissions) {
     return componentConfig.resolvePermissions(data, {

--- a/packages/core/lib/use-breadcrumbs.ts
+++ b/packages/core/lib/use-breadcrumbs.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useAppStore, useAppStoreApi } from "../store";
 import { ItemSelector } from "./get-item";
+import { getComponentConfig } from "./get-component-config";
 
 export type Breadcrumb = {
   label: string;
@@ -29,7 +30,7 @@ export const useBreadcrumbs = (renderCount?: number) => {
         const node = appStore.getState().nodes.nodes[componentId];
 
         const label = node
-          ? config.components[node.data.type]?.label ?? node.data.type
+          ? getComponentConfig(config, node.data.type)?.label ?? node.data.type
           : "Component";
 
         return {

--- a/packages/core/lib/use-component-list.tsx
+++ b/packages/core/lib/use-component-list.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useEffect, useState } from "react";
 import { ComponentList } from "../components/ComponentList";
 import { useAppStore } from "../store";
+import { getComponentConfig } from "./get-component-config";
 
 export const useComponentList = () => {
   const [componentList, setComponentList] = useState<ReactNode[]>();
@@ -28,7 +29,8 @@ export const useComponentList = () => {
               {category.components.map((componentName, i) => {
                 matchedComponents.push(componentName as string);
 
-                const componentConf = config.components[componentName] || {};
+                const componentConf =
+                  getComponentConfig(config, componentName) || {};
 
                 return (
                   <ComponentList.Item
@@ -60,7 +62,8 @@ export const useComponentList = () => {
             title={uiComponentList.other?.title || "Other"}
           >
             {remainingComponents.map((componentName, i) => {
-              const componentConf = config.components[componentName] || {};
+              const componentConf =
+                getComponentConfig(config, componentName) || {};
 
               return (
                 <ComponentList.Item

--- a/packages/core/reducer/data.ts
+++ b/packages/core/reducer/data.ts
@@ -17,7 +17,7 @@ import {
   ReplaceAction,
   ReorderAction,
 } from "./actions";
-import {} from "./actions";
+import { getComponentConfig } from "../lib/get-component-config";
 
 // Restore unregistered zones when re-registering in same session
 export const zoneCache: Record<string, Content> = {};
@@ -60,7 +60,7 @@ export function insertAction<UserData extends Data>(
   const emptyComponentData = {
     type: action.componentType,
     props: {
-      ...(config.components[action.componentType].defaultProps || {}),
+      ...(getComponentConfig(config, action.componentType).defaultProps || {}),
       id: action.id || generateId(action.componentType),
     },
   };

--- a/packages/core/store/index.ts
+++ b/packages/core/store/index.ts
@@ -12,6 +12,7 @@ import {
 } from "../types";
 import { createReducer, PuckAction } from "../reducer";
 import { getItem } from "../lib/get-item";
+import { getComponentConfig as _getComponentConfig } from "../lib/get-component-config";
 import { defaultViewports } from "../components/ViewportControls/default-viewports";
 import { Viewports } from "../types";
 import { create, useStore } from "zustand";
@@ -121,9 +122,9 @@ export const createAppStore = (initialAppStore?: Partial<AppStore>) =>
         const rootFields = config.root?.fields || defaultPageFields;
 
         return type && type !== "root"
-          ? config.components[type]
+          ? _getComponentConfig(config, type)
           : selectedItem
-          ? config.components[selectedItem.type]
+          ? _getComponentConfig(config, selectedItem.type)
           : ({ ...config.root, fields: rootFields } as ComponentConfig);
       },
       dispatch: (action: PuckAction) =>

--- a/packages/core/store/slices/permissions.ts
+++ b/packages/core/store/slices/permissions.ts
@@ -3,6 +3,7 @@ import { flattenData } from "../../lib/flatten-data";
 import { ComponentData, Config, Permissions, UserGenerics } from "../../types";
 import { getChanged } from "../../lib/get-changed";
 import { AppStore, useAppStoreApi } from "../";
+import { getComponentConfig } from "../../lib/get-component-config";
 
 type PermissionsArgs<
   UserConfig extends Config = Config,
@@ -63,7 +64,9 @@ export const createPermissionsSlice = (
         unsetComponentLoading,
       } = get();
       const componentConfig =
-        item.type === "root" ? config.root : config.components[item.type];
+        item.type === "root"
+          ? config.root
+          : getComponentConfig(config, item.type);
 
       if (!componentConfig) {
         return;
@@ -170,7 +173,7 @@ export const createPermissionsSlice = (
       const { globalPermissions, resolvedPermissions } = permissions;
 
       if (item) {
-        const componentConfig = config.components[item.type];
+        const componentConfig = getComponentConfig(config, item.type);
 
         const initialPermissions = {
           ...globalPermissions,
@@ -185,7 +188,7 @@ export const createPermissionsSlice = (
             : initialPermissions
         ) as Permissions;
       } else if (type) {
-        const componentConfig = config.components[type];
+        const componentConfig = getComponentConfig(config, type);
 
         return {
           ...globalPermissions,

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -61,6 +61,11 @@ export type ComponentConfig<
   ) => Promise<Partial<Permissions>> | Partial<Permissions>;
 };
 
+export type ComponentConfigFunction<
+  Props extends DefaultComponentProps = DefaultComponentProps,
+  Context = any
+> = (context?: Context) => ComponentConfig<Props>;
+
 type Category<ComponentName> = {
   components?: ComponentName[];
   title?: string;
@@ -71,16 +76,19 @@ type Category<ComponentName> = {
 export type Config<
   Props extends DefaultComponentProps = DefaultComponentProps,
   RootProps extends DefaultComponentProps = any,
-  CategoryName extends string = string
+  CategoryName extends string = string,
+  Context = any
 > = {
+  context?: Context;
   categories?: Record<CategoryName, Category<keyof Props>> & {
     other?: Category<keyof Props>;
   };
   components: {
-    [ComponentName in keyof Props]: Omit<
-      ComponentConfig<Props[ComponentName], Props[ComponentName]>,
-      "type"
-    >;
+    [ComponentName in keyof Props]:
+      | Omit<ComponentConfig<Props[ComponentName]>, "type">
+      | ((
+          context?: Context
+        ) => Omit<ComponentConfig<Props[ComponentName]>, "type">);
   };
   root?: Partial<
     ComponentConfig<


### PR DESCRIPTION
Added `context`, which can be used during component creation. Currently, there is no easy way to pass data from the API into `ComponentConfig`.

A `context` property has been added to `Config`, which can accept any data type. Now, a component can be declared in two ways:
1. Using `ComponentConfig`
2. Using `ComponentConfigFunction`

Example:

```tsx
export type Context = {
  package: string;
};

const HeadingBlock: ComponentConfigFunction<HeadingBlockProps, Context> = (context) => ({
  fields: {
    title: {
      type: "text",
    },
  },
  defaultProps: {
    title: `${context.package} v${context.version}`,
  },
  render: ({ title }) => <h1>{title}</h1>,
});

const config = {
  context: {
    package: "@measured/puck",
    version: "x.x.x",
  },
  components: {
    HeadingBlock,
  },
};
```