### PR TITLE
fix: typing issue in UsePuckData

### DIFF
--- a/packages/core/lib/use-puck.ts
+++ b/packages/core/lib/use-puck.ts
@@ -17,7 +17,7 @@ export type UsePuckData<
   G extends UserGenerics<UserConfig> = UserGenerics<UserConfig>
 > = {
   appState: AppState;
-  config: Config;
+  config: UserConfig;
   dispatch: AppStore["dispatch"];
   getPermissions: GetPermissions<UserConfig>;
   refreshPermissions: RefreshPermissions<UserConfig>;


### PR DESCRIPTION
Fixes a small typing issue in `UsePuckData` where the non typed `Config` is returned for `config` instead of the typed `UserConfig`