### PR TITLE
fix: keep no-external.css free of external font import

### DIFF
--- a/packages/core/components/AutoField/fields/ArrayField/index.tsx
+++ b/packages/core/components/AutoField/fields/ArrayField/index.tsx
@@ -29,7 +29,7 @@ import { populateIds } from "../../../../lib/data/populate-ids";
 import { defaultSlots } from "../../../../lib/data/default-slots";
 import { getDeep } from "../../../../lib/data/get-deep";
 import { SubField } from "../../subfield";
-import { setDeep } from "../../../../bundle";
+import { setDeep } from "../../../../lib/data/set-deep";
 
 const getClassName = getClassNameFactory("ArrayField", styles);
 const getClassNameItem = getClassNameFactory("ArrayFieldItem", styles);


### PR DESCRIPTION
## Summary

Fix `no-external.css` including external Inter font import by removing an internal dependency that was pulling in the `bundle/index` entry.

Root cause:

- `components/AutoField/fields/ArrayField/index.tsx` imported `setDeep` from `../../../../bundle`.
- That barrel resolves to `bundle/index.ts`, which imports `bundle/index.css` (including the external Inter CSS import).
- During bundling, this caused `no-external.css` to include the external font import.

Change:

- Import `setDeep` directly from `../../../../lib/data/set-deep` instead of `../../../../bundle`.

Closes #1582.

## Verification

- `cd packages/core && yarn build`
- `cd packages/core && rg -n "rsms\.me/inter" dist/no-external.css dist/index.css`
  - `dist/no-external.css`: no matches
  - `dist/index.css`: still contains the Inter import (expected)
- `cd packages/core && yarn test Puck --runInBand`
