### PR TITLE
docs: fix broken link in fields Base docs

### DIFF
--- a/apps/docs/pages/docs/api-reference/fields/base.mdx
+++ b/apps/docs/pages/docs/api-reference/fields/base.mdx
@@ -7,7 +7,7 @@ The base type shared by all fields.
 | Param                     | Example               | Type      | Status |
 | ------------------------- | --------------------- | --------- | ------ |
 | [`label`](#label)         | `label: "Title"`      | String    | -      |
-| [`labelIcon`](#labelIcon) | `labelIcon: <Icon />` | ReactNode | -      |
+| [`labelIcon`](#labelicon) | `labelIcon: <Icon />` | ReactNode | -      |
 | [`metadata`](#metadata)   | `metadata: {}`        | Object    | -      |
 
 ## Optional params


### PR DESCRIPTION
Fixes a broken link to the `labelIcon` section in the Fields Base docs.
