### PR TITLE
chore: reset richtext text-align in case parent changes value

### DIFF
--- a/packages/core/components/RichTextEditor/styles.module.css
+++ b/packages/core/components/RichTextEditor/styles.module.css
@@ -59,6 +59,7 @@
   font-family: inherit;
   font-size: var(--puck-font-size-xxs);
   resize: vertical;
+  text-align: initial;
   transition: border-color 50ms ease-in;
   width: 100%;
   max-width: 100%;


### PR DESCRIPTION
This occurs on the homepage demo 
<img width="296" height="292" alt="image" src="https://github.com/user-attachments/assets/095877a5-90c8-40ed-bf53-522a725908e9" />
