### PR TITLE
fix: richtext inline focus problem with sync-editor

### DIFF
--- a/packages/core/components/RichTextEditor/components/Editor.tsx
+++ b/packages/core/components/RichTextEditor/components/Editor.tsx
@@ -29,14 +29,12 @@ export const Editor = memo((props: EditorProps) => {
 
   const appStoreApi = useAppStoreApi();
 
-  const focusName = `${name}${inline ? "::inline" : ""}`;
-
   const editor = useSyncedEditor({
     content,
     onChange,
     extensions: loadedExtensions,
     editable: !readOnly,
-    name: focusName,
+    name: name,
     onFocusChange: (editor) => {
       if (editor) {
         const s = appStoreApi.getState();
@@ -54,7 +52,7 @@ export const Editor = memo((props: EditorProps) => {
               ...s.state.ui,
               field: {
                 ...s.state.ui.field,
-                focus: focusName,
+                focus: name,
               },
             },
           },


### PR DESCRIPTION
Closes #1557 

## Description

This PR remove overengineering  logic from Editor for checking focus. 

## Changes made

- Delete focusName variable
- Pass `name` to `useSyncedEditor`

Old logic make problem with first `onChange` call when app think what focus on not-inline editor, but call useSyncedEditor from inline editor cause onChange not work.

Using field-name for both work well. 

## How to test

- Use inline richtext editor on `Hero` component.

https://github.com/user-attachments/assets/bfb8dedb-6c1e-4e24-bebf-cc58a1824803
