### PR TITLE
fix(richtext): prevent focus race condition dropping dropdown changes

### DIFF
--- a/packages/core/components/RichTextEditor/lib/use-synced-editor.ts
+++ b/packages/core/components/RichTextEditor/lib/use-synced-editor.ts
@@ -56,12 +56,13 @@ export function useSyncedEditor({
     immediatelyRender: false,
     parseOptions: { preserveWhitespace: "full" },
     onUpdate: ({ editor }) => {
-      // This can trigger during undo/redo history loads
-      if (syncingRef.current || !isFocused) {
-        appStoreApi.getState().setUi({ field: { focus: name } });
-
+      // Skip during sync operations (undo/redo history loads)
+      if (syncingRef.current) {
         return;
       }
+
+      // Ensure focus state is tracked
+      appStoreApi.getState().setUi({ field: { focus: name } });
 
       const html = editor.getHTML();
 


### PR DESCRIPTION
## Summary

Remove the `isFocused` guard from the `onUpdate` callback to fix a race condition where dropdown control changes were silently dropped.

## Problem

When using dropdown controls (font size selector, color picker, heading selector), changes are not recognized by Puck's dirty state tracking:

1. User clicks dropdown → focus leaves editor
2. User selects option → command runs with `.focus()`
3. Tiptap's `onUpdate` fires synchronously
4. React's `isFocused` state is still stale (batched update)
5. Guard condition `!isFocused` is true → early return
6. Change is dropped, dirty indicator doesn't show

## Solution

Remove `!isFocused` from the guard condition. The `syncingRef.current` check is sufficient to prevent processing during undo/redo history loads.

```diff
- if (syncingRef.current || !isFocused) {
-   appStoreApi.getState().setUi({ field: { focus: name } });
-   return;
- }
+ if (syncingRef.current) {
+   return;
+ }
+ appStoreApi.getState().setUi({ field: { focus: name } });
```

## Test plan

- [ ] Apply bold/italic via keyboard shortcut → dirty state triggers
- [ ] Apply bold/italic via toolbar button → dirty state triggers
- [ ] Change heading via dropdown → dirty state triggers (was broken)
- [ ] Change font size via dropdown → dirty state triggers (was broken)
- [ ] Undo/redo still works correctly
- [ ] External content sync still works correctly

Closes #1516
