### PR TITLE
fix: ignore scrollIntoView on outline click when component is not mounted

### DIFF
--- a/packages/core/components/LayerTree/index.tsx
+++ b/packages/core/components/LayerTree/index.tsx
@@ -103,8 +103,10 @@ const Layer = ({
             );
 
             if (!el) {
-              console.error("Scroll failed. No element was found for", itemId);
-
+              setItemSelector({
+                index,
+                zone: zoneCompound,
+              });
               return;
             }
 


### PR DESCRIPTION
Propose method for discord issue. Full description is on this thread.
https://discord.com/channels/1153376562259951687/1372587254517596271/1372587254517596271