### PR TITLE
Feature/puck issue 1403 custom overrides

### DIFF
--- a/packages/core/components/AutoField/index.tsx
+++ b/packages/core/components/AutoField/index.tsx
@@ -221,10 +221,9 @@ function AutoFieldInternal<
     return (_props: any) => null;
   }, [field.type]);
 
-
   let FieldComponent: React.ComponentType<any> = useMemo(() => {
     // if there's an override provided for custom fields, fallback to standard behavior
-    if (field.type === 'custom' && !render[field.type]) {
+    if (field.type === "custom" && !render[field.type]) {
       if (!field.render) {
         return null;
       }


### PR DESCRIPTION
A simple change to allow "custom" to be overwritten from the overrides section.

Closes: [issue](https://github.com/puckeditor/puck/issues/1403)

Now you can simply provide an override for the "custom" field type, and then re-render it manually:

```
export const createPuckOverridesPlugin = () => {
  return {
    overrides: {
      fieldTypes: {
        custom:(props) => {
             return <>Field for: {props.name} -  {props.field.render(props)}</>
        },
    },
  };
};
```