### PR TITLE
feature: Implement copy, cut, and paste actions with clipboard management

### DIFF
--- a/packages/core/bundle/core.ts
+++ b/packages/core/bundle/core.ts
@@ -30,3 +30,5 @@ export {
   type UsePuckData,
   type PuckApi,
 } from "../lib/use-puck";
+export { useClipboardStore } from "../lib/clipboard-store";
+export { useCopyPasteHotkeys } from "../lib/use-copy-paste-hotkeys";

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -50,6 +50,7 @@ import { useLoadedOverrides } from "../../lib/use-loaded-overrides";
 import { DefaultOverride } from "../DefaultOverride";
 import { useInjectGlobalCss } from "../../lib/use-inject-css";
 import { usePreviewModeHotkeys } from "../../lib/use-preview-mode-hotkeys";
+import { useCopyPasteHotkeys } from "../../lib/use-copy-paste-hotkeys";
 import { useRegisterHistorySlice } from "../../store/slices/history";
 import { useRegisterPermissionsSlice } from "../../store/slices/permissions";
 import { monitorHotkeys, useMonitorHotkeys } from "../../lib/use-hotkey";
@@ -493,6 +494,7 @@ function PuckLayout<
   }, [ready, iframe.enabled]);
 
   usePreviewModeHotkeys();
+  useCopyPasteHotkeys();
 
   const layoutOptions: Record<string, any> = {};
 

--- a/packages/core/lib/clipboard-store.ts
+++ b/packages/core/lib/clipboard-store.ts
@@ -1,0 +1,36 @@
+import { create } from "zustand";
+import { ComponentData } from "../types";
+
+export interface ClipboardData {
+  component: ComponentData | null;
+  copiedAt: number;
+}
+
+interface ClipboardStore {
+  clipboardData: ClipboardData;
+  copy: (component: ComponentData) => void;
+  clear: () => void;
+}
+
+export const useClipboardStore = create<ClipboardStore>((set, get) => ({
+  clipboardData: {
+    component: null,
+    copiedAt: 0,
+  },
+  copy: (component: ComponentData) => {
+    set({
+      clipboardData: {
+        component,
+        copiedAt: Date.now(),
+      },
+    });
+  },
+  clear: () => {
+    set({
+      clipboardData: {
+        component: null,
+        copiedAt: 0,
+      },
+    });
+  },
+}));

