### PR TITLE
fix(resolveComponentData): bypass cache when trigger is force

### DIFF
--- a/packages/core/lib/resolve-component-data.ts
+++ b/packages/core/lib/resolve-component-data.ts
@@ -40,7 +40,7 @@ export const resolveComponentData = async <
   if (shouldRunResolver) {
     const { item: oldItem = null, resolved = {} } = cache.lastChange[id] || {};
 
-    if (item && fdeq(item, oldItem)) {
+    if (trigger !== "force" && item && fdeq(item, oldItem)) {
       return { node: resolved, didChange: false };
     }
 


### PR DESCRIPTION
Adresses #1273 Fix: honor trigger "force" in resolveComponentData

This should fix the issue where data is pulled from the cache even when force trigger is present.

I manually tested and it still passes existing tests, just a small change.