### PR TITLE
Type `renderDropZone` to old `React.FC` definition to support Puck patterns

### DIFF
--- a/packages/core/types/Props.tsx
+++ b/packages/core/types/Props.tsx
@@ -3,7 +3,7 @@ import { Metadata } from "./Data";
 import { WithChildren, WithPuckProps } from "./Utils";
 
 export type PuckContext = {
-  renderDropZone: React.FC<DropZoneProps>;
+  renderDropZone: (props: DropZoneProps) => React.ReactNode;
   metadata: Metadata;
   isEditing: boolean;
   dragRef: ((element: Element | null) => void) | null;


### PR DESCRIPTION
Closes #937

The latest `React.FC` now returns a [ReactNode or Promise<ReactNode>](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/2b34e30eb8ea7bd37fbed3b32eaabfdb4d23f678/types/react/index.d.ts#L1052C1-L1052C52).  
This change was made to support React Server Components (RSC) in the long run. However, it breaks Puck’s documented patterns for using `renderDropZone`, since TypeScript can no longer determine whether it should expect a `ReactNode` when calling a functional component as a function under the new definition.

To fix this, I typed `renderDropZone` using the [old React.FC definition](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/2b34e30eb8ea7bd37fbed3b32eaabfdb4d23f678/types/react/v18/index.d.ts#L1127), as that matches what we actually return in the implementation and how it was handled previously.

For the record, you won’t be able to reproduce this in the repo because the core package is still using older React type definitions.
