### PR TITLE
fix: nested RichText fields render on <Render/>

### DIFF
--- a/packages/core/components/RichTextEditor/lib/mapDeep.ts
+++ b/packages/core/components/RichTextEditor/lib/mapDeep.ts
@@ -1,0 +1,26 @@
+import { ReactNode } from "react";
+
+export const mapDeep = (
+  source: any,
+  path: string[],
+  render: (v: any) => ReactNode
+): any => {
+  if (!source) {
+    return null;
+  }
+
+  if (path.length === 0) {
+    return render(source);
+  }
+
+  const [key, ...rest] = path;
+
+  if (Array.isArray(source)) {
+    return source.map((item) => mapDeep(item, path, render));
+  }
+
+  return {
+    ...source,
+    [key]: mapDeep(source![key], rest, render),
+  };
+};

--- a/packages/core/components/RichTextEditor/lib/use-richtext-props.tsx
+++ b/packages/core/components/RichTextEditor/lib/use-richtext-props.tsx
@@ -1,5 +1,4 @@
 import { lazy, Suspense, useMemo } from "react";
-import type { ReactNode } from "react";
 import {
   BaseField,
   Fields,
@@ -7,6 +6,13 @@ import {
   WithPuckProps,
 } from "../../../types";
 import { RichTextRenderFallback } from "../components/RenderFallback";
+import { generateId } from "../../../lib/generate-id";
+import { mapDeep } from "./mapDeep";
+
+type RichtextPath = {
+  path: string[];
+  field: RichtextField;
+};
 
 export function useRichtextProps(
   fields:
@@ -21,15 +27,29 @@ export function useRichtextProps(
     fields:
       | Fields<any, {}>
       | Fields<any, { type: string } & BaseField>
-      | undefined
-  ): string[] => {
+      | undefined,
+    path: string[] = []
+  ): RichtextPath[] => {
     if (!fields) return [];
 
-    const result: string[] = [];
+    const result: RichtextPath[] = [];
 
     for (const [key, field] of Object.entries(fields)) {
+      const currentPath = [...path, key];
+
       if (field.type === "richtext") {
-        result.push(key);
+        result.push({
+          path: currentPath,
+          field: field as RichtextField,
+        });
+      }
+
+      if (field.type === "array" && "arrayFields" in field) {
+        result.push(...findAllRichtextKeys(field.arrayFields, currentPath));
+      }
+
+      if (field.type === "object" && "objectFields" in field) {
+        result.push(...findAllRichtextKeys(field.objectFields, currentPath));
       }
     }
 
@@ -47,17 +67,20 @@ export function useRichtextProps(
       }))
     );
 
-    return richtextKeys.reduce((acc, key) => {
-      acc[key] = (
-        <Suspense fallback={<RichTextRenderFallback content={props[key]} />}>
-          <RichTextRender
-            content={props[key]}
-            field={fields![key] as RichtextField}
-          />
+    let result = { ...props };
+
+    for (const { path, field } of richtextKeys) {
+      result = mapDeep(result, path, (content) => (
+        <Suspense
+          key={generateId()}
+          fallback={<RichTextRenderFallback content={content} />}
+        >
+          <RichTextRender content={content} field={field} />
         </Suspense>
-      );
-      return acc;
-    }, {} as Record<string, ReactNode>);
+      ));
+    }
+
+    return result;
   }, [richtextKeys, props, fields]);
 
   return richtextProps;


### PR DESCRIPTION
Closes [#1508](https://github.com/puckeditor/puck/issues/1508) 

## Description

This PR fix logic of useRichtextProps for working with nested fields like array or object to render <RichTextRender/> on page in <Render/>.

## Changes made

- The `useRichtextProps` hook now save path for nested objects and original field.
- The `useRichtextProps` now using `mapDeep` function for generate nested object with `<RichTextRender/>`

## How to test

1. Nested on Array.

- Add this component on config/index.ts:

```tsx
// config/block/Array.tsx
import React from "react";
import { withLayout, WithLayout } from "../../components/Layout";
import { ComponentConfig } from "@/core";
import { Section } from "../../components/Section";

export type ArrayProps = WithLayout<{
  items: {
    array?: {
      text: string;
    }[];
    text?: string;
  }[];
}>;

const ArrayInner: ComponentConfig<ArrayProps> = {
  fields: {
    items: {
      type: "array",
      arrayFields: {
        text: { type: "richtext" },
        array: {
          type: "array",
          arrayFields: {
            text: {
              type: "richtext",
            },
          },
        },
      },
    },
  },
  render: ({ items }) => {
    return (
      <Section>
        {items.map((item, i) => (
          <div key={i}>
            {item.text}
            <div>{item.array?.map((it) => it.text)}</div>
          </div>
        ))}
      </Section>
    );
  },
  defaultProps: {
    items: [{ text: "<p>Hello <strong>world</strong></p>" }],
  },
};

export const Array = withLayout(ArrayInner);

```

- Render the `Render` component with config with 'richtext' field nested on array

<img width="1152" height="975" alt="image" src="https://github.com/user-attachments/assets/6cf0a338-38cd-4c2a-b372-7f0f53f8026e" />

<img width="1507" height="884" alt="image" src="https://github.com/user-attachments/assets/d8bcffa1-b566-45dc-bc97-407e63eacf6b" />

2. Nested on Object

```tsx
// config/block/Object.tsx

import React from "react";
import { withLayout, WithLayout } from "../../components/Layout";
import { ComponentConfig } from "@/core";
import { Section } from "../../components/Section";
import { isArray } from "node:util";

export type ObjectProps = WithLayout<{
  item: {
    object?: {
      text: string;
    };
    text?: string;
  };
}>;

const ObjectInner: ComponentConfig<ObjectProps> = {
  fields: {
    item: {
      type: "object",
      objectFields: {
        text: { type: "richtext" },
        object: {
          type: "object",
          objectFields: {
            text: {
              type: "richtext",
            },
          },
        },
      },
    },
  },
  render: ({ item }) => {
    return (
      <Section>
        {
          <div>
            {item.text}
            <div>{item.object?.text}</div>
          </div>
        }
      </Section>
    );
  },
  defaultProps: {
    item: { text: "<p>Hello <strong>world</strong></p>" },
  },
};

export const ObjectComp = withLayout(ObjectInner);


```

- Render the `Render` component with config with 'richtext' field nested on object

<img width="1155" height="965" alt="image" src="https://github.com/user-attachments/assets/1623e77f-74f4-407b-9147-cb05c911141d" />

<img width="1519" height="977" alt="image" src="https://github.com/user-attachments/assets/23efac72-7d3a-487f-b168-65e228b8e0ee" />
