### PR TITLE
Fix missing dependency issue

### DIFF
--- a/packages/core/components/Puck/components/Header/index.tsx
+++ b/packages/core/components/Puck/components/Header/index.tsx
@@ -79,7 +79,7 @@ const HeaderInner = <
     }
 
     return DefaultOverride;
-  }, [renderHeader, renderHeaderActions]);
+  }, [renderHeaderActions]);
 
   const CustomHeader = useAppStore(
     (s) => s.overrides.header || defaultHeaderRender


### PR DESCRIPTION
The renderHeaderActions property in the Puck component suffers from a stale closure issue. Below is an example demonstrating the bug:

```
const MyComponent = () => {
  const [state, setState] = useState<string>("init");
  // ...
  return (
    <Puck
      // ...
      renderHeaderActions={() => <>{state}</>}
      // ...
    />
  );
};
```

Regardless of how many times `state` changes, the output will always remain `"init"`, indicating that the closure is referencing the initial state instead of the latest one.