### PR TITLE
feat: add hiddenLabelIcon prop to AutoField components

### DIFF
--- a/packages/core/components/AutoField/fields/ArrayField/index.tsx
+++ b/packages/core/components/AutoField/fields/ArrayField/index.tsx
@@ -27,6 +27,7 @@ export const ArrayField = ({
   readOnly,
   id,
   Label = (props) => <div {...props} />,
+  hiddenLabelIcon,
 }: FieldPropsInternal) => {
   const thisArrayState = useAppStore((s) => s.state.ui.arrayState[id]);
   const setUi = useAppStore((s) => s.setUi);
@@ -162,6 +163,7 @@ export const ArrayField = ({
       icon={labelIcon || <List size={16} />}
       el="div"
       readOnly={readOnly}
+      hiddenLabelIcon={hiddenLabelIcon}
     >
       <SortableProvider
         onDragStart={(id) => setDraggedItem(id)}

--- a/packages/core/components/AutoField/fields/DefaultField/index.tsx
+++ b/packages/core/components/AutoField/fields/DefaultField/index.tsx
@@ -15,6 +15,7 @@ export const DefaultField = ({
   labelIcon,
   Label,
   id,
+  hiddenLabelIcon,
 }: FieldPropsInternal) => {
   const value = _value as string | number | undefined | null;
 
@@ -30,6 +31,7 @@ export const DefaultField = ({
         )
       }
       readOnly={readOnly}
+      hiddenLabelIcon={hiddenLabelIcon}
     >
       <input
         className={getClassName("input")}

--- a/packages/core/components/AutoField/fields/ExternalField/index.tsx
+++ b/packages/core/components/AutoField/fields/ExternalField/index.tsx
@@ -18,6 +18,7 @@ export const ExternalField = ({
   Label,
   id,
   readOnly,
+  hiddenLabelIcon,
 }: FieldPropsInternal) => {
   // DEPRECATED
   const validField = field as ExternalFieldType;
@@ -40,6 +41,7 @@ export const ExternalField = ({
       label={label || name}
       icon={labelIcon || <Link size={16} />}
       el="div"
+      hiddenLabelIcon={hiddenLabelIcon}
     >
       <ExternalInput
         name={name}

--- a/packages/core/components/AutoField/fields/ObjectField/index.tsx
+++ b/packages/core/components/AutoField/fields/ObjectField/index.tsx
@@ -16,6 +16,7 @@ export const ObjectField = ({
   Label,
   readOnly,
   id,
+  hiddenLabelIcon,
 }: FieldPropsInternal) => {
   const { readOnlyFields, localName = name } = useNestedFieldContext();
 
@@ -31,6 +32,7 @@ export const ObjectField = ({
       icon={labelIcon || <MoreVertical size={16} />}
       el="div"
       readOnly={readOnly}
+      hiddenLabelIcon={hiddenLabelIcon}
     >
       <div className={getClassName()}>
         <fieldset className={getClassName("fieldset")}>

--- a/packages/core/components/AutoField/fields/RadioField/index.tsx
+++ b/packages/core/components/AutoField/fields/RadioField/index.tsx
@@ -15,6 +15,7 @@ export const RadioField = ({
   label,
   labelIcon,
   Label,
+  hiddenLabelIcon,
 }: FieldPropsInternal) => {
   if (field.type !== "radio" || !field.options) {
     return null;
@@ -26,6 +27,7 @@ export const RadioField = ({
       label={label || name}
       readOnly={readOnly}
       el="div"
+      hiddenLabelIcon={hiddenLabelIcon}
     >
       <div className={getClassName("radioGroupItems")} id={id}>
         {field.options.map((option) => (

--- a/packages/core/components/AutoField/fields/SelectField/index.tsx
+++ b/packages/core/components/AutoField/fields/SelectField/index.tsx
@@ -15,6 +15,7 @@ export const SelectField = ({
   name,
   readOnly,
   id,
+  hiddenLabelIcon,
 }: FieldPropsInternal) => {
   if (field.type !== "select" || !field.options) {
     return null;
@@ -25,6 +26,7 @@ export const SelectField = ({
       label={label || name}
       icon={labelIcon || <ChevronDown size={16} />}
       readOnly={readOnly}
+      hiddenLabelIcon={hiddenLabelIcon}
     >
       <select
         id={id}

--- a/packages/core/components/AutoField/fields/TextareaField/index.tsx
+++ b/packages/core/components/AutoField/fields/TextareaField/index.tsx
@@ -15,12 +15,14 @@ export const TextareaField = ({
   labelIcon,
   Label,
   id,
+  hiddenLabelIcon,
 }: FieldPropsInternal) => {
   return (
     <Label
       label={label || name}
       icon={labelIcon || <Type size={16} />}
       readOnly={readOnly}
+      hiddenLabelIcon={hiddenLabelIcon}
     >
       <textarea
         id={id}

--- a/packages/core/components/AutoField/index.tsx
+++ b/packages/core/components/AutoField/index.tsx
@@ -36,6 +36,7 @@ export const FieldLabel = ({
   el = "label",
   readOnly,
   className,
+  hiddenLabelIcon,
 }: {
   children?: ReactNode;
   icon?: ReactNode;
@@ -43,12 +44,17 @@ export const FieldLabel = ({
   el?: "label" | "div";
   readOnly?: boolean;
   className?: string;
+  hiddenLabelIcon?: boolean;
 }) => {
   const El = el;
   return (
     <El className={className}>
       <div className={getClassName("label")}>
-        {icon ? <div className={getClassName("labelIcon")}>{icon}</div> : <></>}
+        {!hiddenLabelIcon && icon ? (
+          <div className={getClassName("labelIcon")}>{icon}</div>
+        ) : (
+          <></>
+        )}
         {label}
 
         {readOnly && (
@@ -68,6 +74,7 @@ type FieldLabelPropsInternal = {
   label?: string;
   el?: "label" | "div";
   readOnly?: boolean;
+  hiddenLabelIcon?: boolean;
 };
 
 export const FieldLabelInternal = ({
@@ -76,6 +83,7 @@ export const FieldLabelInternal = ({
   label,
   el = "label",
   readOnly,
+  hiddenLabelIcon,
 }: FieldLabelPropsInternal) => {
   const overrides = useAppStore((s) => s.overrides);
 
@@ -95,6 +103,7 @@ export const FieldLabelInternal = ({
       className={getClassName({ readOnly })}
       readOnly={readOnly}
       el={el}
+      hiddenLabelIcon={hiddenLabelIcon}
     >
       {children}
     </Wrapper>
@@ -108,6 +117,7 @@ type FieldPropsInternalOptional<ValueType = any, F = Field<any>> = FieldProps<
   Label?: React.FC<FieldLabelPropsInternal>;
   label?: string;
   labelIcon?: ReactNode;
+  hiddenLabelIcon?: boolean;
   name?: string;
 };
 
@@ -118,6 +128,7 @@ export type FieldPropsInternal<ValueType = any, F = Field<any>> = FieldProps<
   Label: React.FC<FieldLabelPropsInternal>;
   label?: string;
   labelIcon?: ReactNode;
+  hiddenLabelIcon?: boolean;
   id: string;
   name?: string;
 };
@@ -151,6 +162,7 @@ function AutoFieldInternal<
   const field = props.field as Field<ValueType>;
   const label = field.label;
   const labelIcon = field.labelIcon;
+  const hiddenLabelIcon = field.hiddenLabelIcon;
 
   const defaultId = useSafeId();
   const resolvedId = id || defaultId;
@@ -176,10 +188,11 @@ function AutoFieldInternal<
       field,
       label,
       labelIcon,
+      hiddenLabelIcon,
       Label,
       id: resolvedId,
     }),
-    [props, field, label, labelIcon, Label, resolvedId]
+    [props, field, label, labelIcon, hiddenLabelIcon, Label, resolvedId]
   );
 
   const onFocus = useCallback(

--- a/packages/core/types/Fields.ts
+++ b/packages/core/types/Fields.ts
@@ -11,6 +11,7 @@ type FieldOptions = Array<FieldOption> | ReadonlyArray<FieldOption>;
 export interface BaseField {
   label?: string;
   labelIcon?: ReactElement;
+  hiddenLabelIcon?: boolean;
   metadata?: FieldMetadata;
   visible?: boolean;
 }


### PR DESCRIPTION
This PR introduces the optional `hiddenLabelIcon` prop to all AutoField components. When enabled, it allows hiding the label icon for fields where it’s not needed. Existing behavior stays the same if the prop isn’t used.