--- a/packages/core/lib/use-copy-paste-hotkeys.ts
+++ b/packages/core/lib/use-copy-paste-hotkeys.ts
@@ -1,0 +1,135 @@
+import { useCallback } from "react";
+import { useHotkey } from "./use-hotkey";
+import { useAppStore, useAppStoreApi } from "../store";
+import { useClipboardStore } from "./clipboard-store";
+
+export const useCopyPasteHotkeys = () => {
+  const appStore = useAppStoreApi();
+
+  // Check if we're in a context where copy-paste should work
+  const isValidContext = useCallback(() => {
+    // Get fresh state to ensure we have the latest selection
+    const currentState = appStore.getState();
+    const { itemSelector } = currentState.state.ui;
+    const currentSelectedItem = currentState.selectedItem;
+    
+    // Only allow copy-paste when we have a selected item
+    // and we're not focused on an input field
+    const activeElement = document.activeElement;
+    const isInputFocused = activeElement && (
+      activeElement.tagName === 'INPUT' ||
+      activeElement.tagName === 'TEXTAREA' ||
+      (activeElement as HTMLElement).contentEditable === 'true'
+    );
+    
+    // Check if we have either selectedItem or itemSelector
+    const hasSelection = currentSelectedItem || (itemSelector && typeof itemSelector.index !== 'undefined');
+    
+    return hasSelection && !isInputFocused;
+  }, [appStore]);
+
+  const copy = useCallback(() => {
+    if (!isValidContext()) return;
+    
+    const { state, dispatch } = appStore.getState();
+    const { index, zone } = state.ui.itemSelector || {};
+    
+    if (typeof index !== "undefined" && zone) {
+      dispatch({
+        type: "copy",
+        sourceIndex: index,
+        sourceZone: zone,
+        recordHistory: false,
+      });
+    }
+  }, [appStore, isValidContext]);
+
+  const cut = useCallback(() => {
+    if (!isValidContext()) return;
+    
+    const { state, dispatch } = appStore.getState();
+    const { index, zone } = state.ui.itemSelector || {};
+    
+    if (typeof index !== "undefined" && zone) {
+      dispatch({
+        type: "cut",
+        sourceIndex: index,
+        sourceZone: zone,
+        recordHistory: true,
+      });
+    }
+  }, [appStore, isValidContext]);
+
+  const paste = useCallback(() => {
+    if (!isValidContext()) return;
+    
+    // Get fresh clipboard data instead of using the hook data
+    const freshClipboardData = useClipboardStore.getState().clipboardData;
+    
+    if (!freshClipboardData.component) return;
+    
+    const { state, dispatch, selectedItem } = appStore.getState();
+    const { index, zone } = state.ui.itemSelector || {};
+    
+    
+    if (typeof index !== "undefined" && zone) {
+      // Get the actually selected component from selectedItem
+      if (selectedItem) {
+        // Check if the selected component has slot fields (dropzones)
+        const componentConfig = appStore.getState().config.components[selectedItem.type];
+        const hasSlotFields = componentConfig?.fields && Object.values(componentConfig.fields).some(
+          (field: any) => field.type === 'slot'
+        );
+        
+        if (hasSlotFields && componentConfig?.fields) {
+          // Find the first slot field and paste into it
+          const slotField = Object.entries(componentConfig.fields).find(
+            ([_, field]: any) => field.type === 'slot'
+          );
+          
+          if (slotField) {
+            const [slotFieldName] = slotField;
+            const targetZone = `${selectedItem.props.id}:${slotFieldName}`;
+            
+            // Paste at the beginning of the slot
+            dispatch({
+              type: "paste",
+              destinationIndex: 0,
+              destinationZone: targetZone,
+              recordHistory: true,
+            });
+            return;
+          }
+        }
+      }
+      
+      // Default behavior: paste after the selected item
+      dispatch({
+        type: "paste",
+        destinationIndex: index + 1,
+        destinationZone: zone,
+        recordHistory: true,
+      });
+    } else {
+      // If no selection, paste at the end of content
+      dispatch({
+        type: "paste",
+        destinationIndex: state.data.content.length,
+        destinationZone: "root",
+        recordHistory: true,
+      });
+    }
+  }, [appStore, isValidContext]);
+
+  // Copy shortcuts
+  useHotkey({ meta: true, c: true }, copy);
+  useHotkey({ ctrl: true, c: true }, copy); // Windows
+
+  // Cut shortcuts
+  useHotkey({ meta: true, x: true }, cut);
+  useHotkey({ ctrl: true, x: true }, cut); // Windows
+
+  // Paste shortcuts
+  useHotkey({ meta: true, v: true }, paste);
+  useHotkey({ ctrl: true, v: true }, paste); // Windows
+};

--- a/packages/core/reducer/actions.tsx
+++ b/packages/core/reducer/actions.tsx
@@ -15,6 +15,24 @@ export type DuplicateAction = {
   sourceZone: string;
 };
 
