### PR TITLE
chore: prevent inline text from triggering default keyboard events

### DIFF
--- a/packages/core/components/InlineTextField/index.tsx
+++ b/packages/core/components/InlineTextField/index.tsx
@@ -99,9 +99,15 @@ const InlineTextFieldInternal = ({
         e.stopPropagation();
       }}
       onKeyDown={(e) => {
+        e.stopPropagation();
+
         if ((disableLineBreaks && e.key === "Enter") || isReadOnly) {
           e.preventDefault();
         }
+      }}
+      onKeyUp={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
       }}
       onMouseOverCapture={() => setIsHovering(true)}
       onMouseOutCapture={() => setIsHovering(false)}


### PR DESCRIPTION
Couldn't find a clean way to handle _all_ events, but this covers the use-case documented in #1223

Closes #1223