### PR TITLE
fix: don't flash overlay when moving a component

### DIFF
--- a/packages/core/components/DraggableComponent/index.tsx
+++ b/packages/core/components/DraggableComponent/index.tsx
@@ -545,7 +545,8 @@ export const DraggableComponent = ({
   const onDragFinished = useOnDragFinished((finished) => {
     if (finished) {
       startTransition(() => {
-        scheduleSync();
+        // Sync immediately, to avoid a flash of the overlay in the wrong place.
+        sync();
         setDragFinished(true);
       });
     } else {


### PR DESCRIPTION
This PR fixes an issue introduced in https://github.com/puckeditor/puck/pull/1461, where the overlay would flash in the wrong position when moving a component around the canvas.

This happened because `scheduleSync` defers rendering of the overlay until the next paint.

This created the following sequence:

1. A component is dragged
2. The drag action completes
3. The component re-renders because the drag state changes
4. `onDragFinished` runs, and overlay style syncing is queued for the next animation frame
5. The component renders with an outdated `style` for the overlay, showing the wrong position in the current animation frame
7. Style syncing runs and updates the `style` state
8. The component re-renders and the overlay displays in the correct position

To fix this, we update the `style` state immediately when dropping a component, instead of scheduling it in the next animation frame. This prevents painting with a stale position.