### PR TITLE
fix: debouncing arrayField delete event by 5ms so that the state doesn't get out of sync

### DIFF
--- a/packages/core/components/AutoField/fields/ArrayField/index.tsx
+++ b/packages/core/components/AutoField/fields/ArrayField/index.tsx
@@ -5,6 +5,7 @@ import { AutoFieldPrivate, FieldPropsInternal } from "../..";
 import { IconButton } from "../../../IconButton";
 import { reorder, replace } from "../../../../lib";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useDebouncedCallback } from "use-debounce";
 import { DragIcon } from "../../../DragIcon";
 import { ArrayState, Content, ItemWithId } from "../../../../types";
 import { useAppStore, useAppStoreApi } from "../../../../store";
@@ -145,6 +146,29 @@ export const ArrayField = ({
       });
     },
     [appStore, field]
+  );
+
+  const debouncedDelete = useDebouncedCallback(
+    (e: React.SyntheticEvent, i: number) => {
+      e.stopPropagation();
+
+      const existingValue = [...(value || [])];
+
+      const existingItems = [...(arrayState.items || [])];
+
+      existingValue.splice(i, 1);
+      existingItems.splice(i, 1);
+
+      setUi(
+        mapArrayStateToUi({
+          items: existingItems,
+        }),
+        false
+      );
+
+      onChange(existingValue);
+    },
+    5
   );
 
   if (field.type !== "array" || !field.arrayFields) {
@@ -297,25 +321,7 @@ export const ArrayField = ({
                                         localState.arrayState.items.length
                                     }
                                     onClick={(e) => {
-                                      e.stopPropagation();
-
-                                      const existingValue = [...(value || [])];
-
-                                      const existingItems = [
-                                        ...(arrayState.items || []),
-                                      ];
-
-                                      existingValue.splice(i, 1);
-                                      existingItems.splice(i, 1);
-
-                                      setUi(
-                                        mapArrayStateToUi({
-                                          items: existingItems,
-                                        }),
-                                        false
-                                      );
-
-                                      onChange(existingValue);
+                                      debouncedDelete(e, i);
                                     }}
                                     title="Delete"
                                   >


### PR DESCRIPTION
Related issue: #1161 

The arrayField data was getting out of sync if the user clicked delete too quickly.  I've added a debounce to avoid hitting the race condition.