### PR TITLE
Don't select parent on quick drag

### DIFF
--- a/packages/core/components/DraggableComponent/index.tsx
+++ b/packages/core/components/DraggableComponent/index.tsx
@@ -394,6 +394,13 @@ export const DraggableComponent = ({
 
   const onClick = useCallback(
     (e: Event | SyntheticEvent) => {
+      // Don't change selection during a drag.
+      // This avoids mouseup clicks selecting the dragged-over component.
+      const userIsDragging = !!zoneStore.getState().draggedItem;
+      if (userIsDragging) {
+        return;
+      }
+
       const el = e.target as Element;
 
       if (!el.closest("[data-puck-overlay-portal]")) {


### PR DESCRIPTION
This PR fixes an issue where dragging quickly on a nested component would at times select the parent component for a short moment before moving it back to the moved component.

The reason this happens is because on quick drags the parent's on click triggers. 

Not entirely sure why, it could be a race condition, or it could be that the thresholds setup with dnd kit are too long for that specific interaction which then bubbles up the onClick event.