+export type CopyAction = {
+  type: "copy";
+  sourceIndex: number;
+  sourceZone: string;
+};
+
+export type CutAction = {
+  type: "cut";
+  sourceIndex: number;
+  sourceZone: string;
+};
+
+export type PasteAction = {
+  type: "paste";
+  destinationIndex: number;
+  destinationZone: string;
+};
+
 export type ReplaceAction<UserData extends Data = Data> = {
   type: "replace";
   destinationIndex: number;
@@ -87,6 +105,9 @@ export type PuckAction = { recordHistory?: boolean } & (
   | ReplaceRootAction
   | RemoveAction
   | DuplicateAction
+  | CopyAction
+  | CutAction
+  | PasteAction
   | SetAction
   | SetDataAction
   | SetUiAction

--- a/packages/core/reducer/actions/__tests__/copy-paste.spec.ts
+++ b/packages/core/reducer/actions/__tests__/copy-paste.spec.ts
@@ -1,0 +1,252 @@
+import { Content } from "../../../types";
+import { rootDroppableId } from "../../../lib/root-droppable-id";
+import {
+  defaultData,
+  defaultState,
+  dzZoneCompound,
+  expectIndexed,
+  testSetup,
+} from "../__helpers__";
+import { PrivateAppState } from "../../../types/Internal";
+import { walkAppState } from "../../../lib/data/walk-app-state";
+import { useClipboardStore } from "../../../lib/clipboard-store";
+
+describe("Reducer", () => {
+  const { executeSequence, config, reducer } = testSetup();
+
+  beforeEach(() => {
+    // Clear clipboard before each test
+    useClipboardStore.getState().clear();
+  });
+
+  describe("copy action", () => {
+    describe("with DropZones", () => {
+      it("should copy component to clipboard", () => {
+        const initialState = executeSequence(defaultState, [
+          () => ({
+            type: "insert",
+            componentType: "Comp",
+            destinationZone: rootDroppableId,
+            destinationIndex: 0,
+            id: "sampleId",
+          }),
+          (state) => ({
+            type: "replace",
+            destinationZone: rootDroppableId,
+            destinationIndex: 0,
+            data: {
+              ...state.indexes.nodes["sampleId"].data,
+              props: {
+                ...state.indexes.nodes["sampleId"].data.props,
+                prop: "Some example data",
+              },
+            },
+          }),
+        ]);
+
+        const newState = reducer(initialState, {
+          type: "copy",
+          sourceIndex: 0,
+          sourceZone: rootDroppableId,
+        });
+
+        // Copy action should not modify the state
+        expect(newState).toEqual(initialState);
+      });
+    });
+  });
+
+  describe("cut action", () => {
+    describe("with DropZones", () => {
+      it("should cut component to clipboard and remove from state", () => {
+        const initialState = executeSequence(defaultState, [
+          () => ({
+            type: "insert",
+            componentType: "Comp",
+            destinationZone: rootDroppableId,
+            destinationIndex: 0,
+            id: "sampleId",
+          }),
+          (state) => ({
+            type: "replace",
+            destinationZone: rootDroppableId,
+            destinationIndex: 0,
+            data: {
+              ...state.indexes.nodes["sampleId"].data,
+              props: {
+                ...state.indexes.nodes["sampleId"].data.props,
+                prop: "Some example data",
+              },
+            },
+          }),
+        ]);
+
+        const newState = reducer(initialState, {
+          type: "cut",
+          sourceIndex: 0,
+          sourceZone: rootDroppableId,
+        });
+
+        // Item should be removed from state
+        expect(newState.data.content).toHaveLength(0);
+        
+        // Item should be in clipboard
+        const clipboardData = useClipboardStore.getState().clipboardData;
+        expect(clipboardData.component).toBeTruthy();
+        expect(clipboardData.component?.props.prop).toBe("Some example data");
+      });
+
+      it("should cut from a different zone", () => {
+        const initialState = executeSequence(defaultState, [
+          () => ({
+            type: "insert",
+            componentType: "Comp",
+            destinationZone: dzZoneCompound,
+            destinationIndex: 0,
+            id: "sampleId",
+          }),
+        ]);
+
+        const newState = reducer(initialState, {
+          type: "cut",
+          sourceIndex: 0,
+          sourceZone: dzZoneCompound,
+        });
+
+        const zone = newState.data.zones?.[dzZoneCompound] ?? [];
+        expect(zone).toHaveLength(0);
+        
+        // Item should be in clipboard
+        const clipboardData = useClipboardStore.getState().clipboardData;
+        expect(clipboardData.component).toBeTruthy();
+      });
+    });
+  });
+
+  describe("paste action", () => {
+    describe("with DropZones", () => {
+      it("should paste component from clipboard", () => {
+        // First setup initial state with a component
+        const stateWithComponent = executeSequence(defaultState, [
+          () => ({
+            type: "insert",
+            componentType: "Comp",
+            destinationZone: rootDroppableId,
+            destinationIndex: 0,
+            id: "sampleId",
+          }),
+          (state) => ({
+            type: "replace",
+            destinationZone: rootDroppableId,
+            destinationIndex: 0,
+            data: {
+              ...state.indexes.nodes["sampleId"].data,
+              props: {
+                ...state.indexes.nodes["sampleId"].data.props,
+                prop: "Some example data",
+              },
+            },
+          }),
+        ]);
+
+        // Copy the component
+        reducer(stateWithComponent, {
+          type: "copy",
+          sourceIndex: 0,
+          sourceZone: rootDroppableId,
+        });
+
+        // Paste the component
+        const newState = reducer(stateWithComponent, {
+          type: "paste",
+          destinationIndex: 1,
+          destinationZone: rootDroppableId,
+        });
+
+        expect(newState.data.content).toHaveLength(2);
+        expect(newState.data.content[1].props.id).not.toBe("sampleId");
+        expect(newState.data.content[1].props.prop).toBe("Some example data");
+        expectIndexed(
+          newState,
+          newState.data.content[1],
+          [rootDroppableId],
+          1,
+          config
+        );
+      });
+
+      it("should select the pasted item", () => {
+        const stateWithComponent = executeSequence(defaultState, [
+          () => ({
+            type: "insert",
+            componentType: "Comp",
+            destinationZone: rootDroppableId,
+            destinationIndex: 0,
+            id: "sampleId",
+          }),
+        ]);
+
+        // Copy and paste
+        reducer(stateWithComponent, {
+          type: "copy",
+          sourceIndex: 0,
+          sourceZone: rootDroppableId,
+        });
+
+        const newState = reducer(stateWithComponent, {
+          type: "paste",
+          destinationIndex: 1,
+          destinationZone: rootDroppableId,
+        });
+
+        expect(newState.ui.itemSelector?.index).toBe(1);
+        expect(newState.ui.itemSelector?.zone).toBe(rootDroppableId);
+      });
+    });
+
+    describe("with slots", () => {
+      it("should paste within a slot", () => {
+        const stateWithComponent = executeSequence(defaultState, [
+          () => ({
+            type: "insert",
+            componentType: "Comp",
+            destinationZone: "root:slot",
+            destinationIndex: 0,
+            id: "sampleId",
+          }),
+          (state) => ({
+            type: "replace",
+            destinationZone: "root:slot",
+            destinationIndex: 0,
+            data: {
+              ...state.indexes.nodes["sampleId"].data,
+              props: {
+                ...state.indexes.nodes["sampleId"].data.props,
+                prop: "Some example data",
+              },
+            },
+          }),
+        ]);
+
+        // Copy and paste
+        reducer(stateWithComponent, {
+          type: "copy",
+          sourceIndex: 0,
+          sourceZone: "root:slot",
+        });
+
+        const newState = reducer(stateWithComponent, {
+          type: "paste",
+          destinationIndex: 1,
+          destinationZone: "root:slot",
+        });
+
+        const content = (newState.data.root.props as any)?.slot ?? [];
+        expect(content).toHaveLength(2);
+        expect(content[1].props.id).not.toBe("sampleId");
+        expect(content[1].props.prop).toBe("Some example data");
+        expectIndexed(newState, content[1], ["root:slot"], 1, config);
+      });
+    });
+  });
+});

--- a/packages/core/reducer/actions/copy.ts
+++ b/packages/core/reducer/actions/copy.ts
@@ -1,0 +1,24 @@
+import { Data } from "../../types";
+import { CopyAction } from "../actions";
+import { PrivateAppState } from "../../types/Internal";
+import { getItem } from "../../lib/data/get-item";
+import { AppStore } from "../../store";
+import { useClipboardStore } from "../../lib/clipboard-store";
+
+export function copyAction<UserData extends Data>(
+  state: PrivateAppState<UserData>,
+  action: CopyAction,
+  appStore: AppStore
+): PrivateAppState<UserData> {
+  const item = getItem(
+    { index: action.sourceIndex, zone: action.sourceZone },
+    state
+  );
+
+  if (item) {
+    useClipboardStore.getState().copy(item);
+  }
+
+  // Copy action doesn't modify the state, just stores to clipboard
+  return state;
+}

--- a/packages/core/reducer/actions/cut.ts
+++ b/packages/core/reducer/actions/cut.ts
@@ -1,0 +1,32 @@
+import { Data } from "../../types";
+import { CutAction } from "../actions";
+import { PrivateAppState } from "../../types/Internal";
+import { getItem } from "../../lib/data/get-item";
+import { AppStore } from "../../store";
+import { useClipboardStore } from "../../lib/clipboard-store";
+import { removeAction } from "./remove";
+
+export function cutAction<UserData extends Data>(
+  state: PrivateAppState<UserData>,
+  action: CutAction,
+  appStore: AppStore
+): PrivateAppState<UserData> {
+  const item = getItem(
+    { index: action.sourceIndex, zone: action.sourceZone },
+    state
+  );
+
+  if (item) {
+    // First copy the item to clipboard
+    useClipboardStore.getState().copy(item);
+    
+    // Then remove it from the state
+    return removeAction(state, {
+      type: "remove",
+      index: action.sourceIndex,
+      zone: action.sourceZone,
+    }, appStore);
+  }
+
+  return state;
+}

--- a/packages/core/reducer/actions/paste.ts
+++ b/packages/core/reducer/actions/paste.ts
@@ -1,0 +1,88 @@
+import { Data } from "../../types";
+import { generateId } from "../../lib/generate-id";
+import { PasteAction } from "../actions";
+import { PrivateAppState } from "../../types/Internal";
+import { walkAppState } from "../../lib/data/walk-app-state";
+import { getIdsForParent } from "../../lib/data/get-ids-for-parent";
+import { getItem } from "../../lib/data/get-item";
+import { AppStore } from "../../store";
+import { insert } from "../../lib/data/insert";
+import { useClipboardStore } from "../../lib/clipboard-store";
+
+export function pasteAction<UserData extends Data>(
+  state: PrivateAppState<UserData>,
+  action: PasteAction,
+  appStore: AppStore
+): PrivateAppState<UserData> {
+  const clipboardData = useClipboardStore.getState().clipboardData;
+  
+  if (!clipboardData.component) {
+    return state;
+  }
+
+  const item = clipboardData.component;
+  const idsInPath = getIdsForParent(action.destinationZone, state);
+
+  const newItem = {
+    ...item,
+    props: {
+      ...item.props,
+      id: generateId(item.type),
+    },
+  };
+
+  const modified = walkAppState<UserData>(
+    state,
+    appStore.config,
+    (content, zoneCompound) => {
+      if (zoneCompound === action.destinationZone) {
+        return insert(content, action.destinationIndex, newItem);
+      }
+
+      return content;
+    },
+    (childItem, path, index) => {
+      const zoneCompound = path[path.length - 1];
+      const parents = path.map((p) => p.split(":")[0]);
+
+      if (parents.indexOf(newItem.props.id) > -1) {
+        return {
+          ...childItem,
+          props: {
+            ...childItem.props,
+            id: generateId(childItem.type),
+          },
+        };
+      }
+
+      if (
+        zoneCompound === action.destinationZone &&
+        index === action.destinationIndex
+      ) {
+        return newItem;
+      }
+
+      const [destinationZoneParent] = action.destinationZone.split(":");
+
+      if (
+        destinationZoneParent === childItem.props.id ||
+        idsInPath.indexOf(childItem.props.id) > -1
+      ) {
+        return childItem;
+      }
+
+      return null;
+    }
+  );
+
+  return {
+    ...modified,
+    ui: {
+      ...modified.ui,
+      itemSelector: {
+        index: action.destinationIndex,
+        zone: action.destinationZone,
+      },
+    },
+  };
+}

--- a/packages/core/reducer/index.ts
+++ b/packages/core/reducer/index.ts
@@ -9,6 +9,9 @@ import { insertAction } from "./actions/insert";
 import { replaceAction } from "./actions/replace";
 import { replaceRootAction } from "./actions/replace-root";
 import { duplicateAction } from "./actions/duplicate";
+import { copyAction } from "./actions/copy";
+import { cutAction } from "./actions/cut";
+import { pasteAction } from "./actions/paste";
 import { reorderAction } from "./actions/reorder";
 import { moveAction } from "./actions/move";
 import { removeAction } from "./actions/remove";
@@ -46,6 +49,7 @@ function storeInterceptor<UserData extends Data = Data>(
       "setData",
       "setUi",
       "set",
+      "copy",
     ].includes(action.type);
 
     if (
@@ -91,6 +95,18 @@ export function createReducer<UserData extends Data>({
 
       if (action.type === "duplicate") {
         return duplicateAction(state, action, appStore);
+      }
+
+      if (action.type === "copy") {
+        return copyAction(state, action, appStore);
+      }
+
+      if (action.type === "cut") {
+        return cutAction(state, action, appStore);
+      }
+
+      if (action.type === "paste") {
+        return pasteAction(state, action, appStore);
       }
 
       if (action.type === "reorder") {


### PR DESCRIPTION
This pull request introduces a complete copy/cut/paste workflow for components in the core package, including hotkey support, a clipboard store, reducer actions, and UI integration. The changes allow users to copy, cut, and paste components via both UI buttons and keyboard shortcuts, with robust handling for slots and drop zones.

**Clipboard and Hotkey Functionality**
* Added a new `useClipboardStore` (Zustand store) to manage clipboard data for components, including methods for copy and clear. (`packages/core/lib/clipboard-store.ts`, [packages/core/lib/clipboard-store.tsR1-R36](diffhunk://#diff-be6eb25a15ab3c49bb7f311e58bed3fca37e584ff29213a255e2b3e278bb2bcbR1-R36))
* Implemented the `useCopyPasteHotkeys` hook to handle keyboard shortcuts (Cmd/Ctrl+C/X/V) for copy, cut, and paste actions, with context checks to prevent unintended operations. (`packages/core/lib/use-copy-paste-hotkeys.ts`, [packages/core/lib/use-copy-paste-hotkeys.tsR1-R135](diffhunk://#diff-ceb4901460b3d47bc7bc9a7a0c8b61cb67caab3424c507d3b9b17804492945f5R1-R135))
* Registered the hotkey hook in the main layout to enable copy-paste shortcuts throughout the app. (`packages/core/components/Puck/index.tsx`, [[1]](diffhunk://#diff-327e75debc05583175fb291677a4debed50b1823f66b426127c0fdfc8690fab3R53) [[2]](diffhunk://#diff-327e75debc05583175fb291677a4debed50b1823f66b426127c0fdfc8690fab3R497)

**Reducer Actions and Logic**
* Defined new reducer actions for copy, cut, and paste, and added corresponding handler functions to manage state and clipboard updates. (`packages/core/reducer/actions.tsx`, [[1]](diffhunk://#diff-6a8847e0f80c500ccc3f5cefd9edf79b266f0c5cbff5797273ef0e2551413ec6R18-R35) [[2]](diffhunk://#diff-6a8847e0f80c500ccc3f5cefd9edf79b266f0c5cbff5797273ef0e2551413ec6R108-R110); `packages/core/reducer/actions/copy.ts`, [[3]](diffhunk://#diff-bdcfc834f49548d2297d4351057d7fcd1eefef439ea1706fb7faf7a272ddbf5aR1-R24); `packages/core/reducer/actions/cut.ts`, [[4]](diffhunk://#diff-0840d34f0b98b12fa52243ea6841d29c71fd5680207fb29c30aa3d737aa2f72aR1-R32)
* Added comprehensive tests for copy, cut, and paste reducer logic, including scenarios with drop zones and slot fields. (`packages/core/reducer/actions/__tests__/copy-paste.spec.ts`, [packages/core/reducer/actions/__tests__/copy-paste.spec.tsR1-R252](diffhunk://#diff-1aa2535bdb47f89cfe11660f37a54082a634b9e5f898f4336fbbdaa97ab1e98eR1-R252))

**UI Integration**
* Updated the `DraggableComponent` to include Copy, Cut, and Paste actions in the `ActionBar`, with appropriate icon buttons and callbacks wired to the new reducer actions and clipboard store. (`packages/core/components/DraggableComponent/index.tsx`, [[1]](diffhunk://#diff-d625e3b274e5aa193679313129123d868084442be8eaa76119437f5ceb0f6ebaL17-R17) [[2]](diffhunk://#diff-d625e3b274e5aa193679313129123d868084442be8eaa76119437f5ceb0f6ebaR35) [[3]](diffhunk://#diff-d625e3b274e5aa193679313129123d868084442be8eaa76119437f5ceb0f6ebaR121) [[4]](diffhunk://#diff-d625e3b274e5aa193679313129123d868084442be8eaa76119437f5ceb0f6ebaR415-R472) [[5]](diffhunk://#diff-d625e3b274e5aa193679313129123d868084442be8eaa76119437f5ceb0f6ebaR699-R713)
* Exported the clipboard store and hotkey hook from the core bundle for use across the app. (`packages/core/bundle/core.ts`, [packages/core/bundle/core.tsR33-R34](diffhunk://#diff-cefd03073e4f6d4db2bab60fb23808d265648dca2f41c72c43e1739ae7058688R33-R34))

These changes provide a robust, user-friendly copy-paste workflow for component manipulation in the editor, both via UI and keyboard shortcuts.
[puck_copy_paste.webm](https://github.com/user-attachments/assets/2bf93389-73fd-484b-9935-69a6ea06659a)
