### PR TITLE
Allow custom root label in breadcrumb navigation

### DIFF
--- a/packages/core/lib/use-breadcrumbs.ts
+++ b/packages/core/lib/use-breadcrumbs.ts
@@ -21,7 +21,7 @@ export const useBreadcrumbs = (renderCount?: number) => {
 
         if (componentId === "root") {
           return {
-            label: config?.root?.label ||"Page",
+            label: config?.root?.label || "Page",
             selector: null,
           };
         }


### PR DESCRIPTION
## Description

This PR adds support for customizing the **root breadcrumb label** in the Puck editor.
Instead of always displaying the default `"Page"` label, the breadcrumb now respects an optional `config.root.label` value, allowing consumers to define a more meaningful or domain-specific root name.

## Changes made

* Updated breadcrumb generation logic to use `config.root.label` when the component ID is `"root"`.
* Preserved backward compatibility by defaulting to `"Page"` when no custom label is configured.

## How to test

* Configure a custom root label in the Puck config:

  ```ts
  const config = {
    root: {
      label: "My Custom Root",
    },
  };
  ```
* Open the editor and verify that the breadcrumb root displays **“My Custom Root”** instead of **“Page”**.
* Remove the custom label and confirm that the breadcrumb falls back to **“Page”**.