### PR TITLE
Remove unused private APIs from resolveAllData

### DIFF
--- a/packages/core/lib/resolve-all-data.ts
+++ b/packages/core/lib/resolve-all-data.ts
@@ -16,19 +16,11 @@ import { mapFields } from "./data/map-fields";
 export async function resolveAllData<
   Components extends DefaultComponents = DefaultComponents,
   RootProps extends Record<string, any> = DefaultRootFieldProps
->(
-  data: Partial<Data>,
-  config: Config,
-  metadata: Metadata = {},
-  onResolveStart?: (item: ComponentData) => void,
-  onResolveEnd?: (item: ComponentData) => void
-) {
+>(data: Partial<Data>, config: Config, metadata: Metadata = {}) {
   const defaultedData = defaultData(data);
 
   const resolveNode = async <T extends ComponentData | RootData>(_node: T) => {
     const node = toComponent(_node);
-
-    onResolveStart?.(node);
 
     const resolved = (
       await resolveComponentData(
@@ -46,8 +38,6 @@ export async function resolveAllData<
       { slot: ({ value }) => processContent(value) },
       config
     )) as T;
-
-    onResolveEnd?.(toComponent(resolvedDeep));
 
     return resolvedDeep;
   };


### PR DESCRIPTION
Closes #899

The `resolveAllData` function contained deprecated APIs that were [previously used](https://github.com/measuredco/puck/blob/358e61995aabc889ab0df60704d78c91b3004855/packages/core/components/Puck/index.tsx#L155-L176) to manage component load state internally.

These APIs were never documented or intended for external use outside of Puck’s internals.

So far, no one has reported using these APIs, but we should document this as a breaking change in the migration guide.
