### PR TITLE
docs: add metadata parameter to resolveAllData function documentation

### DIFF
--- a/apps/docs/pages/docs/api-reference/functions/resolve-all-data.mdx
+++ b/apps/docs/pages/docs/api-reference/functions/resolve-all-data.mdx
@@ -16,15 +16,15 @@ This is useful if you need to run your resolvers before passing your data to [`<
 
 ## Args
 
-| Param            | Example              | Type                                                    |
-| ---------------- | -------------------- | ------------------------------------------------------- |
-| `data`           | `{}`                 | [Data](/docs/api-reference/data-model/data)             |
-| `config`         | `{ components: {} }` | [Config](/docs/api-reference/configuration/config)      |
-| `metadata`       | `{}`                 | [Metadata](/docs/api-reference/data-model/metadata)     |
+| Param                   | Example              | Type                                               |
+| ----------------------- | -------------------- | -------------------------------------------------- |
+| `data`                  | `{}`                 | [Data](/docs/api-reference/data-model/data)        |
+| `config`                | `{ components: {} }` | [Config](/docs/api-reference/configuration/config) |
+| [`metadata`](#metadata) | `{}`                 | Object                                             |
 
 ### metadata
 
-An optional [Metadata](/docs/api-reference/components/puck.mdx#metadata) object to pass to the resolvers. Defaults to `{}`.
+An object containing additional data provided to each component's [resolveData](/docs/api-reference/configuration/component-config#resolvedatadata-params) functions.
 
 ## Returns
 


### PR DESCRIPTION
## Description

This PR adds documentation for the metadata parameter to the resolveAllData function documentation. 

## Changes made

- Updated the Args table in the resolveAllData documentation to include the metadata parameter
- Added a description section explaining that metadata is an optional object passed to resolvers, defaulting to {}

## How to test

- Navigate to the resolveAllData API reference page and verify the metadata parameter is documented in the Args table
- Confirm the description explains that it's an optional parameter with a default value of {}