### PR TITLE
fix: prevent block deletion on backspace key press in rich text

### DIFF
--- a/packages/core/components/RichTextEditor/components/EditorInner.tsx
+++ b/packages/core/components/RichTextEditor/components/EditorInner.tsx
@@ -49,6 +49,11 @@ export const EditorInner = memo(
           event.preventDefault();
           editor?.commands.toggleItalic?.();
         }
+
+        // Prevent event propagation for backspace. When propagated, it will trigger block deletion
+        if (event.key.toLowerCase() === "backspace") {
+          event.stopPropagation();
+        }
       },
       [editor]
     );


### PR DESCRIPTION
Closes #1529
