### PR TITLE
fix: ensure setHistories resets the appState

### DIFF
--- a/packages/core/store/slices/__tests__/history.spec.tsx
+++ b/packages/core/store/slices/__tests__/history.spec.tsx
@@ -200,7 +200,7 @@ describe("history slice", () => {
       expect(index).toBe(1);
       expect(appStore.getState().dispatch).toHaveBeenCalledWith({
         type: "set",
-        state: defaultAppState, // from the old store’s last item or initialAppState
+        state: { ...defaultAppState, data: "Two" },
       });
     });
   });

--- a/packages/core/store/slices/history.ts
+++ b/packages/core/store/slices/history.ts
@@ -128,8 +128,7 @@ export const createHistorySlice = (
       dispatch({
         type: "set",
         state:
-          history.histories[history.histories.length - 1]?.state ||
-          history.initialAppState,
+          histories[histories.length - 1]?.state || history.initialAppState,
       });
 
       set({ history: { ...history, histories, index: histories.length - 1 } });


### PR DESCRIPTION
Puck was resetting to the old histories.

Closes #1101