### PR TITLE
Move `@measured/puck` mentions to `@puckeditor/core`

### DIFF
--- a/apps/docs/pages/docs/api-reference/components/puck-layout.mdx
+++ b/apps/docs/pages/docs/api-reference/components/puck-layout.mdx
@@ -10,7 +10,7 @@ import { Puck } from "@/puck";
 Render the standard Puck layout. This is useful for implementing behavior using the [internal Puck API](/docs/extending-puck/internal-puck-api) without changing the default UI.
 
 ```tsx {13} showLineNumbers copy
-import { Puck } from "@measured/puck";
+import { Puck } from "@puckeditor/core";
 
 const Example = ({ children }) => {
   useEffect(() => console.log("Hello, world"), []);

--- a/apps/docs/pages/docs/api-reference/plugins/blocks-plugin.mdx
+++ b/apps/docs/pages/docs/api-reference/plugins/blocks-plugin.mdx
@@ -7,7 +7,7 @@ title: blocksPlugin
 Show the component drawer for dragging new components onto the canvas.
 
 ```tsx copy
-import { Puck, blocksPlugin } from "@measured/puck";
+import { Puck, blocksPlugin } from "@puckeditor/core";
 
 const blocks = blocksPlugin();
 

--- a/apps/docs/pages/docs/api-reference/plugins/fields-plugin.mdx
+++ b/apps/docs/pages/docs/api-reference/plugins/fields-plugin.mdx
@@ -7,7 +7,7 @@ title: fieldsPlugin
 Show the fields for the currently selected component. On desktop, the fields will appear in the right-hand sidebar. On mobile, they will appear in the plugin rail.
 
 ```tsx copy
-import { Puck, fieldsPlugin } from "@measured/puck";
+import { Puck, fieldsPlugin } from "@puckeditor/core";
 
 const fields = fieldsPlugin();
 

--- a/apps/docs/pages/docs/api-reference/plugins/legacy-side-bar-plugin.mdx
+++ b/apps/docs/pages/docs/api-reference/plugins/legacy-side-bar-plugin.mdx
@@ -7,7 +7,7 @@ title: legacySideBarPlugin
 Hide the plugin rail and show a single sidebar with stacked "Components" and "Outline" sections. This will not affect mobile behavior.
 
 ```tsx copy
-import { Puck, legacySideBarPlugin } from "@measured/puck";
+import { Puck, legacySideBarPlugin } from "@puckeditor/core";
 
 const legacySideBar = legacySideBarPlugin();
 

--- a/apps/docs/pages/docs/api-reference/plugins/outline-plugin.mdx
+++ b/apps/docs/pages/docs/api-reference/plugins/outline-plugin.mdx
@@ -7,7 +7,7 @@ title: outlinePlugin
 Show an outline of the components currently on the canvas.
 
 ```tsx copy
-import { Puck, outlinePlugin } from "@measured/puck";
+import { Puck, outlinePlugin } from "@puckeditor/core";
 
 const outline = outlinePlugin();
 

--- a/apps/docs/pages/docs/extending-puck/plugins.mdx
+++ b/apps/docs/pages/docs/extending-puck/plugins.mdx
@@ -68,7 +68,7 @@ You can leverage the [internal Puck API](internal-puck-api) to integrate Puck be
 
 ```tsx showLineNumbers copy {2, 4, 10-14}
 import { Coffee } from "lucide-react";
-import { createUsePuck } from "@measured/puck";
+import { createUsePuck } from "@puckeditor/core";
 
 const usePuck = createUsePuck();
 


### PR DESCRIPTION
## Description

This PR removes some remaining `@measured/puck` imports from the docs snippets