### PR TITLE
fix: don't override ui.viewport.current on editor render

### DIFF
--- a/packages/core/components/Puck/components/Canvas/index.tsx
+++ b/packages/core/components/Puck/components/Canvas/index.tsx
@@ -31,6 +31,7 @@ export const Canvas = () => {
   const {
     _experimentalFullScreenCanvas,
     viewports: viewportOptions = defaultViewports,
+    ui: uiProp,
   } = usePropsContext();
 
   const {
@@ -156,8 +157,12 @@ export const Canvas = () => {
 
   const appStoreApi = useAppStoreApi();
 
+  // Select closest viewport on load
   useEffect(() => {
     if (typeof window === "undefined") return;
+
+    // Don't override if user has set a viewport
+    if (uiProp?.viewports?.current) return;
 
     const viewportWidth = window.innerWidth;
     const frameWidth = frameRef.current?.getBoundingClientRect().width;
@@ -223,7 +228,13 @@ export const Canvas = () => {
 
       appStoreApi.setState({ ...appState, history });
     }
-  }, [viewportOptions, frameRef.current, iframe, appStoreApi]);
+  }, [
+    viewportOptions,
+    frameRef.current,
+    iframe,
+    appStoreApi,
+    uiProp?.viewports?.current,
+  ]);
 
   return (
     <div


### PR DESCRIPTION
Closes #1544

## Description

This PR fixes a bug where the default selected viewport provided by the user in `ui.viewports.current` was being overridden by changes introduced in commit 435c32f2071a6a677a4184440a922c2378c1daa2.

## Changes Made

- We now check if the user provided a default viewport ui before selecting the most appropiate one based on screen size.

## How to Test

1. Render the `Puck` component with a default viewport set to the smallest size:

```tsx
const Editor = () => {
  const viewportOptions = [
    { width: 300, height: 300, label: "S" },
    { width: 600, height: 600, label: "M" },
    { width: 900, height: 900, label: "L" },
  ];

  return (
    <Puck
      config={config}
      data={data}
      viewports={viewportOptions}
      ui={{
        viewports: {
          controlsVisible: true,
          current: { width: 300, height: 300 },
          options: viewportOptions,
        },
      }}
    />
  );
};
```

2. Navigate to the editor.
3. Confirm that the specified `current` viewport is selected as expected.
