### PR TITLE
Eliminate re-rendering of components when hovered in the canvas

### DIFF
--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -52,6 +52,7 @@ import { getSlotTransform } from "../../lib/field-transforms/default-transforms/
 import { getRichTextTransform } from "../../lib/field-transforms/default-transforms/rich-text-transform";
 import { FieldTransforms } from "../../types/API/FieldTransforms";
 import { useRichtextProps } from "../RichTextEditor/lib/use-richtext-props";
+import { MemoizeComponent } from "../MemoizeComponent";
 
 const getClassName = getClassNameFactory("DropZone", styles);
 
@@ -223,7 +224,7 @@ const DropZoneChild = ({
 
   if (!item) return;
 
-  let Render = componentConfig
+  const Render = componentConfig
     ? componentConfig.render
     : () => (
         <div style={{ padding: 48, textAlign: "center" }}>
@@ -253,15 +254,13 @@ const DropZoneChild = ({
       {(dragRef) => {
         if (componentConfig?.inline && !isInserting) {
           return (
-            <>
-              <Render
-                {...transformedProps}
-                puck={{
-                  ...transformedProps.puck,
-                  dragRef,
-                }}
-              />
-            </>
+            <MemoizeComponent
+              Component={Render}
+              componentProps={{
+                ...transformedProps,
+                puck: { ...transformedProps.puck, dragRef },
+              }}
+            />
           );
         }
 
@@ -276,7 +275,10 @@ const DropZoneChild = ({
                 }
               />
             ) : (
-              <Render {...transformedProps} />
+              <MemoizeComponent
+                Component={Render}
+                componentProps={transformedProps}
+              />
             )}
           </div>
         );

--- a/packages/core/components/MemoizeComponent/index.tsx
+++ b/packages/core/components/MemoizeComponent/index.tsx
@@ -1,0 +1,27 @@
+import { deepEqual } from "fast-equals";
+import { ComponentType, memo } from "react";
+import { shallowEqual } from "../../lib/shallow-equal";
+
+const RenderComponent = ({
+  Component,
+  componentProps: renderProps,
+}: {
+  Component: ComponentType<any>;
+  componentProps: any;
+}) => {
+  return <Component {...renderProps} />;
+};
+
+/**　Renders the Component and only re-renders when its props change using shallow comparison. Uses deep comparison for the "puck" prop. */
+export const MemoizeComponent = memo(RenderComponent, (prev, next) => {
+  let puckEquals = true;
+  if ("puck" in prev.componentProps && "puck" in next.componentProps) {
+    puckEquals = deepEqual(prev.componentProps.puck, next.componentProps.puck);
+  }
+
+  return (
+    prev.Component === next.Component &&
+    shallowEqual(prev.componentProps, next.componentProps, ["puck"]) &&
+    puckEquals
+  );
+});

--- a/packages/core/lib/shallow-equal.ts
+++ b/packages/core/lib/shallow-equal.ts
@@ -1,0 +1,48 @@
+/**
+ * Does a shallow equality check between two objects, ignoring specified keys.
+ * @returns true if the objects are shallowly equal (excluding ignored keys), false otherwise.
+ */
+export function shallowEqual(
+  obj1: any,
+  obj2: any,
+  keysToIgnore: readonly string[] = []
+): boolean {
+  // Quick reference/value check
+  if (Object.is(obj1, obj2)) return true;
+
+  // Check for null and non-objects
+  if (
+    typeof obj1 !== "object" ||
+    obj1 === null ||
+    typeof obj2 !== "object" ||
+    obj2 === null
+  ) {
+    return false;
+  }
+
+  // Guard against non-POJO false positives (e.g., Date, RegExp)
+  if (Object.getPrototypeOf(obj1) !== Object.getPrototypeOf(obj2)) {
+    return false;
+  }
+
+  const ignore = new Set(keysToIgnore);
+
+  const keys1 = Object.keys(obj1).filter((k) => !ignore.has(k));
+  const keys2 = Object.keys(obj2).filter((k) => !ignore.has(k));
+
+  if (keys1.length !== keys2.length) return false;
+
+  for (let i = 0; i < keys1.length; i++) {
+    const currKey = keys1[i];
+
+    // Check if obj2 has the key
+    if (!Object.prototype.hasOwnProperty.call(obj2, currKey)) return false;
+
+    // Check if values are the same
+    const val1 = obj1[currKey];
+    const val2 = obj2[currKey];
+    if (!Object.is(val1, val2)) return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
Closes #1442

## Description

This PR fixes a performance issue where components re-rendered when hovered over in the canvas.

## Changes made

- The `renderPreview` function in `DropZoneChild` was moved to its own component to simplify the code and avoid remounting and unnecessary re-renders.
- The `DropZoneChild` component now uses `MemoizeComponent` to render user components. This component accepts two props: the component to render, and the props to pass to it. It memoizes the rendering by only re-rendering when the props change, using shallow comparison for general props and deep comparison for the `puck` prop. This approach was chosen because user props can be large and deeply nested, making deep equality checks costly. For solving the hover-related re-renders, this level of optimization was enough.
- A new `shallowEqual` utility was introduced to check for shallow equality between two objects.

## How to test

1. Render the Puck editor with a config that uses slots:

```tsx
const config = {
  components: {
    Slot: {
      fields: { items: { type: "slot" } },
      render: ({ items: Items }) => {
        console.log("Re-rendering Slot");
        return <Items />;
      }
    },
    Heading: {
      fields: { title: { type: "text" } },
      defaultProps: { title: "Heading" },
      render: ({ title }) => {
        console.log("Re-rendering Heading");
        return <h1>{title}</h1>;
      }
    }
  }
};
```

2. Navigate to the editor.  
3. Open the devtools console.  
4. Drag and drop a `Slot`.  
5. Drag and drop two `Heading` components inside the `Slot`.  
6. Hover over the `Slot` component.  
7. Watch the console.  
8. Confirm that no re-rendering logs are printed.

https://github.com/user-attachments/assets/72099349-fc6f-4831-9a3c-fbe318dea87f
