### PR TITLE
fix: updating root component Id using populateIds

### DIFF
--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -232,13 +232,14 @@ function PuckProvider<
 
     const defaultedRootProps = {
       ...config.root?.defaultProps,
-      ...rootProps,
+      ...(rootProps as AsFieldProps<DefaultComponentProps> | AsFieldProps<any>),
     };
 
     const root = populateIds(
       toComponent({ ...initialData?.root, props: defaultedRootProps }),
       config
     );
+
     const newAppState = {
       ...defaultAppState,
       data: {


### PR DESCRIPTION
fixes #1221 

Supercedes #1303 

Updating root component ids with `populateIds` helper function to avoid touching `walk-app-state`.  