### PR TITLE
docs: fix broken link

### DIFF
--- a/apps/docs/pages/docs/api-reference/functions/use-puck.mdx
+++ b/apps/docs/pages/docs/api-reference/functions/use-puck.mdx
@@ -18,7 +18,7 @@ const Example = () => {
 };
 ```
 
-You can also access `usePuck` as a direct export, but you won't be able to use [selectors](#selector), resulting in unwanted re-renders and degraded performance.
+You can also access `usePuck` as a direct export, but you won't be able to use [selectors](#selectordata), resulting in unwanted re-renders and degraded performance.
 
 ## Args
 


### PR DESCRIPTION
Fixes a broken link to the selector function documentation in the `usePuck` docs.
