### PR TITLE
fix: respect custom root label when no breadcrumb displayed

### DIFF
--- a/packages/core/components/Puck/components/Layout/index.tsx
+++ b/packages/core/components/Puck/components/Layout/index.tsx
@@ -35,7 +35,7 @@ const FieldSideBar = () => {
     s.selectedItem
       ? s.config.components[s.selectedItem.type]?.["label"] ??
         s.selectedItem.type.toString()
-      : "Page"
+      : s.config.root?.label || "Page"
   );
 
   return (


### PR DESCRIPTION
There was no associated issue. This is something I just discovered.

## Description

Similar to the change [here](https://github.com/puckeditor/puck/commit/de0baf3937f5c902472c97c03c59c994b20643e4), the root label was not being respected when the bread crumb control was not displayed.

## Changes made

When no component is selected in the outline, the label of the root component is now correctly displayed in the fields sidebar.

## How to test

```tsx
// Create Puck component config
const config:Config = {
  root: {
    label: 'asdf',
  },
  components: {
    HeadingBlock: {
      fields: {
        children: {
          type: "text",
        },
      },
      render: ({ children }) => {
        return <h1>{children}</h1>;
      },
    },
  },
};

// Describe the initial data
const initialData = {};
 
// Save the data to your database
const save = (data) => {};

function Component(props) {
    return <Puck config={config} data={initialData} onPublish={save} />
}
```

<!--
  List any manual tests you did to verify the behavior of the changes.
  Add any media or screenshots that may help verify the outcome.
 -->
