### PR TITLE
fix: improve plugin sorting to ensure consistent ordering

### DIFF
--- a/packages/core/components/Puck/components/Layout/index.tsx
+++ b/packages/core/components/Puck/components/Layout/index.tsx
@@ -192,10 +192,15 @@ export const Layout = ({ children }: { children?: ReactNode }) => {
 
     const defaultPlugins: PluginInternal[] = [blocksPlugin(), outlinePlugin()];
 
+    const isLegacy = (plugin: PluginInternal) =>
+      plugin.name === "legacy-side-bar" ? -1 : 0;
+
+    // Always place legacy-side-bar first
+    // Stable tie-break ensures consistent order for non-legacy plugins
     const combinedPlugins: PluginInternal[] = [
       ...defaultPlugins,
       ...(plugins ?? []),
-    ].sort((a) => (a.name === "legacy-side-bar" ? -1 : 1)); // Always place legacy-side-bar first
+    ].sort((a, b) => isLegacy(a) - isLegacy(b));
 
     if (!plugins?.some((p) => p.name === "fields")) {
       combinedPlugins.push(fieldsPlugin());


### PR DESCRIPTION
Closes #1509

<!--
  Replace XXXX with the actual issue number this PR closes.
  Every PR should be linked to an issue.
  PRs without an issue may take longer to review or may be closed as non-actionable.
-->

## Description

This PR makes the sort comparator function deterministic. Ensures consistent ordering in browsers. 

<!--
  Include a concise and clear description of what this PR does.
  Mention any considerations or reasons behind the changes.
  Highlight any breaking changes.
  Keep the explanation centered around Puck.
 -->

## Changes made

- The `Puck` component now receives an optional `style` prop and passes it to the editor `div` wrapper.

<!--
  List the key changes made and the reasons behind them.
 -->

## How to test

- If you run the demo app, and check the edit page on Firefox and Chrome, you'll see that the order of the blocks are the same.

<!--
  List any manual tests you did to verify the behavior of the changes.
  Add any media or screenshots that may help verify the outcome.
 -->
