### PR TITLE
Respect `readOnly` in root fields

### DIFF
--- a/packages/core/lib/data/walk-app-state.ts
+++ b/packages/core/lib/data/walk-app-state.ts
@@ -15,6 +15,7 @@ import {
 } from "../../types/Internal";
 import { mapFields } from "./map-fields";
 import { flattenNode } from "./flatten-node";
+import { toComponent } from "./to-component";
 
 /**
  * Walk the Puck state, generate indexes and make modifications to nodes.
@@ -130,7 +131,7 @@ export function walkAppState<UserData extends Data = Data>(
 
     processRelatedZones(item, id, path);
 
-    const newItem = { ...item, props: newProps };
+    const newItem = { ...mappedItem, props: newProps };
 
     const thisZoneCompound = path[path.length - 1];
     const [parentId, zone] = thisZoneCompound
@@ -188,18 +189,19 @@ export function walkAppState<UserData extends Data = Data>(
     newZones[zoneCompound] = newContent;
   }, newZones);
 
-  const processedRoot = processItem(
-    {
-      type: "root",
-      props: { ...(state.data.root.props ?? state.data.root), id: "root" },
-    },
-    [],
-    -1
-  );
+  let rootAsComponent: ComponentData = toComponent({
+    props: { ...(state.data.root.props ?? state.data.root) },
+  });
+
+  if (state.data.root.readOnly) {
+    rootAsComponent.readOnly = state.data.root.readOnly;
+  }
+
+  const processedRoot = processItem(rootAsComponent, [], -1);
 
   const root = {
     ...state.data.root,
-    props: processedRoot.props,
+    ...processedRoot,
   } as RootDataWithProps;
 
   return {


### PR DESCRIPTION
Closes #1556

## Description

This PR fixes a bug where using `readOnly` on root fields wasn't being respected. 

The issue was that `readOnly` wasn't passed correctly to the final root data in `walkAppState`. Specifically, `processItem` inside `walkAppState` was [using the global state value](https://github.com/puckeditor/puck/blob/e16ff6b5f246ebb2e8807dcfbab4318d335dcbd5/packages/core/lib/data/walk-app-state.ts#L133) instead of the one returned by the mapper function, which made it impossible for the mapper to apply `readOnly` to any item.

This didn’t happen with non-root items because, for those, we pass a [content mapper that sets the `readOnly` properties](https://github.com/puckeditor/puck/blob/e16ff6b5f246ebb2e8807dcfbab4318d335dcbd5/packages/core/reducer/actions/replace.ts#L70) [before `processItem` is called](https://github.com/puckeditor/puck/blob/e16ff6b5f246ebb2e8807dcfbab4318d335dcbd5/packages/core/lib/data/walk-app-state.ts#L161).

## Changes Made

- Updated `processItem` to spread the value returned from the mapper function, not the state, ensuring the latest values are used.
- Added `root.readOnly` to both the value passed to `processItem` and the value returned from `walkAppState`.

## How to Test

1. In the demo [root config](https://github.com/puckeditor/puck/blob/e16ff6b5f246ebb2e8807dcfbab4318d335dcbd5/apps/demo/config/root.tsx), add the following:

```tsx
fields: {
  title: { type: "text" },
  someOther: { type: "text" },
},
resolveData: (data, params) => {
  return {
    ...data,
    props: { ...data.props },
    readOnly: { title: !data.readOnly?.title, someOther: false },
  };
},
```

2. Navigate to the editor.
3. Verify that the `title` field is initially rendered as `readOnly`.
4. Edit the `someOther` field.
5. Confirm that the `title` field toggles between `readOnly` and editable on each character input.
