### PR TITLE
Don't duplicate empty array items on item click

### DIFF
--- a/packages/core/components/AutoField/fields/ArrayField/index.tsx
+++ b/packages/core/components/AutoField/fields/ArrayField/index.tsx
@@ -124,10 +124,12 @@ const ArrayFieldItemInternal = ({
           <div
             ref={handleRef}
             onClick={(e) => {
-              if (isDragging || !hasVisibleFields) return;
+              if (isDragging) return;
 
               e.preventDefault();
               e.stopPropagation();
+
+              if (!hasVisibleFields) return;
 
               onToggleExpand(id, isExpanded);
             }}


### PR DESCRIPTION
Closes #1550

## Description

#1485 fixed a UI bug where an array item with no visible nested fields could still be expanded. However, the changes also introduced a new bug: clicking on an item with no visible nested fields caused item duplication when using `AutoField` inside a `Label`.

## Changes Made

- Previously, click events on array items without nested fields were never stopped. Now we always stop click propagation, and only expand the item if it contains visible nested fields.

## How to Test

1. Use the following component in a Puck config.
```tsx

type TestComponentProps = {
  list: { value: string }[];
};

const TestComponent = {
    label: "Test Component",
    defaultProps: {
      list: [],
    },
    fields: {
      list: {
        type: "custom",
        render: ({ value, onChange }) => {
          return (
            <div>
              <FieldLabel label="List">
                <AutoField
                  field={
                    {
                      type: "array",
                      arrayFields: {
                        value: {
                          type: "text",
                          visible: false,
                        },
                      },
                      defaultItemProps: { value: "abc" },
                    } satisfies ArrayField<{ value: string }[]>
                  }
                  value={value}
                  onChange={onChange}
                />
              </FieldLabel>
            </div>
          );
        },
      },
    } satisfies Fields<TestComponentProps>,
    render: (props: TestComponentProps) => {
      return (
        <div>
          <h2>Test Component</h2>
          <ul>
            {props.list.map((item, index) => (
              <li key={index}>{item?.value}</li>
            ))}
          </ul>
        </div>
      );
    },
  } satisfies ComponentConfig<TestComponentProps>,
```
2. Navigate to the editor.
3. Drag and drop a Test Component.
4. Add an item to the array field.
5. Click on the item.
6. Verify that it does not get duplicated.

## Follow-ups

This change restores the previous behavior, but we should consider making the default element of the label a `div` since this is consistent with what happens internally when using `type: "array"`
