### PR TITLE
docs: clarify return values of item selector getters

### DIFF
--- a/apps/docs/pages/docs/api-reference/puck-api.mdx
+++ b/apps/docs/pages/docs/api-reference/puck-api.mdx
@@ -65,7 +65,7 @@ getItemBySelector({
 
 ### `getItemById(id)`
 
-Get an item’s [`ComponentData`](/docs/api-reference/data-model/component-data) by its component id.
+Get an item's [`ComponentData`](/docs/api-reference/data-model/component-data) by its component id.
 
 ```tsx
 getItemById("HeadingBlock-123");

--- a/apps/docs/pages/docs/api-reference/puck-api.mdx
+++ b/apps/docs/pages/docs/api-reference/puck-api.mdx
@@ -53,7 +53,7 @@ dispatch({
 
 ### `getItemBySelector(selector)`
 
-Get the item for a given [selector](/docs/api-reference/data-model/item-selector).
+Get an item’s [`ComponentData`](/docs/api-reference/data-model/component-data) by its [selector](/docs/api-reference/data-model/item-selector).
 
 ```tsx
 getItemBySelector({
@@ -65,7 +65,7 @@ getItemBySelector({
 
 ### `getItemById(id)`
 
-Get the item for a given id.
+Get an item’s [`ComponentData`](/docs/api-reference/data-model/component-data) by its component id.
 
 ```tsx
 getItemById("HeadingBlock-123");
@@ -74,7 +74,7 @@ getItemById("HeadingBlock-123");
 
 ### `getSelectorForId(id)`
 
-Get the [selector](/docs/api-reference/data-model/app-state#uiitemselector) for a component of a given id.
+Get an item's [selector](/docs/api-reference/data-model/app-state#uiitemselector) by its component id.
 
 ```tsx
 getItemById("HeadingBlock-123");

--- a/apps/docs/pages/docs/api-reference/puck-api.mdx
+++ b/apps/docs/pages/docs/api-reference/puck-api.mdx
@@ -53,7 +53,7 @@ dispatch({
 
 ### `getItemBySelector(selector)`
 
-Get an item’s [`ComponentData`](/docs/api-reference/data-model/component-data) by its [selector](/docs/api-reference/data-model/item-selector).
+Get an item's [`ComponentData`](/docs/api-reference/data-model/component-data) by its [selector](/docs/api-reference/data-model/item-selector).
 
 ```tsx
 getItemBySelector({


### PR DESCRIPTION
Adds documentation details and links specifying what the new item selector getters return.