### PR TITLE
Feature: Add maxItems Property to Slot Component

### DIFF
--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -278,6 +278,7 @@ export const DropZoneEdit = forwardRef<HTMLDivElement, DropZoneProps>(
       zone,
       allow,
       disallow,
+      maxItems,
       style,
       className,
       minEmptyHeight: userMinEmptyHeight = 128,
@@ -360,6 +361,11 @@ export const DropZoneEdit = forwardRef<HTMLDivElement, DropZoneProps>(
           return true;
         }
 
+        // Check maxItems limit
+        if (maxItems !== undefined && contentIds.length >= maxItems) {
+          return false;
+        }
+
         if (disallow) {
           const defaultedAllow = allow || [];
 
@@ -379,7 +385,7 @@ export const DropZoneEdit = forwardRef<HTMLDivElement, DropZoneProps>(
 
         return true;
       },
-      [allow, disallow]
+      [allow, disallow, maxItems, contentIds.length]
     );
 
     const targetAccepted = useContextStore(ZoneStoreContext, (s) => {
@@ -471,6 +477,7 @@ export const DropZoneEdit = forwardRef<HTMLDivElement, DropZoneProps>(
           isAreaSelected,
           hasChildren: contentIds.length > 0,
           isAnimating,
+          isMaxed: maxItems !== undefined && contentIds.length >= maxItems,
         })}${className ? ` ${className}` : ""}`}
         ref={(node) => {
           assignRefs<HTMLDivElement>([ref, dropRef, userRef], node);
@@ -500,6 +507,27 @@ export const DropZoneEdit = forwardRef<HTMLDivElement, DropZoneProps>(
             />
           );
         })}
+        {maxItems !== undefined && contentIds.length >= maxItems && contentIds.length > 0 && (
+          <div
+            style={{
+              position: "absolute",
+              top: "50%",
+              left: "50%",
+              transform: "translate(-50%, -50%)",
+              background: "rgba(0, 0, 0, 0.7)",
+              color: "white",
+              padding: "8px 12px",
+              borderRadius: "4px",
+              fontSize: "12px",
+              fontWeight: "500",
+              pointerEvents: "none",
+              zIndex: 10,
+              whiteSpace: "nowrap",
+            }}
+          >
+            Max items reached ({maxItems}/{maxItems})
+          </div>
+        )}
       </div>
     );
   }

--- a/packages/core/components/DropZone/styles.module.css
+++ b/packages/core/components/DropZone/styles.module.css
@@ -60,6 +60,15 @@
   outline: 2px dashed var(--puck-color-azure-06);
 }
 
+.DropZone--isMaxed {
+  opacity: 0.6;
+}
+
+[data-puck-dragging] .DropZone--isMaxed {
+  outline: 2px dashed var(--puck-color-grey-06);
+  background: color-mix(in srgb, var(--puck-color-grey-09) 20%, transparent);
+}
+
 .DropZone > *:not([data-puck-component]) {
   opacity: 0;
 }

--- a/packages/core/components/DropZone/types.ts
+++ b/packages/core/components/DropZone/types.ts
@@ -5,6 +5,7 @@ export type DropZoneProps = {
   zone: string;
   allow?: string[];
   disallow?: string[];
+  maxItems?: number;
   style?: CSSProperties;
   minEmptyHeight?: number;
   className?: string;

--- a/packages/core/lib/field-transforms/default-transforms/slot-transform.tsx
+++ b/packages/core/lib/field-transforms/default-transforms/slot-transform.tsx
@@ -16,6 +16,7 @@ export const getSlotTransform = (
       render({
         allow: field?.type === "slot" ? field.allow : [],
         disallow: field?.type === "slot" ? field.disallow : [],
+        maxItems: field?.type === "slot" ? field.maxItems : undefined,
         ...dzProps,
         zone: propName,
         content,

--- a/packages/core/types/Fields.ts
+++ b/packages/core/types/Fields.ts
@@ -139,6 +139,7 @@ export type SlotField = BaseField & {
   type: "slot";
   allow?: string[];
   disallow?: string[];
+  maxItems?: number;
 };
 
 export type Field<ValueType = any, UserField extends {} = {}> =


### PR DESCRIPTION
 **Problem**

  Currently, Puck's Slot component allows unlimited items to be added. In many real-world use cases, developers need to limit the number of items that can be
  placed in a slot to maintain design integrity and usability.

  **Solution**

  This PR introduces an optional maxItems property to the Slot field configuration:

  ```
{
    type: 'slot',
    label: 'Action Buttons',
    allow: ['Button'],
    maxItems: 3  // Limits slot to maximum 3 buttons
  }
```

  **Why This Matters**

  **Without maxItems:**
  - Users can add unlimited items, potentially breaking layouts
  - No way to enforce design system constraints
  - Content editors lack guidance on recommended limits

  **With maxItems:**
  - Enforces component limits at the framework level
  - Provides immediate visual feedback when limit is reached
  - Maintains consistent user experience across the application

  **Common Use Cases**

  - Hero CTAs: Limit to 2-3 buttons to avoid decision paralysis
  - Navigation Bars: Cap at 5-7 items for optimal usability
  - Card Grids: Restrict to specific numbers for responsive layouts
  - Testimonials: Limit carousel items for better performance
  - Footer Links: Control number of link columns