### PR TITLE
fix: Slot type resolution

### DIFF
--- a/packages/core/types/Internal.tsx
+++ b/packages/core/types/Internal.tsx
@@ -32,9 +32,7 @@ export type PrivateAppState<UserData extends Data = Data> =
 export type WithPopulatedSlots<
   Props extends DefaultComponentProps = DefaultComponentProps,
   SlotProps extends DefaultComponentProps = Props
-> = Props extends any
-  ? any
-  : {
+> = {
       [PropName in keyof Props]: Props[PropName] extends Slot<SlotProps>
         ? Content<SlotProps>
         : Props[PropName];


### PR DESCRIPTION
This fixes the resolution of the slot props, used in `ComponentData`. 

Currently `WithPopulatedSlots` always resolves to `any` because every type extends `any`. I don't think an additional check in `WithPopulatedSlots` is needed, because `Props` already extends `DefaultComponentProps`.

Example: 

```typescript
type Child = {
  Child: {
    text: string;
  };
};

type config = Config<
  {
    Parent: {
      content: Slot<Child>;
    };
  } & Child
>
```

Current behaviour:

```typescript
type data = ComponentData<ExtractPropsFromConfig<config>, "Parent">
          /* = {
  type: "Parent";
  props: any;
  readOnly: undefined | { Child: unknown; Parent: unknown };
}; */
```

After fix:

```typescript
type data = ComponentData<ExtractPropsFromConfig<config>, "Parent">
          /* = {
  type: "Parent";
  props: {
    Parent: {
      content: Array<{
        type: "Child";
        props: { text: string; id: undefined | string };
        readOnly: undefined | { text: unknown };
      }>;
    };
    Child: { text: string };
    id: string;
  };
  readOnly: undefined | { Child: unknown; Parent: unknown };
}*/
```