### PR TITLE
React Native rendering support

### DIFF
--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -487,7 +487,14 @@ export const DropZoneEdit = forwardRef<HTMLDivElement, DropZoneProps>(
       [dropRef]
     );
 
-    const El = as ?? "div";
+    const config = useAppStore((s) => s.config);
+
+    const Wrapper = useMemo(
+      () => config.overrides?.slot || "div",
+      [config.overrides]
+    );
+
+    const El = as ?? Wrapper;
 
     return (
       <El
@@ -583,6 +590,11 @@ const DropZoneRender = forwardRef<HTMLDivElement, DropZoneProps>(
     let zoneCompound = `${areaId}:${zone}`;
     let content = data?.content || [];
 
+    const Wrapper = useMemo(
+      () => config.overrides?.slot || "div",
+      [config.overrides]
+    );
+
     // Register zones if running Render mode inside editor (i.e. previewMode === "interactive")
     useEffect(() => {
       // Only register zones, not slots
@@ -593,7 +605,7 @@ const DropZoneRender = forwardRef<HTMLDivElement, DropZoneProps>(
       }
     }, [content]);
 
-    const El = as ?? "div";
+    const El = as ?? Wrapper;
 
     if (!data || !config) {
       return null;

--- a/packages/core/components/SlotRender/server.tsx
+++ b/packages/core/components/SlotRender/server.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from "react";
+import { forwardRef, useMemo } from "react";
 import { DropZoneProps } from "../DropZone/types";
 import {
   ComponentData,
@@ -60,7 +60,12 @@ export const SlotRender = forwardRef<HTMLDivElement, SlotRenderProps>(
     { className, style, content, config, metadata, as },
     ref
   ) {
-    const El = as ?? "div";
+    const Wrapper = useMemo(
+      () => config.overrides?.slot || "div",
+      [config.overrides]
+    );
+
+    const El = as ?? Wrapper;
 
     return (
       <El className={className} style={style} ref={ref}>

--- a/packages/core/lib/bubble-pointer-event.ts
+++ b/packages/core/lib/bubble-pointer-event.ts
@@ -2,8 +2,40 @@ export interface BubbledPointerEventType extends PointerEvent {
   originalTarget: EventTarget | null;
 }
 
+// Necessary for environments without DOM
+class EventShim {
+  type: string;
+  bubbles: boolean;
+  cancelable: boolean;
+  defaultPrevented: boolean;
+
+  constructor(
+    type: string,
+    data: { bubbles?: boolean; cancelable?: boolean } = {}
+  ) {
+    this.type = type;
+    this.bubbles = !!data.bubbles;
+    this.cancelable = !!data.cancelable;
+    this.defaultPrevented = false;
+  }
+
+  preventDefault() {
+    if (this.cancelable) {
+      this.defaultPrevented = true;
+    }
+  }
+
+  stopPropagation() {}
+  stopImmediatePropagation() {}
+}
+
 // Necessary to enable server build
-const BaseEvent = typeof PointerEvent !== "undefined" ? PointerEvent : Event;
+const BaseEvent =
+  typeof PointerEvent !== "undefined"
+    ? PointerEvent
+    : typeof Event !== "undefined"
+    ? Event
+    : EventShim;
 
 export class BubbledPointerEvent extends BaseEvent {
   _originalTarget: EventTarget | null = null;

--- a/packages/core/types/API/Overrides.ts
+++ b/packages/core/types/API/Overrides.ts
@@ -81,3 +81,11 @@ export type FieldRenderFunctions<
   },
   "custom"
 >;
+
+export interface RenderOverrides {
+  slot?: RenderFunc<{
+    children?: ReactNode;
+    className?: string;
+    style?: React.CSSProperties;
+  }>;
+}

--- a/packages/core/types/API/index.ts
+++ b/packages/core/types/API/index.ts
@@ -3,7 +3,7 @@ import { WithDeepSlots } from "../Internal";
 import { DefaultComponentProps } from "../Props";
 import { AppState } from "./../AppState";
 import { ComponentDataOptionalId, Content, Data } from "./../Data";
-import { Overrides } from "./Overrides";
+import { Overrides, RenderOverrides } from "./Overrides";
 import { FieldTransforms } from "./FieldTransforms";
 import { Config, DefaultComponents } from "../Config";
 import { ReactNode } from "react";
@@ -75,6 +75,6 @@ export type RichText = string | ReactNode;
 export * from "./DropZone";
 export * from "./Viewports";
 
-export type { Overrides };
+export type { Overrides, RenderOverrides };
 
 export * from "./FieldTransforms";

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -5,7 +5,7 @@ import { ComponentData, ComponentMetadata, RootData } from "./Data";
 import { AsFieldProps, WithChildren, WithId, WithPuckProps } from "./Utils";
 import { AppState } from "./AppState";
 import { DefaultComponentProps, DefaultRootFieldProps } from "./Props";
-import { Permissions } from "./API";
+import { Permissions, RenderOverrides } from "./API";
 import { DropZoneProps } from "../components/DropZone/types";
 import {
   AssertHasValue,
@@ -175,6 +175,7 @@ type ConfigInternal<
     >;
   };
   root?: RootConfigInternal<RootProps, UserField>;
+  overrides?: RenderOverrides;
 };
 
 // This _deliberately_ casts as any so the user can pass in something that widens the types


### PR DESCRIPTION
We would like to use Puck in React Native project that uses [react-native-web](https://github.com/necolas/react-native-web). Requirements were that editor works on web only, but rendering the JSON with `<Render>` should work cross-platform.

Issue is that internally Puck renders `<div>` elements that do not work on native platforms. This was solved by adding `overrides` to config for rendering div – similar to how you can already override parts of the editor UI.

Now divs can be replaced with `<View>` on native platforms by providing config like this to `<Render>`

```
import { View } from 'react-native';

const config = {
  components: { ... },
  overrides: {
    slot: props => {
      return <View {...props} />;
    }
  }
}
```

Another issue that caused app to crash on native platforms when importing anything from `@measured/puck` was in `bubble-pointer-events.ts` which tried to use `Event` interface, but it's not defined in native environment. This interface was simply shimmed to prevent crash since I believe it's relevant for editor only.

These changes allowed us to use Puck in our React Native project successfully.
