### PR TITLE
fix: preserve selection when switching viewports and using zoom select

### DIFF
--- a/packages/core/components/Puck/components/Canvas/index.tsx
+++ b/packages/core/components/Puck/components/Canvas/index.tsx
@@ -185,7 +185,6 @@ export const Canvas = () => {
 
               const newUi: Partial<UiState> = {
                 viewports: { ...viewports, current: uiViewport },
-                itemSelector: null,
               };
 
               setUi(newUi);

--- a/packages/core/components/ViewportControls/index.tsx
+++ b/packages/core/components/ViewportControls/index.tsx
@@ -162,6 +162,9 @@ export const ViewportControls = ({
       <select
         className={getClassName("zoomSelect")}
         value={zoom.toString()}
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
         onChange={(e) => {
           onZoom(parseFloat(e.currentTarget.value));
         }}


### PR DESCRIPTION
### Addresses #1170 
### Bug Fix: Preserve Selection When Switching Viewports

#### What was happening
When switching between viewports using the viewport buttons, the currently selected component in the outline/canvas was being deselected. This also happened when switching zoom levels using the zoom select dropdown. This broke the editing flow because users lost track of the node they were working on.

#### What’s the fix
- Updated the viewport selection handling so that switching viewport does not clear selection.  
- Updated the zoom selection handling so switching zoom level does not clear selection.
- The fix ensures selection state persists unless the selected node is no longer present in the new viewport (e.g. conditionally hidden).

#### Testing
- Switching between desktop, tablet, and mobile viewports preserves the current selection.  
- Changing zoom via both the zoom dropdown and the zoom buttons preserves selection.  
- Clicking the canvas background still clears selection as expected.  
- Outline and property panel interactions remain unchanged.  
- Verified selection clears gracefully if the selected node disappears in the new viewport.

Video:

https://github.com/user-attachments/assets/51cb4df0-a7b0-4686-9a27-907c29bc6f30


