### PR TITLE
Index-based plugin ordering

### DIFF
--- a/apps/demo/next-env.d.ts
+++ b/apps/demo/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/docs/pages/docs/api-reference/data-model/app-state.mdx
+++ b/apps/docs/pages/docs/api-reference/data-model/app-state.mdx
@@ -104,11 +104,11 @@ Current width of the left side bar in pixels.
 
 | Param                         | Example    | Type   |
 | ----------------------------- | ---------- | ------ |
-| [`current`](#uiplugincurrent) | `"blocks:` | String |
+| [`current`](#uiplugincurrent) | `0` | Number |
 
 #### `ui.plugin.current`
 
-The currently visible plugin. Matches the plugin `name` parameter.
+Zero-based index of the currently visible plugin. It maps to the order of the resolved plugin list (defaults first unless you override the order via the `plugins` prop).
 
 ---
 

--- a/packages/core/components/Puck/components/Nav/index.tsx
+++ b/packages/core/components/Puck/components/Nav/index.tsx
@@ -44,14 +44,14 @@ export const Nav = ({
   items,
   mobileActions,
 }: {
-  items: Record<string, MenuItem>;
+  items: (MenuItem & { id: string })[];
   mobileActions?: ReactNode;
 }) => {
   return (
     <nav className={getClassName()}>
       <ul className={getClassName("list")}>
-        {Object.entries(items).map(([key, item]) => (
-          <MenuItem key={key} {...item} />
+        {items.map(({ id, ...item }) => (
+          <MenuItem key={id} {...item} />
         ))}
       </ul>
       {mobileActions && (

--- a/packages/core/plugins/blocks/index.tsx
+++ b/packages/core/plugins/blocks/index.tsx
@@ -1,9 +1,9 @@
 import { Hammer } from "lucide-react";
-import { Plugin } from "../../types";
+import { PluginInternal } from "../../types/Internal";
 import { Components } from "../../components/Puck/components/Components";
 
-export const blocksPlugin: () => Plugin = () => ({
-  name: "blocks",
+export const blocksPlugin: () => PluginInternal = () => ({
+  __name: "blocks",
   label: "Blocks",
   render: Components,
   icon: <Hammer />,

--- a/packages/core/plugins/fields/index.tsx
+++ b/packages/core/plugins/fields/index.tsx
@@ -23,7 +23,7 @@ const CurrentTitle = () => {
 export const fieldsPlugin: (params?: {
   mobileOnly?: boolean;
 }) => PluginInternal = ({ mobileOnly = true } = {}) => ({
-  name: "fields",
+  __name: "fields",
   label: "Fields",
   render: () => (
     <div className={getClassName()}>

--- a/packages/core/plugins/legacy-side-bar/index.tsx
+++ b/packages/core/plugins/legacy-side-bar/index.tsx
@@ -1,10 +1,10 @@
-import { Plugin } from "../../types";
+import { PluginInternal } from "../../types/Internal";
 import { Components } from "../../components/Puck/components/Components";
 import { Outline } from "../../components/Puck/components/Outline";
 import { SidebarSection } from "../../components/SidebarSection";
 
-export const legacySideBarPlugin: () => Plugin = () => ({
-  name: "legacy-side-bar",
+export const legacySideBarPlugin: () => PluginInternal = () => ({
+  __name: "legacy-side-bar",
   render: () => (
     <div style={{ overflowY: "auto" }}>
       <SidebarSection title="Components" noBorderTop>

--- a/packages/core/plugins/outline/index.tsx
+++ b/packages/core/plugins/outline/index.tsx
@@ -1,9 +1,9 @@
 import { Layers } from "lucide-react";
 import { Outline } from "../../components/Puck/components/Outline";
-import { Plugin } from "../../types";
+import { PluginInternal } from "../../types/Internal";
 
-export const outlinePlugin: () => Plugin = () => ({
-  name: "outline",
+export const outlinePlugin: () => PluginInternal = () => ({
+  __name: "outline",
   label: "Outline",
   render: Outline,
   icon: <Layers />,

--- a/packages/core/types/API/index.ts
+++ b/packages/core/types/API/index.ts
@@ -28,7 +28,6 @@ export type OnAction<UserData extends Data = Data> = (
 ) => void;
 
 export type Plugin<UserConfig extends Config = Config> = {
-  name?: string;
   label?: string;
   icon?: ReactNode;
   render?: () => ReactElement;

--- a/packages/core/types/AppState.tsx
+++ b/packages/core/types/AppState.tsx
@@ -39,7 +39,7 @@ export type UiState = {
   };
   field: { focus?: string | null; metadata?: Record<string, any> };
   plugin: {
-    current: string | null;
+    current: number | null;
   };
 };
 

--- a/packages/core/types/Internal.tsx
+++ b/packages/core/types/Internal.tsx
@@ -103,6 +103,7 @@ export type RenderFunc<
 > = (props: Props) => ReactElement;
 
 export type PluginInternal = Plugin & {
+  __name?: string;
   mobileOnly?: boolean;
   desktopOnly?: boolean;
 };


### PR DESCRIPTION
## Description

This PR removes the public plugin `name` prop in favor of internal indexes so downstream apps can reorder/override the default plugins deterministically without worrying about collisions. It also updates the docs/demo to reflect the new API surface.

## Changes made

- switch plugin resolution/state to rely on indexes and private `__name` identifiers
- update default plugins plus docs/demo to match the new behavior and ordering expectations

## How to test

- Load the demo editor with a custom `plugins` array (e.g. placing `fieldsPlugin` first) and confirm the side bar ordering plus active tab toggling matches the array order
- Toggle between plugins and verify `ui.plugin.current` remains a zero-based index in the app state inspector
