### PR TITLE
fix(core): update FieldComponent on `custom` field update using `resolveFields`

### DIFF
--- a/packages/core/components/AutoField/index.tsx
+++ b/packages/core/components/AutoField/index.tsx
@@ -229,7 +229,7 @@ function AutoFieldInternal<
     } else if (field.type !== "slot") {
       return render[field.type] as (props: FieldProps) => ReactElement;
     }
-  }, [field.type, render]);
+  }, [field, render]);
 
   const { visible = true } = props.field;
 


### PR DESCRIPTION
Closes #1288.

Since [`mergedProps`](https://github.com/puckeditor/puck/blob/main/packages/core/components/AutoField/index.tsx#L173) also depends on `field`, this change does not create extra re-renders.

I used [`react-scan`](https://react-scan.com/) to track the perfomance.

Before:

https://github.com/user-attachments/assets/537dbba3-5cd8-4b46-a104-ff90e6055f68

After:

https://github.com/user-attachments/assets/84f715a0-5b37-4f18-80d5-1acd4aaabe7c

