### PR TITLE
refactor: encode empty objects as strings to prevent stripping them

### DIFF
--- a/packages/core/lib/data/flatten-node.ts
+++ b/packages/core/lib/data/flatten-node.ts
@@ -19,7 +19,7 @@ function encodeEmptyObjects(props: Record<string, any> = {}) {
 
     const val = props[key];
 
-    if (Array.isArray(val)) {
+    if (Array.isArray(val) && val.length === 0) {
       result[key] = emptyArrayStr;
     } else if (isPureObject(val) && Object.keys(val).length === 0) {
       result[key] = emptyObjectStr;


### PR DESCRIPTION
Closes #1494 

## Description

a4bfae4f202ddaab12294cfffd2664d809e7cb54 stripped empty objects to prevent infinite renders in certain scenarios, but accidentally removed empty objects/arrays from expected scenarios.

Instead of stripping them, this approach encodes/decodes the empty objects as strings, solving the original re-rendering problem without losing the value.

## How to test

- Follow steps from #1494
- Also ensure no regressions by following test steps in https://github.com/puckeditor/puck/pull/1479
