### PR TITLE
fix: update Radio component styles and enhance FieldOption type to support ReactNode

### DIFF
--- a/apps/docs/pages/docs/api-reference/fields/radio.mdx
+++ b/apps/docs/pages/docs/api-reference/fields/radio.mdx
@@ -60,7 +60,7 @@ const config = {
 
 ### `type`
 
-The type of the field. Must be `"radio"` for Array fields.
+The type of the field. Must be `"radio"` for Radio fields.
 
 ```tsx {6} copy
 const config = {


### PR DESCRIPTION
`<RadioField />` can now support icons.

<img width="317" height="96" alt="exemple-radio" src="https://github.com/user-attachments/assets/d14f124e-76b8-44ce-9793-ba4b69a0fafc" />