### PR TITLE
chore: streamline github templates and remove title prefixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -3,8 +3,8 @@ name: "Bug Report 🐛"
 about:
   Report a problem with Puck. Please provide enough information to reproduce
   the problem.
-title: "Bug: "
-labels: ""
+title: ""
+labels: ["type: bug 🐛"]
 assignees: ""
 ---
 
@@ -15,58 +15,46 @@ assignees: ""
 <!--
   Provide a clear and concise description of the bug.
   Don't assume we know anything about your repository or codebase.
-  Keep it centered around Puck—avoid detailing your use case unless
-  it directly helps explain the issue.
-  Test the issue using the latest version of Puck to confirm it hasn’t
-  already been fixed.
-  Include screenshots or videos if helpful.
+  Keep it centered around Puck—avoid detailing your use case unless it directly helps explain the issue.
+  Test the issue using the latest version of Puck to confirm it hasn't already been fixed.
 -->
 
 ## Environment
 
-- Puck version: [e.g. 0.19.0, 1.0.0...]
-- Browser version: [e.g. Chrome 135 (desktop), Firefox 133 (mobile)...]
-- Additional environment info: [e.g. bundler, OS, device type...]
+- Puck version: [0.19.0, 1.0.0...]
+- Browser version: [Chrome 135 (desktop), Firefox 133 (mobile)...]
+- Additional environment info: [bundler, OS, device type...]
 
 <!--
-  Include relevant environment details such as Puck version, browser,
-  bundling tools, operating system, or anything else that might be relevant.
+  Detail the environment where the bug is occurring.
 -->
 
 ## Steps to reproduce
 
-1. Render the `<X />` component in a grid layout...
+1. Render the `<Puck />` component in a grid layout...
 
 ```tsx
-//... your code example
+const Editor = () => {
+  return (
+    <div style={{ display: "grid" }}>
+      <Puck config={config} data={data} />
+    </div>
+  );
+};
 ```
 
-2. Run in the application in development mode...
-3. Navigate to the page where the component is rendered...
+2. Run the application in development mode...
 
 <!--
-  Provide clear steps with code examples so that we can verify the bug.
-  Avoid adding dependencies other than Puck.
-
-  Issues without reproduction steps or code examples may be immediately
-  closed as not actionable.
--->
-
-Link to code example: [Your link here]
-
-<!--
-  If possible, provide a CodeSandbox (https://codesandbox.io/s/new), a link to a
-  repository on GitHub, or provide a minimal code example that demonstrates the
-  problem.
-
-  Screenshots or recordings are welcome if they help clarify the problem.
-
+  Provide clear steps with code examples so that we can reproduce the bug.
+  Avoid including dependencies other than Puck.
+  Issues without reproduction steps or code examples may be closed as not actionable.
   For help on providing minimal, reproducible examples: https://stackoverflow.com/help/mcve
 -->
 
 ## What happens
 
-[Example: "A white screen appears and the editor does not load..."]
+[Example: "A white screen appears and the editor doesn't load..."]
 
 <!--
   State what is the result of the steps above.
@@ -75,7 +63,7 @@ Link to code example: [Your link here]
 
 ## What I expect to happen
 
-[Example: "The Puck component should be rendered in any CSS layout..."]
+[Example: "The Puck component should render correctly in any CSS layout..."]
 
 <!--
   State what was the result you expected from the steps above.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,8 @@
 ---
 name: "Feature Request ✨"
 about: "Share ideas for new features."
-title: "Feat: "
-labels: ""
+title: ""
+labels: ["type: feature"]
 assignees: ""
 ---
 
@@ -18,8 +18,8 @@ assignees: ""
 
 ## Considerations
 
-- This might be related to field validation, which is currently being tracked in issue:...
-- The file implementing the `text` field lives at...
+- This might be related to field validation, which is currently being tracked in issue: #1...
+- The file implementing the `text` field lives at `core/text.tsx`...
 
 <!--
   List any special considerations for this feature that might help or make the changes more difficult.


### PR DESCRIPTION
This pull request simplifies the bug report template and removes the title prefixes.