### PR TITLE
Use latest item position to correctly resolve data after component insert

### DIFF
--- a/packages/core/components/DragDropContext/index.tsx
+++ b/packages/core/components/DragDropContext/index.tsx
@@ -353,7 +353,7 @@ const DragDropContextClient = ({
                     thisPreview.componentType,
                     thisPreview.zone,
                     thisPreview.index,
-                    appStore.getState()
+                    appStore
                   );
                 } else if (initialSelector.current) {
                   dispatch({

--- a/packages/core/lib/__tests__/insert-component.spec.tsx
+++ b/packages/core/lib/__tests__/insert-component.spec.tsx
@@ -80,7 +80,7 @@ describe("use-insert-component", () => {
     });
 
     it("should dispatch the insert action", async () => {
-      insertComponent("MyComponent", rootDroppableId, 0, appStore.getState());
+      insertComponent("MyComponent", rootDroppableId, 0, appStore);
 
       expect(dispatchedEvents[0]).toEqual<PuckAction>({
         type: "insert",
@@ -93,7 +93,7 @@ describe("use-insert-component", () => {
     });
 
     it("should dispatch the setUi action, and select the item", async () => {
-      insertComponent("MyComponent", rootDroppableId, 0, appStore.getState());
+      insertComponent("MyComponent", rootDroppableId, 0, appStore);
 
       expect(dispatchedEvents[1]).toEqual<PuckAction>({
         type: "setUi",
@@ -107,7 +107,7 @@ describe("use-insert-component", () => {
     });
 
     it("should run any resolveData methods on the inserted item", async () => {
-      insertComponent("MyComponent", rootDroppableId, 0, appStore.getState());
+      insertComponent("MyComponent", rootDroppableId, 0, appStore);
 
       expect(resolvedDataEvents[0]).toEqual({
         type: "MyComponent",


### PR DESCRIPTION
Closes #1421

## Description

This PR fixes an issue where moving a component during a long `resolveData` operation after insertion caused the resolved data to be applied to the wrong component. The bug occurred because the update logic assumed the `itemSelector` remained static during resolution, leading to stale state references when a component was moved before the promise resolved.

With this fix, the latest component position is now retrieved dynamically before applying resolved data, ensuring the update always targets the correct component, even if it was moved during resolution.

## Changes made

- Updated `insertComponent` to use the latest item selector from the current state before applying resolved data.
  - `insertComponent` now receives the app store API instead of the app store state so that it can access the latest state on demand using `getState`.
- Adjusted related tests in `insert-component.spec.tsx` to match the updated function signature and store API usage.
- Changed `DragAndDropContext` to match the updated function signature and store API usage.
- Minor refactor of `insertComponent` to improve readibility.

## How to test

1. Use a Puck config with a component that has a long `resolveData` promise, such as:

  ```tsx
   export const conf = {
     components: {
       Test: {
         fields: { text: { type: "text" } },
         resolveData: async (data) => {
           const someResolveValue = await new Promise((res) =>
             setTimeout(() => res(Math.floor(Math.random() * 100)), 10000)
           );
           return {
             ...data,
             props: { ...data.props, text: `${data.props.text} - Resolved: ${someResolveValue}` },
           };
         },
         defaultProps: { text: "Test" },
         render: ({ text }) => <h1>{text}</h1>,
       },
       Heading: {
         fields: { title: { type: "text" } },
         defaultProps: { title: "Heading" },
         render: ({ title }) => <h1>{title}</h1>,
       },
     },
   };
  ```
2. Open the Puck editor with this config.
3. Add two `Heading` components.
4. Insert a `Test` component at the end.
5. While `resolveData` is still pending, move the `Test` component to the first position.
6. Verify that:
  a. No error appears in the console.
  b. The resolved data is applied to the correct Test component.


https://github.com/user-attachments/assets/42f7374e-d004-4ac5-8d24-cccf10f6b07d

