### PR TITLE
Memoize initialHistoryIndex and check the index provided by the user is not out of bounds

### DIFF
--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -295,8 +295,17 @@ function PuckProvider<
     })
   );
 
-  const initialHistoryIndex =
-    _initialHistory?.index || blendedHistories.length - 1;
+  const initialHistoryIndex = useMemo(() => {
+    if (
+      _initialHistory?.index !== undefined &&
+      _initialHistory?.index >= 0 &&
+      _initialHistory?.index < blendedHistories.length
+    ) {
+      return _initialHistory?.index;
+    }
+
+    return blendedHistories.length - 1;
+  }, []);
   const initialAppState = blendedHistories[initialHistoryIndex].state;
 
   // Load all plugins into the overrides


### PR DESCRIPTION
Closes #1406.

This PR adds a safety check to ensure the initial history index provided by the user is within the bounds of the history array. It also memoizes the initial history index to avoid reacting to changes, since we don’t currently support live updates to the initial history, a changing index could cause issues.

I believe checking that the index is within range is necessary. Whether we want to support reacting to index changes is up for discussion. That said, since this is the **initial** history, I think it makes sense to keep it static. I'm open to removing the `useMemo` if we decide otherwise.

Either way, this fix resolves the issue reported in #1406.

## Changes made

- Added a safety check to ensure the initial history index is within the range of the blended histories array.
- Memoized the initial history index to prevent unintended re-evaluation on prop changes.

## Manual tests

- Confirmed that changes to the initial history index are not picked up by the `Puck` component after initialization.
