### PR TITLE
fix(core): prevent slot array corruption during dnd

### DIFF
--- a/packages/core/lib/data/default-slots.ts
+++ b/packages/core/lib/data/default-slots.ts
@@ -3,6 +3,9 @@ import { Fields } from "../../types";
 export const defaultSlots = (value: object, fields: Fields) =>
   Object.keys(fields).reduce(
     (acc, fieldName) =>
-      fields[fieldName].type === "slot" ? { [fieldName]: [], ...acc } : acc,
+      fields[fieldName].type === "slot"
+        ? { ...acc, [fieldName]: Array.isArray((acc as Record<string, unknown>)[fieldName]) ? (acc as Record<string,
+            unknown>)[fieldName] : [] }
+        : acc,
     value
   );

--- a/packages/core/lib/data/map-fields.ts
+++ b/packages/core/lib/data/map-fields.ts
@@ -67,7 +67,7 @@ export const walkField = ({
   const map = mappers[fieldType];
 
   if (map && fieldType === "slot") {
-    const content = (value as Content) || [];
+    const content = Array.isArray(value) ? value : [];
 
     const mappedContent = recurseSlots
       ? content.map((el) => {


### PR DESCRIPTION
  Description:                                                                                                             
  ## Problem                                                                                                               
  Intermittent `TypeError: arr.some is not a function` errors when dragging components with slots.                         
                                                                                                                           
  ## Root Cause                                                                                                            
  Two related bugs:                                                                                                        
  1. **defaultSlots**: Wrong spread order `{ [fieldName]: [], ...acc }` was overwriting existing slot arrays               
  2. **walkField**: `value || []` doesn't protect against non-array truthy values                                          
                                                                                                                           
  ## Solution                                                                                                              
  1. Fix spread order and add `Array.isArray()` check in `defaultSlots`                                                    
  2. Use `Array.isArray(value) ? value : []` in `walkField`                                                                
                                                                                                                           
  ## Testing                                                                                                               
  - Existing tests pass                                                                                                    
  - Manually tested drag & drop with nested slot components