### PR TITLE
fix: prevent infinite loop with nested richtext fields

### DIFF
--- a/packages/core/components/AutoField/fields/ObjectField/index.tsx
+++ b/packages/core/components/AutoField/fields/ObjectField/index.tsx
@@ -61,6 +61,10 @@ export const ObjectField = ({
                   }}
                   value={data[subName]}
                   onChange={(val, ui) => {
+                    // Skip onChange if value hasn't changed to prevent infinite loop
+                    if (data[subName] === val) {
+                      return;
+                    }
                     onChange(
                       {
                         ...data,


### PR DESCRIPTION
Fixes issue with richtext fields and potentially other field types.

Closes [#1457](https://github.com/puckeditor/puck/issues/1457)


## Description

This PR fixes an infinite re-render loop in `ObjectField` when using nested `richtext` fields (and potentially other field types with side effects).

**Root cause:** `ObjectField` always creates new object references via spread operator, even when values haven't changed. This triggers unnecessary re-renders, causing fields with effects (like richtext) to loop infinitely.


## Changes made

- Added value comparison in `ObjectField`'s `onChange` handler
- Skips update when `data[subName] === val`

Non-breaking change, fully backward compatible.


## How to test

Create a component with this structure and try editing the richtext fields:
```
{
  fields: {
    content: {
      type: "object",
      objectFields: {
        title: { type: "text", contentEditable: true },
        subtitle: { type: "richtext", contentEditable: true },
        description: { type: "richtext", contentEditable: true }
      }
    }
  }
}
```

**Before this fix:** Infinite loop error when editing richtext fields
**After this fix:** Fields work correctly

See: https://github.com/asterixcapri/puck/commit/6bf62dfcd184eb0204e4d586615bffceb380e8f2