### PR TITLE
docs: fix broken links in ComponentData docs

### DIFF
--- a/apps/docs/pages/docs/api-reference/data-model/component-data.mdx
+++ b/apps/docs/pages/docs/api-reference/data-model/component-data.mdx
@@ -18,8 +18,8 @@ An object representing an instance of a component.
 
 ## Params
 
-| Param                          | Example                                         | Type   | Status   |
-| ------------------------------ | ----------------------------------------------- | ------ | -------- |
+| Param                   | Example                                         | Type   | Status   |
+| ----------------------- | ----------------------------------------------- | ------ | -------- |
 | [`type`](#type)         | `type: "HeadingBlock"`                          | String | Required |
 | [`props`](#props)       | `props: { id: "12345", title: "Hello, world" }` | Object | Required |
 | [`readOnly`](#readonly) | `readOnly: { title: true }`                     | Object | -        |

--- a/apps/docs/pages/docs/api-reference/data-model/component-data.mdx
+++ b/apps/docs/pages/docs/api-reference/data-model/component-data.mdx
@@ -20,9 +20,9 @@ An object representing an instance of a component.
 
 | Param                          | Example                                         | Type   | Status   |
 | ------------------------------ | ----------------------------------------------- | ------ | -------- |
-| [`type`](#contenttype)         | `type: "HeadingBlock"`                          | String | Required |
-| [`props`](#contentprops)       | `props: { id: "12345", title: "Hello, world" }` | Object | Required |
-| [`readOnly`](#contentreadonly) | `readOnly: { title: true }`                     | Object | -        |
+| [`type`](#type)         | `type: "HeadingBlock"`                          | String | Required |
+| [`props`](#props)       | `props: { id: "12345", title: "Hello, world" }` | Object | Required |
+| [`readOnly`](#readonly) | `readOnly: { title: true }`                     | Object | -        |
 
 ### Required params
 


### PR DESCRIPTION
Fixes broken links in the table of contents of the `ComponentData` documentation.
