### PR TITLE
Use latest onChange for text, number, and textarea fields

### DIFF
--- a/packages/core/components/AutoField/lib/use-local-value.ts
+++ b/packages/core/components/AutoField/lib/use-local-value.ts
@@ -8,10 +8,13 @@ export const useLocalValue = (path: string, onChange: (val: any) => void) => {
 
   const [localValue, setLocalValue] = useState(value?.toString());
 
-  const onChangeLocal = useCallback((val: any) => {
-    setLocalValue(val);
-    onChange(val);
-  }, []);
+  const onChangeLocal = useCallback(
+    (val: any) => {
+      setLocalValue(val);
+      onChange(val);
+    },
+    [onChange]
+  );
 
   useEffect(() => {
     // Prevent global state from setting local state if this field is focused


### PR DESCRIPTION
Closes #1605

## Description

This PR fixes a bug where `text`, `number`, and `textarea` fields used a stale `onChange` callback, which created problems when using `AutoField` to update properties within object values, as reported in #1605.

This happened because of the `useLocalValue` hook, which was used in all of these fields. It created a memoized `onChangeLocal` that did not react to changes in the upstream `onChange` reference.

## Changes made

- Added `onChange` to the `onChangeLocal` definition.