### PR TITLE
fix: add optional ref prop to DropZones and slots

### DIFF
--- a/packages/core/components/DropZone/types.ts
+++ b/packages/core/components/DropZone/types.ts
@@ -1,4 +1,4 @@
-import { CSSProperties, ElementType } from "react";
+import { CSSProperties, ElementType, Ref } from "react";
 import { DragAxis } from "../../types";
 
 export type DropZoneProps = {
@@ -10,4 +10,5 @@ export type DropZoneProps = {
   className?: string;
   collisionAxis?: DragAxis;
   as?: ElementType;
+  ref?: Ref<any>;
 };


### PR DESCRIPTION
Closes #1439

## Description

This PR fixes a type issue where refs were not accepted in Slot render functions or DropZones, which did not match internal or documented behavior.

## Changes made

- The `DropZoneProps` type now includes an optional `ref` prop.

## How to test

1. Define a component that uses a slot and pass a ref to that slot:

```tsx
SomeSlot: {
  fields: {
    content: { type: "slot" },
  },
  render: ({ content: Content }) => {
    const ref = useRef<HTMLDivElement>(null);

    return <Content ref={ref} />;
  },
},
```

2. Confirm that TypeScript does not throw an error.
