### PR TITLE
fix: unset syncRafRef when unmounting draggable component

### DIFF
--- a/packages/core/components/DraggableComponent/index.tsx
+++ b/packages/core/components/DraggableComponent/index.tsx
@@ -335,6 +335,7 @@ export const DraggableComponent = ({
     return () => {
       if (syncRafRef.current != null) {
         cancelAnimationFrame(syncRafRef.current);
+        syncRafRef.current = null;
       }
     };
   }, []);


### PR DESCRIPTION
This PR fixes an issue that #1461 introduced where the overlay didn't update when cloning, dropping, or moving components between zones in development mode.

The reason this happened was because of strict mode unmounting and remounting components. The unmounting canceled the animation frame for syncing overlay styles without setting its ref to null, so when remounting the style syncing would always exit early without clearing it.