### PR TITLE
docs: fix wrong function call in getSelectorForId snippet

### DIFF
--- a/apps/docs/pages/docs/api-reference/puck-api.mdx
+++ b/apps/docs/pages/docs/api-reference/puck-api.mdx
@@ -77,7 +77,7 @@ getItemById("HeadingBlock-123");
 Get the [selector](/docs/api-reference/data-model/app-state#uiitemselector) for a component of a given id.
 
 ```tsx
-getItemById("HeadingBlock-123");
+getSelectorForId("HeadingBlock-123");
 // { index: 0, zone: "Flex-123:children" }
 ```
 


### PR DESCRIPTION
Fixes the snippet for the `getSelectorForId` documentation.