### PR TITLE
fix: memoize assignRefs to prevent max-depth error

### DIFF
--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -463,6 +463,13 @@ export const DropZoneEdit = forwardRef<HTMLDivElement, DropZoneProps>(
       ref,
     });
 
+    const setRefs = useCallback(
+      (node: any) => {
+        assignRefs<any>([ref, dropRef, userRef], node);
+      },
+      [dropRef]
+    );
+
     const El = as ?? "div";
 
     return (
@@ -475,9 +482,7 @@ export const DropZoneEdit = forwardRef<HTMLDivElement, DropZoneProps>(
           hasChildren: contentIds.length > 0,
           isAnimating,
         })}${className ? ` ${className}` : ""}`}
-        ref={(node: any) => {
-          assignRefs<any>([ref, dropRef, userRef], node);
-        }}
+        ref={setRefs}
         data-testid={`dropzone:${zoneCompound}`}
         data-puck-dropzone={zoneCompound}
         style={


### PR DESCRIPTION
Closes #1440 

<!--
  Replace XXXX with the actual issue number this PR closes.
  Every PR should be linked to an issue.
  PRs without an issue may take longer to review or may be closed as non-actionable.
-->

## Description

This PR adds fixes the max-depth error when adding a drag ref to slots on the canary.

```
Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.
```

<!--
  Include a concise and clear description of what this PR does.
  Mention any considerations or reasons behind the changes.
  Highlight any breaking changes.
  Keep the explanation centered around Puck.
 -->

## Changes made

-  Wrapped assignRefs for slots in a useCallback.

<!--
  List the key changes made and the reasons behind them.
 -->

## How to test

- Render the Puck editor with a config that uses a slot field and inline mode, passing the dragRef to the slot render function or component:

```tsx
export const config = {
  components: {
    SomeSlot: {
      fields: {
        content: { type: "slot" },
      },
      inline: true,
      render: ({ content: Content, puck }) => (
        <Content style={{ height: "fit-content" }} ref={puck.dragRef} />
      ),
    },
  },
};
```
Drag and drop a SomeSlot component and see no errors. 
<!--
  List any manual tests you did to verify the behavior of the changes.
  Add any media or screenshots that may help verify the outcome.
 -->
