### PR TITLE
fix: Array fields show empty collapsible content even if there are no visible fields inside

### DIFF
--- a/packages/core/components/AutoField/fields/ArrayField/index.tsx
+++ b/packages/core/components/AutoField/fields/ArrayField/index.tsx
@@ -82,13 +82,23 @@ const ArrayFieldItemInternal = ({
     (s) => s.permissions.getPermissions({ item: s.selectedItem }).edit
   );
 
+  const hasVisibleFields = useMemo(() => {
+    if (!field.arrayFields) {
+      return false;
+    }
+
+    return Object.values(field.arrayFields).some(
+      (subField) => subField.type !== "slot" && subField.visible !== false
+    );
+  }, [field.arrayFields]);
+
   return (
     <Sortable id={id} index={dragIndex} disabled={readOnly}>
       {({ isDragging, ref, handleRef }) => (
         <div
           ref={ref}
           className={getClassNameItem({
-            isExpanded,
+            isExpanded: isExpanded && hasVisibleFields,
             isDragging,
             readOnly,
           })}
@@ -96,7 +106,7 @@ const ArrayFieldItemInternal = ({
           <div
             ref={handleRef}
             onClick={(e) => {
-              if (isDragging) return;
+              if (isDragging || !hasVisibleFields) return;
 
               e.preventDefault();
               e.stopPropagation();
@@ -116,7 +126,7 @@ const ArrayFieldItemInternal = ({
             </div>
           </div>
           <div className={getClassNameItem("body")}>
-            {isExpanded && (
+            {isExpanded && hasVisibleFields && (
               <fieldset className={getClassNameItem("fieldset")}>
                 {Object.keys(field.arrayFields!).map((subName) => {
                   const subField = field.arrayFields![subName];


### PR DESCRIPTION
### **Closes #1407**

## Description

This PR fixes an issue where array field items rendered an expandable/collapsible UI even when they contained no visible fields.


## Changes made

* Added a `hasVisibleFields` check to determine whether an array item contains any visible, non-slot fields
* Disabled expand/collapse behavior and actionable styling when no visible fields are present

## How to test

1. Render the Puck editor with a component that uses only slots inside an array field:

```ts
const config = {
  components: {
    Test: {
      fields: {
        columns: {
          type: "array",
          arrayFields: { items: { type: "slot" } },
          defaultItemProps: { items: [] },
        },
      },
      defaultProps: { columns: [] },
      render: ({ columns }) => (
        <div>
          {columns.map(({ items: Items }) => (
            <Items />
          ))}
        </div>
      ),
    },
  },
};

export const Editor = () => {
  return <Puck data={{}} config={config} />;
};
```

2. Run the application and open the editor
3. Drag the `Test` component into the canvas
4. Select the component and add items to the array field
5. Click on an array item and verify that:

   * Items with no visible fields do **not** expand
   * No empty collapsible content is shown
